### PR TITLE
fix: close every leak the chokepoint review found

### DIFF
--- a/crates/pdfboss-cli/src/main.rs
+++ b/crates/pdfboss-cli/src/main.rs
@@ -374,14 +374,19 @@ fn scan_version(data: &[u8]) -> Option<(u8, u8)> {
 }
 
 /// `pdfboss text`: one page (1-based `--page`) or all pages joined by
-/// form feed.
+/// form feed. Extraction is lenient — content that will not read yields
+/// no text rather than an error — so anything skipped is surfaced as a
+/// stderr warning instead of vanishing.
 fn cmd_text(file: &Path, page: Option<usize>) -> Result<(), String> {
     let doc = Document::open(file).map_err(|e| e.to_string())?;
     let text = match page {
         Some(n) => {
             let index = page_index(n, doc.page_count())?;
             let page = doc.page(index).map_err(|e| e.to_string())?;
-            pdfboss_text::extract_text(&doc, &page).map_err(|e| e.to_string())?
+            let (text, report) =
+                pdfboss_text::extract_text_reporting(&doc, &page).map_err(|e| e.to_string())?;
+            warn_skips(n, &report);
+            text
         }
         None => {
             // Fanned out across the cores, one document fork per worker;
@@ -389,15 +394,32 @@ fn cmd_text(file: &Path, page: Option<usize>) -> Result<(), String> {
             // flattened tree, not the declared `/Count`, which on a damaged
             // file may not match what the tree yields) and returns them in
             // page order.
-            let parts = pdfboss_core::map_pages(&doc, pdfboss_text::extract_text)
+            let parts = pdfboss_core::map_pages(&doc, pdfboss_text::extract_text_reporting)
                 .into_iter()
-                .map(|text| text.map_err(|e| e.to_string()))
+                .enumerate()
+                .map(|(index, outcome)| {
+                    let (text, report) = outcome.map_err(|e| e.to_string())?;
+                    warn_skips(index + 1, &report);
+                    Ok(text)
+                })
                 .collect::<Result<Vec<String>, String>>()?;
             parts.join("\u{c}")
         }
     };
     println!("{text}");
     Ok(())
+}
+
+/// One stderr line per skipped stream, 1-based page numbers matching
+/// `--page`. Warnings, not errors: the text on stdout is still everything
+/// that could be read.
+fn warn_skips(page_no: usize, report: &pdfboss_text::ExtractReport) {
+    for skip in &report.skipped {
+        eprintln!(
+            "warning: page {page_no}: skipped {} ({})",
+            skip.kind, skip.cause
+        );
+    }
 }
 
 /// Resolves `--fonts`/`--font-dir` into a [`pdfboss_render::SubstituteSource`].

--- a/crates/pdfboss-core/src/document.rs
+++ b/crates/pdfboss-core/src/document.rs
@@ -941,15 +941,26 @@ pub async fn page_content_with<S: AsyncObjectSource>(src: S, page: &Page) -> Res
 /// streams, font programs, `/ToUnicode` CMaps, `/CIDToGIDMap` tables —
 /// anything that parses what it fetches.
 ///
-/// This is [`AsyncObjectSource::stream_data`] with one refusal in front:
-/// a stream whose trailing `/Filter` entry is an image codec (`DCTDecode`,
+/// This is [`AsyncObjectSource::stream_data`] with two refusals in front.
+/// A stream whose trailing `/Filter` entry is an image codec (`DCTDecode`,
 /// `JPXDecode`) fails with [`Error::UnsupportedFilter`] instead of handing
-/// back the passthrough (ISO 32000-1 7.4.9). A raw JPEG or JPEG 2000
+/// back the passthrough (ISO 32000-1 7.4.9): a raw JPEG or JPEG 2000
 /// codestream is indistinguishable from decoded data to anything that is
-/// not an image decoder: a parser fed one chews binary garbage into
-/// operators, tables, or mappings with a clean result. The refusal turns
-/// the mislabelled stream into the same reportable error as any other
-/// filter this library cannot run.
+/// not an image decoder, and a parser fed one chews binary garbage into
+/// operators, tables, or mappings with a clean result. And a `/Filter`
+/// that cannot be READ at all — a reference cycle, or a chain deeper than
+/// [`crate::source::MAX_RESOLVE_DEPTH`] — is refused with the resolve
+/// error, because a value that cannot be read might name an image codec,
+/// and `decode_stream` would leniently return the bytes as stored. Either
+/// refusal is the same reportable error as any other filter this library
+/// cannot run.
+///
+/// One leniency is kept, deliberately: a `/Filter` that READS as `null`
+/// (a dangling reference included — ISO 32000-1 7.3.10 makes one
+/// equivalent to `null`) or as an unusable value says "no filter", which
+/// is exactly what `decode_stream` does with it; the stored bytes are the
+/// decoded bytes by that reading, and no codec name can hide in a value
+/// that is fully visible.
 ///
 /// Raw [`AsyncObjectSource::stream_data`] remains correct in exactly one
 /// place: the image layer, which reads the trailing filter itself and
@@ -957,7 +968,7 @@ pub async fn page_content_with<S: AsyncObjectSource>(src: S, page: &Page) -> Res
 /// belongs here instead. Same calling convention as [`page_content_with`]
 /// (`src` by value; see that function's docs).
 pub async fn decoded_stream_data_with<S: AsyncObjectSource>(src: S, s: &Stream) -> Result<Vec<u8>> {
-    if let Some(name) = filters::trailing_filter_with(&src, &s.dict).await {
+    if let Some(name) = filters::trailing_filter_checked_with(&src, &s.dict).await? {
         if filters::is_image_codec(&name.0) {
             return Err(Error::UnsupportedFilter(name.0));
         }
@@ -1037,6 +1048,32 @@ mod tests {
                 other => panic!("{codec} content must be refused, got {other:?}"),
             }
         }
+    }
+
+    /// A `/Contents` whose `/Filter` is a reference CYCLE is refused as
+    /// unreadable, never fetched: `decode_stream` cannot resolve the value
+    /// either and would leniently return the bytes AS STORED — and a value
+    /// nobody can read might name an image codec, so the stored bytes may
+    /// be a passthrough codestream. The bytes below are deliberately valid
+    /// operator syntax to prove the refusal is about the unreadable label.
+    #[test]
+    fn an_unreadable_filter_refuses_the_content_not_returns_it_raw() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+        );
+        b.stream(4, "/Filter 6 0 R", b"1 0 0 rg 0 0 100 100 re f");
+        b.object(6, "7 0 R");
+        b.object(7, "6 0 R");
+        let doc = Document::load(b.build(1)).expect("load");
+        let page = doc.page(0).expect("page");
+        assert!(
+            page.content(&doc).is_err(),
+            "an unreadable /Filter must refuse, not pass stored bytes"
+        );
     }
 
     /// The composition every page-reading algorithm actually uses: the caller

--- a/crates/pdfboss-core/src/document.rs
+++ b/crates/pdfboss-core/src/document.rs
@@ -935,27 +935,47 @@ pub async fn page_content_with<S: AsyncObjectSource>(src: S, page: &Page) -> Res
     }
 }
 
-/// Fetches and decodes one CONTENT stream — page `/Contents`, a form
-/// XObject, a Type3 CharProc, a pattern cell: anything whose bytes feed a
-/// content parser rather than an image decoder.
+/// Fetches one stream's bytes GUARANTEED DECODED — refusing the streams
+/// whose bytes `decode_stream` leaves encoded for the image layer. This is
+/// the fetch for **every consumer that is not an image decoder**: content
+/// streams, font programs, `/ToUnicode` CMaps, `/CIDToGIDMap` tables —
+/// anything that parses what it fetches.
 ///
 /// This is [`AsyncObjectSource::stream_data`] with one refusal in front:
 /// a stream whose trailing `/Filter` entry is an image codec (`DCTDecode`,
 /// `JPXDecode`) fails with [`Error::UnsupportedFilter`] instead of handing
-/// back the passthrough. `decode_stream` leaves those bytes ENCODED for
-/// the image layer (ISO 32000-1 7.4.9); a content parser fed the raw
-/// codestream would chew binary garbage into operators — typically a blank
-/// page with a clean report — so the refusal here is what turns the
-/// mislabelled stream into the same reported skip as any other filter this
-/// library cannot run. Same calling convention as [`page_content_with`]
+/// back the passthrough (ISO 32000-1 7.4.9). A raw JPEG or JPEG 2000
+/// codestream is indistinguishable from decoded data to anything that is
+/// not an image decoder: a parser fed one chews binary garbage into
+/// operators, tables, or mappings with a clean result. The refusal turns
+/// the mislabelled stream into the same reportable error as any other
+/// filter this library cannot run.
+///
+/// Raw [`AsyncObjectSource::stream_data`] remains correct in exactly one
+/// place: the image layer, which reads the trailing filter itself and
+/// decodes the passthrough. A new call site that is not decoding images
+/// belongs here instead. Same calling convention as [`page_content_with`]
 /// (`src` by value; see that function's docs).
-pub async fn content_stream_data_with<S: AsyncObjectSource>(src: S, s: &Stream) -> Result<Vec<u8>> {
+pub async fn decoded_stream_data_with<S: AsyncObjectSource>(src: S, s: &Stream) -> Result<Vec<u8>> {
     if let Some(name) = filters::trailing_filter_with(&src, &s.dict).await {
         if filters::is_image_codec(&name.0) {
             return Err(Error::UnsupportedFilter(name.0));
         }
     }
     src.stream_data(s).await
+}
+
+/// Fetches and decodes one CONTENT stream — page `/Contents`, a form
+/// XObject, a Type3 CharProc, a pattern cell: anything whose bytes feed a
+/// content parser rather than an image decoder.
+///
+/// The content-flavored name for [`decoded_stream_data_with`], which is
+/// the same refusal for every non-image consumer; see it for why a
+/// passthrough image codec must never reach a parser. For a content
+/// stream the refusal is what turns the mislabelled stream into the same
+/// reported skip as any other filter this library cannot run.
+pub async fn content_stream_data_with<S: AsyncObjectSource>(src: S, s: &Stream) -> Result<Vec<u8>> {
+    decoded_stream_data_with(src, s).await
 }
 
 #[cfg(test)]

--- a/crates/pdfboss-core/src/filters/mod.rs
+++ b/crates/pdfboss-core/src/filters/mod.rs
@@ -80,12 +80,19 @@ pub(crate) fn bool_parm(parms: Option<&Dict>, key: &str, default: bool) -> bool 
     }
 }
 
-/// Chases indirect references through `resolver` (bounded depth to break
-/// reference cycles); direct objects are cloned. Returns `None` when a
-/// reference cannot be resolved.
+/// Chases indirect references through `resolver`, depth-capped at
+/// [`crate::source::MAX_RESOLVE_DEPTH`] to break reference cycles; direct
+/// objects are cloned. Returns `None` when a reference cannot be resolved.
+///
+/// The cap is shared with the source-level chase deliberately: the
+/// image-codec gate reads `/Filter` through `src.resolve` and this decoder
+/// reads it here, and a chain one side follows further than the other is a
+/// stream the gate vouches for but the decoder leaves encoded (or the
+/// reverse). `deep_filter_ref_chains_decode_like_the_gate_reads_them` pins
+/// the agreement.
 fn resolve_value(obj: Option<&Object>, resolver: &dyn Resolve) -> Option<Object> {
     let mut cur = obj?.clone();
-    for _ in 0..8 {
+    for _ in 0..crate::source::MAX_RESOLVE_DEPTH {
         match cur {
             Object::Ref(r) => cur = resolver.resolve_ref(r)?,
             other => return Some(other),
@@ -364,6 +371,43 @@ mod tests {
                 "passthrough recognition of {filter:?}"
             );
         }
+    }
+
+    /// The gate (`trailing_filter_with`) and the decoder chase `/Filter`
+    /// reference chains to the same depth. Before they shared the cap, a
+    /// 9-hop chain sat exactly in the gap: deep enough that the decoder
+    /// gave up (leniently returning the bytes still encoded), shallow
+    /// enough that the gate resolved it and vouched for the stream —
+    /// handing still-compressed bytes to a content parser with a clean
+    /// result.
+    #[test]
+    fn deep_filter_ref_chains_decode_like_the_gate_reads_them() {
+        use crate::source::{block_on, Immediate};
+
+        let payload: &[u8] = b"BT (deep) Tj ET";
+        let compressed = zlib(payload);
+        // /Filter -> 1 0 R -> 2 0 R -> ... -> 9 0 R = /FlateDecode.
+        let mut map = HashMap::new();
+        for n in 1u32..9 {
+            map.insert((n, 0u16), Object::Ref(ObjRef { num: n + 1, gen: 0 }));
+        }
+        map.insert((9, 0), Object::Name(name("FlateDecode")));
+        let s = make_stream(
+            vec![("Filter", Object::Ref(ObjRef { num: 1, gen: 0 }))],
+            &compressed,
+        );
+        let src = Immediate(MapSource(map.clone()));
+        let gate_sees = block_on(trailing_filter_with(&src, &s.dict));
+        assert_eq!(
+            gate_sees.map(|n| n.0),
+            Some("FlateDecode".to_string()),
+            "the gate resolves the chain and passes the stream"
+        );
+        let decoded = decode_stream(&s, &MapResolve(map)).expect("decode");
+        assert_eq!(
+            decoded, payload,
+            "the decoder must chase /Filter as deep as the gate does"
+        );
     }
 
     #[test]

--- a/crates/pdfboss-core/src/filters/mod.rs
+++ b/crates/pdfboss-core/src/filters/mod.rs
@@ -231,13 +231,33 @@ pub fn is_image_codec(name: &str) -> bool {
 /// `trailing_filter_reads_the_chain_like_decode_stream` pins the
 /// agreement.
 pub async fn trailing_filter_with<S: AsyncObjectSource>(src: &S, dict: &Dict) -> Option<Name> {
-    let filter = dict.get("Filter")?;
-    match src.resolve(filter).await.ok()? {
-        Object::Name(n) => Some(n),
+    // The overwhelmingly common shapes — a bare name, or an array of bare
+    // names — are read straight off the dictionary. Each `resolve` is a
+    // boxed future plus an owned-Object clone, and this gate runs in front
+    // of every content fetch (up to once per form invocation), so the
+    // resolve is reserved for values that actually contain a reference.
+    let owned;
+    let filter = match dict.get("Filter")? {
+        Object::Ref(_) => {
+            owned = src.resolve(dict.get("Filter")?).await.ok()?;
+            &owned
+        }
+        direct => direct,
+    };
+    match filter {
+        Object::Name(n) => Some(n.clone()),
         Object::Array(items) => {
             for item in items.iter().rev() {
-                if let Ok(Object::Name(n)) = src.resolve(item).await {
-                    return Some(n);
+                match item {
+                    Object::Name(n) => return Some(n.clone()),
+                    Object::Ref(_) => {
+                        if let Ok(Object::Name(n)) = src.resolve(item).await {
+                            return Some(n);
+                        }
+                    }
+                    // Not a name and not a road to one: skipped, exactly
+                    // as decode_stream skips it.
+                    _ => {}
                 }
             }
             None
@@ -370,6 +390,90 @@ mod tests {
                 trailing.is_some(),
                 "passthrough recognition of {filter:?}"
             );
+        }
+    }
+
+    /// A direct `/Filter` value costs the gate no `resolve` round-trip.
+    /// The overwhelmingly common shapes — a bare name, or an array of bare
+    /// names — are read straight off the dictionary; the boxed resolve
+    /// future (plus its owned-Object clone) is reserved for values that
+    /// actually contain a reference. Every content fetch pays this gate,
+    /// up to once per form invocation, which is what makes the fast path
+    /// worth pinning.
+    #[test]
+    fn direct_filter_values_cost_the_gate_no_resolve() {
+        use crate::source::{block_on, resolve_with, AsyncObjectSource, BoxFuture};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Counts `resolve` calls — each one is a boxed future plus an
+        /// owned-Object clone, which is the cost the fast path exists to
+        /// avoid, whether or not a fetch follows.
+        struct CountingSource {
+            map: HashMap<(u32, u16), Object>,
+            resolves: AtomicUsize,
+        }
+
+        impl AsyncObjectSource for CountingSource {
+            fn get(&self, r: ObjRef) -> BoxFuture<'_, Result<Object>> {
+                let got = self
+                    .map
+                    .get(&(r.num, r.gen))
+                    .cloned()
+                    .ok_or_else(|| Error::Decode("missing object".into()));
+                Box::pin(std::future::ready(got))
+            }
+
+            fn stream_data<'a>(&'a self, s: &'a Stream) -> BoxFuture<'a, Result<Vec<u8>>> {
+                Box::pin(std::future::ready(Ok(s.data.clone())))
+            }
+
+            fn resolve<'a>(&'a self, o: &'a Object) -> BoxFuture<'a, Result<Object>> {
+                self.resolves.fetch_add(1, Ordering::Relaxed);
+                Box::pin(resolve_with(self, o))
+            }
+        }
+
+        let map = HashMap::from([((7u32, 0u16), Object::Name(name("JPXDecode")))]);
+        let direct: Vec<(Object, Option<&str>)> = vec![
+            (Object::Name(name("DCTDecode")), Some("DCTDecode")),
+            (
+                Object::Array(vec![
+                    Object::Name(name("FlateDecode")),
+                    Object::Name(name("DCTDecode")),
+                ]),
+                Some("DCTDecode"),
+            ),
+            (Object::Array(vec![Object::Null]), None),
+            (Object::Int(3), None),
+        ];
+        for (filter, expected) in direct {
+            let src = CountingSource {
+                map: map.clone(),
+                resolves: AtomicUsize::new(0),
+            };
+            let dict = make_dict(vec![("Filter", filter.clone())]);
+            let got = block_on(trailing_filter_with(&src, &dict));
+            assert_eq!(got.map(|n| n.0), expected.map(str::to_string));
+            assert_eq!(
+                src.resolves.load(Ordering::Relaxed),
+                0,
+                "direct value {filter:?} must not resolve"
+            );
+        }
+        // The reference shapes still resolve — the fast path must not
+        // have cost them their answer.
+        for filter in [
+            Object::Ref(ObjRef { num: 7, gen: 0 }),
+            Object::Array(vec![Object::Ref(ObjRef { num: 7, gen: 0 })]),
+        ] {
+            let src = CountingSource {
+                map: map.clone(),
+                resolves: AtomicUsize::new(0),
+            };
+            let dict = make_dict(vec![("Filter", filter)]);
+            let got = block_on(trailing_filter_with(&src, &dict));
+            assert_eq!(got.map(|n| n.0), Some("JPXDecode".to_string()));
+            assert!(src.resolves.load(Ordering::Relaxed) > 0);
         }
     }
 

--- a/crates/pdfboss-core/src/filters/mod.rs
+++ b/crates/pdfboss-core/src/filters/mod.rs
@@ -233,38 +233,85 @@ pub fn is_image_codec(name: &str) -> bool {
 /// `trailing_filter_reads_the_chain_like_decode_stream` pins the
 /// agreement.
 pub async fn trailing_filter_with<S: AsyncObjectSource>(src: &S, dict: &Dict) -> Option<Name> {
+    match read_trailing_filter(src, dict, false).await {
+        Ok(name) => name,
+        // Unreachable with `strict` false; spelled out rather than unwrapped.
+        Err(_) => None,
+    }
+}
+
+/// [`trailing_filter_with`] except that a `/Filter` value that cannot be
+/// READ — a reference cycle, or a chain deeper than
+/// [`crate::source::MAX_RESOLVE_DEPTH`] — is an error instead of "no
+/// trailing filter". A value that cannot be read might name an image
+/// codec, so the checked fetch
+/// ([`crate::document::decoded_stream_data_with`]) must refuse the stream
+/// rather than pass its possibly-still-encoded bytes to a parser.
+///
+/// A `/Filter` that resolves to `null` (a dangling reference included —
+/// ISO 32000-1 7.3.10 makes one equivalent to `null`) or to an unusable
+/// value is still `Ok(None)`: the value is readable and says "no filter",
+/// which is exactly how [`decode_stream`] treats it.
+pub async fn trailing_filter_checked_with<S: AsyncObjectSource>(
+    src: &S,
+    dict: &Dict,
+) -> Result<Option<Name>> {
+    read_trailing_filter(src, dict, true).await
+}
+
+/// The one reading of `/Filter` under both public faces above, so the
+/// strict and the lenient reader cannot drift apart on anything but their
+/// treatment of a resolve error.
+async fn read_trailing_filter<S: AsyncObjectSource>(
+    src: &S,
+    dict: &Dict,
+    strict: bool,
+) -> Result<Option<Name>> {
     // The overwhelmingly common shapes — a bare name, or an array of bare
     // names — are read straight off the dictionary. Each `resolve` is a
     // boxed future plus an owned-Object clone, and this gate runs in front
     // of every content fetch (up to once per form invocation), so the
     // resolve is reserved for values that actually contain a reference.
+    let Some(filter) = dict.get("Filter") else {
+        return Ok(None);
+    };
     let owned;
-    let filter = match dict.get("Filter")? {
-        Object::Ref(_) => {
-            owned = src.resolve(dict.get("Filter")?).await.ok()?;
-            &owned
-        }
+    let filter = match filter {
+        Object::Ref(_) => match src.resolve(filter).await {
+            Ok(resolved) => {
+                owned = resolved;
+                &owned
+            }
+            Err(e) if strict => return Err(e),
+            Err(_) => return Ok(None),
+        },
         direct => direct,
     };
     match filter {
-        Object::Name(n) => Some(n.clone()),
+        Object::Name(n) => Ok(Some(n.clone())),
         Object::Array(items) => {
             for item in items.iter().rev() {
                 match item {
-                    Object::Name(n) => return Some(n.clone()),
-                    Object::Ref(_) => {
-                        if let Ok(Object::Name(n)) = src.resolve(item).await {
-                            return Some(n);
-                        }
-                    }
+                    Object::Name(n) => return Ok(Some(n.clone())),
+                    Object::Ref(_) => match src.resolve(item).await {
+                        Ok(Object::Name(n)) => return Ok(Some(n)),
+                        // Readable but not a name (null included): skipped,
+                        // exactly as decode_stream skips it.
+                        Ok(_) => {}
+                        Err(e) if strict => return Err(e),
+                        // Lenient: an unreadable item is skipped like a
+                        // null one; decode_stream does the same, and the
+                        // two must agree on which filter is "last".
+                        Err(_) => {}
+                    },
                     // Not a name and not a road to one: skipped, exactly
                     // as decode_stream skips it.
                     _ => {}
                 }
             }
-            None
+            Ok(None)
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
@@ -514,6 +561,66 @@ mod tests {
             decoded, payload,
             "the decoder must chase /Filter as deep as the gate does"
         );
+    }
+
+    /// A `/Filter` behind a reference cycle splits the readers on purpose.
+    /// The lenient reader and `decode_stream` agree — no usable filter,
+    /// data as stored — which is right for the image layer. The CHECKED
+    /// reader errors instead: a value that cannot be read might name an
+    /// image codec, so the checked fetch must refuse the stream rather
+    /// than let `decode_stream`'s stored bytes reach a parser.
+    #[test]
+    fn a_circular_filter_errors_the_checked_reader_only() {
+        use crate::source::{block_on, Immediate};
+
+        let map = HashMap::from([
+            ((7u32, 0u16), Object::Ref(ObjRef { num: 8, gen: 0 })),
+            ((8u32, 0u16), Object::Ref(ObjRef { num: 7, gen: 0 })),
+        ]);
+        for filter in [
+            Object::Ref(ObjRef { num: 7, gen: 0 }),
+            // The same cycle one level down, as an array element.
+            Object::Array(vec![Object::Ref(ObjRef { num: 7, gen: 0 })]),
+        ] {
+            let s = make_stream(vec![("Filter", filter.clone())], b"stored");
+            let src = Immediate(MapSource(map.clone()));
+            assert!(
+                block_on(trailing_filter_with(&src, &s.dict)).is_none(),
+                "lenient reader of {filter:?}"
+            );
+            assert!(
+                block_on(trailing_filter_checked_with(&src, &s.dict)).is_err(),
+                "checked reader of {filter:?}"
+            );
+            assert_eq!(
+                decode_stream(&s, &MapResolve(map.clone())).unwrap(),
+                b"stored",
+                "decode_stream leniency of {filter:?}"
+            );
+        }
+    }
+
+    /// The checked reader stays lenient where the value is READABLE and
+    /// says "no filter": a dangling reference is `null` (ISO 32000-1
+    /// 7.3.10), and null means unfiltered — exactly `decode_stream`'s
+    /// treatment. Only unreadability is an error.
+    #[test]
+    fn a_dangling_filter_reads_as_no_filter_for_both_readers() {
+        use crate::source::{block_on, Immediate};
+
+        // Object 9 does not exist anywhere.
+        let map: HashMap<(u32, u16), Object> = HashMap::new();
+        let s = make_stream(
+            vec![("Filter", Object::Ref(ObjRef { num: 9, gen: 0 }))],
+            b"stored",
+        );
+        let src = Immediate(MapSource(map.clone()));
+        assert!(block_on(trailing_filter_with(&src, &s.dict)).is_none());
+        assert_eq!(
+            block_on(trailing_filter_checked_with(&src, &s.dict)).expect("readable"),
+            None
+        );
+        assert_eq!(decode_stream(&s, &MapResolve(map)).unwrap(), b"stored");
     }
 
     #[test]

--- a/crates/pdfboss-core/src/filters/mod.rs
+++ b/crates/pdfboss-core/src/filters/mod.rs
@@ -233,11 +233,11 @@ pub fn is_image_codec(name: &str) -> bool {
 /// `trailing_filter_reads_the_chain_like_decode_stream` pins the
 /// agreement.
 pub async fn trailing_filter_with<S: AsyncObjectSource>(src: &S, dict: &Dict) -> Option<Name> {
-    match read_trailing_filter(src, dict, false).await {
-        Ok(name) => name,
-        // Unreachable with `strict` false; spelled out rather than unwrapped.
-        Err(_) => None,
-    }
+    // An error is unreachable with `strict` false, and `None` would be its
+    // only lenient reading anyway.
+    read_trailing_filter(src, dict, false)
+        .await
+        .unwrap_or_default()
 }
 
 /// [`trailing_filter_with`] except that a `/Filter` value that cannot be

--- a/crates/pdfboss-core/src/filters/mod.rs
+++ b/crates/pdfboss-core/src/filters/mod.rs
@@ -213,7 +213,9 @@ pub fn decode_stream(stream: &Stream, resolver: &dyn Resolve) -> Result<Vec<u8>>
 /// `JPXDecode` (ISO 32000-1 7.4.9). Their decoded form exists only at the
 /// image layer; every other consumer of stream bytes must refuse them,
 /// because a raw JPEG or JPEG 2000 codestream is indistinguishable from
-/// decoded data to anything that is not an image decoder.
+/// decoded data to anything that is not an image decoder. Consumers do
+/// not check this themselves: they fetch through
+/// [`crate::document::decoded_stream_data_with`], which is that refusal.
 pub fn is_image_codec(name: &str) -> bool {
     matches!(name, "DCTDecode" | "DCT" | "JPXDecode")
 }

--- a/crates/pdfboss-core/src/lib.rs
+++ b/crates/pdfboss-core/src/lib.rs
@@ -21,7 +21,8 @@ pub mod xref;
 
 pub use crypt::Decryptor;
 pub use document::{
-    content_stream_data_with, map_pages, page_content_with, Document, DocumentSeed, Metadata, Page,
+    content_stream_data_with, decoded_stream_data_with, map_pages, page_content_with, Document,
+    DocumentSeed, Metadata, Page,
 };
 pub use elements::{Element, ElementOpts, Span, XrefKind};
 pub use error::{Error, Result};

--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -339,6 +339,11 @@ impl Document {
     /// each worker thread holds its own fork of the document (shared bytes
     /// and cross-reference table, private caches), pulling page indexes from
     /// a shared counter so a slow page never idles the other cores.
+    ///
+    /// Per-page lenient like rendering: a page whose content will not
+    /// fetch, decode, or parse contributes an empty string rather than
+    /// failing the whole document. An error here means the document
+    /// itself could not be read.
     fn extract_text(&self, py: Python<'_>) -> PyResult<String> {
         let inner = &self.inner;
         py.allow_threads(move || {
@@ -860,8 +865,11 @@ impl AsyncDocument {
     }
 
     /// Extracts text from all pages, joined by form feed ("\f"), like the
-    /// sync `Document.extract_text`. Coroutine; the extraction runs on the
-    /// tokio runtime, so the asyncio loop is never blocked.
+    /// sync `Document.extract_text` — including its per-page leniency: a
+    /// page whose content will not read contributes an empty string, and
+    /// an error means the document itself could not be read. Coroutine;
+    /// the extraction runs on the tokio runtime, so the asyncio loop is
+    /// never blocked.
     fn extract_text<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -1597,7 +1597,21 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             self.skip(SkippedKind::XObject, SkipReason::Missing);
             return None;
         };
-        match stream.dict.get_name("Subtype").map(|n| n.0.as_str()) {
+        // `/Subtype` may be indirect like any dictionary value (ISO 32000-1
+        // 7.3.8.1): a direct name answers on the spot, a reference resolves.
+        let resolved;
+        let subtype = match stream.dict.get("Subtype") {
+            Some(Object::Name(n)) => Some(n.0.as_str()),
+            Some(indirect @ Object::Ref(_)) => {
+                resolved = self.src.resolve(indirect).await.ok();
+                resolved
+                    .as_ref()
+                    .and_then(|o| o.as_name())
+                    .map(|n| n.0.as_str())
+            }
+            _ => None,
+        };
+        match subtype {
             Some("Image") => {
                 self.draw_image_xobject(&stream, chain, gs).await;
                 None
@@ -2579,6 +2593,25 @@ mod tests {
             !dark_at(&pix, 55, 115),
             "the CharProc bytes must not be parsed as content"
         );
+    }
+
+    /// `/Subtype` may be indirect like any dictionary value (ISO 32000-1
+    /// 7.3.8.1). The XObject dispatch resolves it: a form declared through
+    /// a reference paints, rather than being skipped as an unsupported
+    /// XObject with its whole content subtree.
+    #[test]
+    fn a_form_whose_subtype_is_indirect_still_paints() {
+        let bytes = small_doc("/XObject << /Fm0 5 0 R >>", b"/Fm0 Do", |b| {
+            b.stream(
+                5,
+                "/Type /XObject /Subtype 6 0 R /BBox [0 0 100 100]",
+                b"1 0 0 rg 0 0 100 100 re f",
+            );
+            b.object(6, "/Form");
+        });
+        let (pix, report) = render_reporting(bytes);
+        assert_ne!(px(&pix, 50, 50), WHITE, "the form painted");
+        assert!(drops(&report).is_empty(), "nothing to report");
     }
 
     #[test]

--- a/crates/pdfboss-render/src/glyph.rs
+++ b/crates/pdfboss-render/src/glyph.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex, PoisonError};
 
 #[cfg(test)]
 use pdfboss_core::{block_on, Document, Immediate};
-use pdfboss_core::{AsyncObjectSource, Dict, Matrix, Object};
+use pdfboss_core::{decoded_stream_data_with, AsyncObjectSource, Dict, Matrix, Object};
 
 use crate::cff::CffFont;
 use crate::path::{PathBuilder, Subpath};
@@ -833,17 +833,24 @@ async fn load_type0_truetype<S: AsyncObjectSource>(src: &S, cid: &Dict) -> Optio
     let tt = TrueType::parse(program)?;
 
     // /CIDToGIDMap: /Identity (or absent) means GID == CID; a stream is a
-    // big-endian u16 table indexed by CID.
+    // big-endian u16 table indexed by CID, fetched through the checked
+    // fetch — chunking a passthrough codestream into u16s would paint
+    // every glyph of the font from a nonsense table. A refused or
+    // unreadable map keeps the font loaded with an EMPTY table rather
+    // than failing the load or falling back to Identity: every CID then
+    // resolves to gid 0, so each drawn code is a reported NoGlyph skip
+    // (its advance still applies) instead of a silent drop or a wrong
+    // glyph.
     let map = match rv(src, cid, "CIDToGIDMap").await {
-        Some(Object::Stream(s)) => {
-            let bytes = src.stream_data(&s).await.ok()?;
-            Some(
+        Some(Object::Stream(s)) => match decoded_stream_data_with(src, &s).await {
+            Ok(bytes) => Some(
                 bytes
                     .chunks_exact(2)
                     .map(|c| u16::from_be_bytes([c[0], c[1]]))
                     .collect(),
-            )
-        }
+            ),
+            Err(_) => Some(Vec::new()),
+        },
         _ => None, // Identity
     };
     Some(GlyphFont {
@@ -976,10 +983,14 @@ async fn resolve_dict<S: AsyncObjectSource>(src: &S, obj: &Object) -> Option<Dic
     src.resolve(obj).await.ok()?.as_dict().cloned()
 }
 
-/// Resolves an object to a stream and returns its decoded bytes.
+/// Resolves an object to a stream and returns its decoded bytes. Fetched
+/// through the checked fetch, not raw `stream_data`: every caller here
+/// hands the bytes to a font-program parser, and a stream whose trailing
+/// `/Filter` is an image codec holds a passthrough codestream no parser
+/// may read. Refusal reads as any other unreadable program: `None`.
 async fn stream_bytes<S: AsyncObjectSource>(src: &S, obj: &Object) -> Option<Vec<u8>> {
     match src.resolve(obj).await.ok()? {
-        Object::Stream(s) => src.stream_data(&s).await.ok(),
+        Object::Stream(s) => decoded_stream_data_with(src, &s).await.ok(),
         _ => None,
     }
 }
@@ -1390,6 +1401,85 @@ mod tests {
             "second glyph must paint at the /W-implied origin (135,115), not \
              stacked on the first glyph as the program's 0 advance would give"
         );
+    }
+
+    /// One page drawing `<00010001>` through a Type0/CIDFontType2 whose
+    /// `/CIDToGIDMap` stream carries `map_dict` around `map_bytes`.
+    fn cid_map_doc(map_dict: &str, map_bytes: &[u8]) -> Document {
+        let mut b = PdfBuilder::new().version(1, 5);
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+             /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F0 100 Tf 20 50 Td <00010001> Tj ET");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type0 /BaseFont /X /Encoding /Identity-H \
+             /DescendantFonts [6 0 R] >>",
+        );
+        b.object(
+            6,
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /X \
+             /FontDescriptor 7 0 R /CIDToGIDMap 9 0 R /DW 1000 >>",
+        );
+        b.object(
+            7,
+            "<< /Type /FontDescriptor /FontName /X /Flags 4 /FontFile2 8 0 R >>",
+        );
+        b.stream(8, "", &build_font());
+        b.stream(9, map_dict, map_bytes);
+        Document::load(b.build(1)).expect("load")
+    }
+
+    /// A `/CIDToGIDMap` whose trailing `/Filter` is an image codec is
+    /// refused — chunking a passthrough codestream into u16s would paint
+    /// every glyph of the font from a nonsense table. The refusal keeps
+    /// the font loaded over an empty table, so each drawn code lands on
+    /// gid 0 and is reported as a NoGlyph skip instead of dropping
+    /// silently (the pre-refusal shape: a clean report over wrong ink).
+    /// The bytes are a deliberately valid table, so the label decides.
+    #[test]
+    fn an_image_codec_cid_to_gid_map_reports_every_drawn_glyph() {
+        let doc = cid_map_doc("/Filter /DCTDecode", &[0, 0, 0, 1]);
+        let page = doc.page(0).expect("page");
+        let (pix, report) =
+            crate::render_page_reporting(&doc, &page, 1.0, &RenderOptions::default())
+                .expect("render");
+        assert!(!dark_pixel_at(&pix, 55, 115), "no garbage glyph painted");
+        let drops: Vec<_> = report
+            .skipped
+            .iter()
+            .map(|s| (s.kind, s.reason.clone(), s.count))
+            .collect();
+        assert_eq!(
+            drops,
+            vec![(
+                crate::SkippedKind::Glyph,
+                crate::SkipReason::NoGlyph {
+                    code: 1,
+                    font: "X".to_string(),
+                },
+                2,
+            )],
+        );
+    }
+
+    /// The inverse: a benign trailing filter on the map decodes and the
+    /// glyphs paint — refusal is about the image codecs, not about
+    /// `/Filter` being present at all.
+    #[test]
+    fn a_filtered_cid_to_gid_map_still_paints() {
+        // CID 0 -> gid 0, CID 1 -> gid 1, hex-encoded.
+        let doc = cid_map_doc("/Filter /ASCIIHexDecode", b"00000001>");
+        let page = doc.page(0).expect("page");
+        let (pix, report) =
+            crate::render_page_reporting(&doc, &page, 1.0, &RenderOptions::default())
+                .expect("render");
+        assert!(dark_pixel_at(&pix, 55, 115), "the mapped glyph paints");
+        assert!(report.skipped.is_empty(), "nothing skipped: {report:?}");
     }
 
     #[test]

--- a/crates/pdfboss-text/src/extract.rs
+++ b/crates/pdfboss-text/src/extract.rs
@@ -6,7 +6,7 @@ use crate::font::Font;
 use pdfboss_core::content::{parse_content, Op, TextItem};
 use pdfboss_core::{
     content_stream_data_with, page_content_with, AsyncObjectSource, Dict, Matrix, Object, Page,
-    Point, Result,
+    Point,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -31,21 +31,135 @@ pub struct RawSpan {
     pub font: String,
 }
 
+/// What extraction could not read. Extraction is lenient the way rendering
+/// is — content that will not fetch, decode, or parse yields no text rather
+/// than an error — and this report is what keeps that leniency accountable:
+/// an empty result with an empty report really is an empty page.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ExtractReport {
+    /// Every piece of content that yielded no text, in encounter order.
+    pub skipped: Vec<SkippedText>,
+}
+
+impl ExtractReport {
+    /// True when every operator stream was fetched, parsed, and executed —
+    /// nothing the extraction saw was left out of the result.
+    pub fn is_complete(&self) -> bool {
+        self.skipped.is_empty()
+    }
+
+    fn record(&mut self, kind: SkippedTextKind, cause: SkipCause) {
+        self.skipped.push(SkippedText { kind, cause });
+    }
+}
+
+/// One piece of content whose text (if any) is missing from the result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkippedText {
+    pub kind: SkippedTextKind,
+    pub cause: SkipCause,
+}
+
+/// Which kind of operator stream was skipped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkippedTextKind {
+    /// The page's own `/Contents` — the whole page yielded no text.
+    PageContents,
+    /// A form XObject: its text and its entire subtree (nested forms
+    /// included) are absent.
+    Form,
+    /// An XObject name that resolved to nothing usable; whether it held
+    /// text cannot be known.
+    XObject,
+}
+
+impl std::fmt::Display for SkippedTextKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            SkippedTextKind::PageContents => "the page contents",
+            SkippedTextKind::Form => "a form XObject",
+            SkippedTextKind::XObject => "an XObject",
+        })
+    }
+}
+
+/// Why the stream was skipped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkipCause {
+    /// A `/Filter` this library cannot run — including the two passthrough
+    /// image codecs, whose still-encoded bytes no content parser may read
+    /// (ISO 32000-1 7.4.9). A stream so labelled that nonetheless holds
+    /// valid operators is skipped all the same: the label, not the bytes,
+    /// is what decides, exactly as in rendering.
+    UnsupportedFilter(String),
+    /// The stream would not fetch or decode.
+    Unreadable,
+    /// The decoded bytes did not parse as content operators.
+    Parse,
+    /// The named resource is missing, or is not a stream.
+    Missing,
+    /// Form nesting depth or the per-page invocation budget was exhausted.
+    LimitExceeded,
+}
+
+impl std::fmt::Display for SkipCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SkipCause::UnsupportedFilter(name) => write!(f, "unsupported filter /{name}"),
+            SkipCause::Unreadable => f.write_str("stream would not read"),
+            SkipCause::Parse => f.write_str("content would not parse"),
+            SkipCause::Missing => f.write_str("missing resource"),
+            SkipCause::LimitExceeded => f.write_str("form limit exceeded"),
+        }
+    }
+}
+
+/// Maps a fetch/decode error onto its cause, keeping the filter name — the
+/// one detail a caller can act on (the same split rendering reports).
+fn cause_for(error: &pdfboss_core::Error) -> SkipCause {
+    match error {
+        pdfboss_core::Error::UnsupportedFilter(name) => SkipCause::UnsupportedFilter(name.clone()),
+        _ => SkipCause::Unreadable,
+    }
+}
+
 /// Runs the page's content stream (and any form XObjects) and collects
-/// every shown string as a [`RawSpan`], in emission order.
+/// every shown string as a [`RawSpan`], in emission order, along with the
+/// report of what could not be read.
+///
+/// Lenient like rendering: a `/Contents` that will not fetch, decode, or
+/// parse contributes no spans and one report entry, never an error — the
+/// twin of `render_page_reporting`'s blank-page-with-a-report behavior.
 ///
 /// The source is taken by value so that the returned future can be `'static`;
 /// `page` is borrowed, which does not stand in the way, because a caller that
 /// owns its page creates the borrow inside its own `async move` block. See
 /// `pdfboss_core::source`'s "Signing a shared algorithm".
-pub async fn page_spans_with<S: AsyncObjectSource>(src: S, page: &Page) -> Result<Vec<RawSpan>> {
-    let content = page_content_with(&src, page).await?;
-    let ops = parse_content(&content)?;
+pub async fn page_spans_with<S: AsyncObjectSource>(
+    src: S,
+    page: &Page,
+) -> (Vec<RawSpan>, ExtractReport) {
+    let mut report = ExtractReport::default();
+    let content = match page_content_with(&src, page).await {
+        Ok(content) => content,
+        Err(e) => {
+            report.record(SkippedTextKind::PageContents, cause_for(&e));
+            Vec::new()
+        }
+    };
+    let ops = match parse_content(&content) {
+        Ok(ops) => ops,
+        Err(_) => {
+            report.record(SkippedTextKind::PageContents, SkipCause::Parse);
+            Vec::new()
+        }
+    };
     let mut exec = Executor {
         src: &src,
         spans: Vec::new(),
         fallback: Arc::new(Font::fallback()),
         forms: 0,
+        report,
     };
     let root = Frame::new(
         ops.into(),
@@ -54,7 +168,7 @@ pub async fn page_spans_with<S: AsyncObjectSource>(src: S, page: &Page) -> Resul
         0,
     );
     exec.run(root).await;
-    Ok(exec.spans)
+    (exec.spans, exec.report)
 }
 
 /// The graphics-state parameters text extraction cares about. Saved and
@@ -149,6 +263,8 @@ struct Executor<'a, S> {
     /// Form-XObject invocations so far, checked against
     /// `MAX_FORM_INVOCATIONS`.
     forms: usize,
+    /// What could not be read; carried out alongside the spans.
+    report: ExtractReport,
 }
 
 impl<S: AsyncObjectSource> Executor<'_, S> {
@@ -370,10 +486,14 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
     /// own `/Resources` **prepended to** the caller's chain, and `/Matrix`
     /// prepended to the CTM — under a depth cap and a total-invocation budget.
     ///
-    /// `None` wherever the recursive version simply returned: over budget, no
-    /// such resource, not a form, or content that will not parse. The
-    /// invocation is counted before any of those checks, exactly as before, so
-    /// a page of unreadable forms still exhausts its budget.
+    /// `None` on five ways out, each reported except the one that is normal:
+    /// depth or budget exhausted (`LimitExceeded`); no such resource, or one
+    /// that is not a stream (`Missing`); not a form — images and other
+    /// XObjects carry no text, so this is silent; a fetch the chokepoint
+    /// refuses (`UnsupportedFilter`, image codecs included) or that fails to
+    /// decode (`Unreadable`); and content that will not parse (`Parse`). The
+    /// invocation is counted before any of those checks, so a page of
+    /// unreadable forms still exhausts its budget.
     async fn form_frame(
         &mut self,
         name: &str,
@@ -382,18 +502,21 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         depth: usize,
     ) -> Option<Frame> {
         if depth >= MAX_FORM_DEPTH || self.forms >= MAX_FORM_INVOCATIONS {
+            self.report
+                .record(SkippedTextKind::Form, SkipCause::LimitExceeded);
             return None;
         }
         self.forms += 1;
         // Moved out, not cloned: `find_res` hands back an owned object, and
         // a form's stream carries its whole content body.
-        let stream = self
-            .find_res(chain, "XObject", name)
-            .await
-            .and_then(|o| match o {
-                Object::Stream(s) => Some(s),
-                _ => None,
-            })?;
+        let stream = match self.find_res(chain, "XObject", name).await {
+            Some(Object::Stream(s)) => s,
+            _ => {
+                self.report
+                    .record(SkippedTextKind::XObject, SkipCause::Missing);
+                return None;
+            }
+        };
         // `/Subtype` may be indirect like any dictionary value (ISO 32000-1
         // 7.3.8.1): a direct name answers on the spot, a reference resolves.
         let is_form = match stream.dict.get("Subtype") {
@@ -412,9 +535,22 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         }
         // Through the content chokepoint, not raw stream_data: a form whose
         // trailing /Filter is an image codec holds passthrough bytes, not
-        // operators (see `content_stream_data_with`).
-        let data = content_stream_data_with(self.src, &stream).await.ok()?;
-        let ops = parse_content(&data).ok()?;
+        // operators (see `content_stream_data_with`). The refusal is a
+        // report entry, the same accountable skip rendering records.
+        let data = match content_stream_data_with(self.src, &stream).await {
+            Ok(data) => data,
+            Err(e) => {
+                self.report.record(SkippedTextKind::Form, cause_for(&e));
+                return None;
+            }
+        };
+        let ops = match parse_content(&data) {
+            Ok(ops) => ops,
+            Err(_) => {
+                self.report.record(SkippedTextKind::Form, SkipCause::Parse);
+                return None;
+            }
+        };
         // The form's own /Resources shadows the caller's for the names it
         // defines and falls through for the ones it does not, so it is
         // prepended rather than substituted. A form that declares
@@ -521,9 +657,12 @@ mod tests {
     /// The synchronous spans accessor. Production has no use for one — the public
     /// entry points in `lib.rs` wrap [`page_spans_with`] themselves — but it is
     /// the same `block_on` over `Immediate`, so every test below still asserts on
-    /// exactly what a synchronous caller receives.
-    fn page_spans(doc: &Document, page: &Page) -> Result<Vec<RawSpan>> {
-        block_on(page_spans_with(Immediate(doc), page))
+    /// exactly what a synchronous caller receives. The report is asserted
+    /// complete: no test here expects to lose content.
+    fn page_spans(doc: &Document, page: &Page) -> Vec<RawSpan> {
+        let (spans, report) = block_on(page_spans_with(Immediate(doc), page));
+        assert!(report.is_complete(), "unexpected skips: {report:?}");
+        spans
     }
 
     /// Extracted, laid-out text of a one-page document with `content` as
@@ -531,14 +670,14 @@ mod tests {
     fn text_of(content: &str) -> String {
         let doc = Document::load(doc_with_graphics(content)).unwrap();
         let page = doc.page(0).unwrap();
-        layout(&page_spans(&doc, &page).unwrap())
+        layout(&page_spans(&doc, &page))
     }
 
     /// Raw spans of the same setup.
     fn spans_of(content: &str) -> Vec<RawSpan> {
         let doc = Document::load(doc_with_graphics(content)).unwrap();
         let page = doc.page(0).unwrap();
-        page_spans(&doc, &page).unwrap()
+        page_spans(&doc, &page)
     }
 
     #[test]
@@ -673,13 +812,23 @@ mod tests {
         }
         let doc = Document::load(b.build(1)).unwrap();
         let page = doc.page(0).unwrap();
-        let spans = page_spans(&doc, &page).unwrap();
+        // Raw call: exhausting the budget is this test's point, so the
+        // report is legitimately incomplete here.
+        let (spans, report) = block_on(page_spans_with(Immediate(&doc), &page));
         assert!(!spans.is_empty()); // nested forms still extract text
         assert!(
             spans.len() <= MAX_FORM_INVOCATIONS,
             "fan-out not bounded: {} spans",
             spans.len()
         );
+        assert!(
+            report
+                .skipped
+                .iter()
+                .all(|s| s.cause == SkipCause::LimitExceeded),
+            "only the budget may cut this page short: {report:?}"
+        );
+        assert!(!report.is_complete(), "the cut-off must be visible");
     }
 
     /// Emission order is depth-first and in stream order: a form's spans land
@@ -731,7 +880,7 @@ mod tests {
         );
         let doc = Document::load(b.build(1)).unwrap();
         let page = doc.page(0).unwrap();
-        let spans = page_spans(&doc, &page).unwrap();
+        let spans = page_spans(&doc, &page);
         let order: Vec<&str> = spans.iter().map(|s| s.text.as_str()).collect();
         assert_eq!(order, ["A", "B", "C", "D", "E"]);
     }

--- a/crates/pdfboss-text/src/extract.rs
+++ b/crates/pdfboss-text/src/extract.rs
@@ -385,14 +385,28 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             return None;
         }
         self.forms += 1;
+        // Moved out, not cloned: `find_res` hands back an owned object, and
+        // a form's stream carries its whole content body.
         let stream = self
             .find_res(chain, "XObject", name)
             .await
-            .and_then(|o| o.as_stream().cloned())?;
-        let is_form = stream
-            .dict
-            .get_name("Subtype")
-            .is_some_and(|n| n.0 == "Form");
+            .and_then(|o| match o {
+                Object::Stream(s) => Some(s),
+                _ => None,
+            })?;
+        // `/Subtype` may be indirect like any dictionary value (ISO 32000-1
+        // 7.3.8.1): a direct name answers on the spot, a reference resolves.
+        let is_form = match stream.dict.get("Subtype") {
+            Some(Object::Name(n)) => n.0 == "Form",
+            Some(indirect @ Object::Ref(_)) => self
+                .src
+                .resolve(indirect)
+                .await
+                .ok()
+                .and_then(|o| o.as_name().map(|n| n.0 == "Form"))
+                .unwrap_or(false),
+            _ => false,
+        };
         if !is_form {
             return None; // images and other XObjects carry no text
         }

--- a/crates/pdfboss-text/src/font.rs
+++ b/crates/pdfboss-text/src/font.rs
@@ -4,7 +4,7 @@
 
 use crate::cmap::ToUnicode;
 use crate::sfnt;
-use pdfboss_core::{AsyncObjectSource, Dict, Object};
+use pdfboss_core::{decoded_stream_data_with, AsyncObjectSource, Dict, Object};
 use pdfboss_encoding as encodings;
 use std::collections::HashMap;
 
@@ -76,10 +76,13 @@ impl Font {
     }
 
     /// Reads and parses `/ToUnicode`, treating an empty CMap as absent so that
-    /// the lower-priority mappings still get their chance.
+    /// the lower-priority mappings still get their chance. Fetched through the
+    /// checked fetch, not raw `stream_data`: a CMap whose trailing `/Filter`
+    /// is an image codec holds a passthrough codestream, and token-scanning
+    /// one yields an empty — or in principle a bogus — mapping.
     async fn load_to_unicode<S: AsyncObjectSource>(src: &S, dict: &Dict) -> Option<ToUnicode> {
         let obj = rv(src, dict, "ToUnicode").await?;
-        let data = src.stream_data(obj.as_stream()?).await.ok()?;
+        let data = decoded_stream_data_with(src, obj.as_stream()?).await.ok()?;
         let cmap = ToUnicode::parse(&data);
         (!cmap.is_empty()).then_some(cmap)
     }
@@ -344,13 +347,17 @@ impl Font {
     }
 
     /// Decoded bytes of `descriptor[key]` when it is a readable stream.
+    /// Fetched through the checked fetch, not raw `stream_data`: a font
+    /// program whose trailing `/Filter` is an image codec holds a
+    /// passthrough codestream, and reading one as an sfnt table directory
+    /// would let arbitrary JPEG bytes decide the WinAnsi guess.
     async fn sfnt_program<S: AsyncObjectSource>(
         src: &S,
         descriptor: &Dict,
         key: &str,
     ) -> Option<Vec<u8>> {
         let obj = rv(src, descriptor, key).await?;
-        src.stream_data(obj.as_stream()?).await.ok()
+        decoded_stream_data_with(src, obj.as_stream()?).await.ok()
     }
 
     /// Builds the 256-entry Unicode table from `/Encoding`: a base table
@@ -672,6 +679,87 @@ mod tests {
                 "code {byte:#04X} must keep its StandardEncoding character",
             );
         }
+    }
+
+    /// A `/FontFile2` whose trailing `/Filter` is an image codec is refused
+    /// by the checked fetch, so its bytes — a passthrough codestream, here
+    /// deliberately a valid sfnt to prove the refusal happens on the label —
+    /// contribute no WinAnsi evidence. Before the refusal, whatever the
+    /// codestream happened to contain decided how codes >= 128 read.
+    #[test]
+    fn an_image_codec_font_program_offers_no_winansi_evidence() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >> >>",
+        );
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /TrueType /BaseFont /OPPEKN+TimesNewRoman \
+             /FontDescriptor 7 0 R >>",
+        );
+        b.stream(6, "/Filter /DCTDecode", &sfnt_program(&[(3, 0)]));
+        b.object(7, "<< /Type /FontDescriptor /Flags 6 /FontFile2 6 0 R >>");
+        let doc = Document::load(b.build(1)).unwrap();
+        let obj = doc.get(ObjRef { num: 5, gen: 0 }).unwrap();
+        let f = block_on(Font::load(&Immediate(&doc), obj.as_dict().unwrap()));
+        assert!(
+            !f.winansi_high_codes,
+            "a refused program is no evidence at all"
+        );
+        assert_eq!(f.decode(0x92), "\u{FFFD}");
+    }
+
+    /// Builds a document whose object 5 is a Type1 font carrying the given
+    /// `/ToUnicode` stream. The CMap maps code 65 to U+03A9, so the two
+    /// outcomes read apart: `Ω` when the mapping is honored, `A` (falling
+    /// through to StandardEncoding) when the stream is refused.
+    fn font_with_tounicode(stream_dict: &str, data: &[u8]) -> Font {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >> >>",
+        );
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /ToUnicode 8 0 R >>",
+        );
+        b.stream(8, stream_dict, data);
+        let doc = Document::load(b.build(1)).unwrap();
+        let obj = doc.get(ObjRef { num: 5, gen: 0 }).unwrap();
+        block_on(Font::load(&Immediate(&doc), obj.as_dict().unwrap()))
+    }
+
+    const OMEGA_CMAP: &[u8] = b"1 begincodespacerange <00> <FF> endcodespacerange\n\
+                                1 beginbfchar <41> <03A9> endbfchar";
+
+    /// A `/ToUnicode` whose trailing `/Filter` is an image codec is refused,
+    /// never token-scanned: the bytes here are deliberately a valid CMap to
+    /// prove the refusal happens on the label, not on the content.
+    #[test]
+    fn an_image_codec_tounicode_is_refused_not_parsed() {
+        let f = font_with_tounicode("/Filter /DCTDecode", OMEGA_CMAP);
+        assert_eq!(f.decode(65), "A", "the mapping must not apply");
+    }
+
+    /// The inverse of the refusal: a benign trailing filter the decoder can
+    /// run (here ASCIIHexDecode) must keep working — over-refusal would
+    /// silently strip the mappings from every compressed ToUnicode.
+    #[test]
+    fn a_hex_encoded_tounicode_still_reads() {
+        let hex: Vec<u8> = OMEGA_CMAP
+            .iter()
+            .flat_map(|b| format!("{b:02X}").into_bytes())
+            .chain([b'>'])
+            .collect();
+        let f = font_with_tounicode("/Filter /ASCIIHexDecode", &hex);
+        assert_eq!(f.decode(65), "\u{3A9}", "the mapping must apply");
     }
 
     #[test]

--- a/crates/pdfboss-text/src/font.rs
+++ b/crates/pdfboss-text/src/font.rs
@@ -756,7 +756,7 @@ mod tests {
         let hex: Vec<u8> = OMEGA_CMAP
             .iter()
             .flat_map(|b| format!("{b:02X}").into_bytes())
-            .chain([b'>'])
+            .chain(*b">")
             .collect();
         let f = font_with_tounicode("/Filter /ASCIIHexDecode", &hex);
         assert_eq!(f.decode(65), "\u{3A9}", "the mapping must apply");

--- a/crates/pdfboss-text/src/lib.rs
+++ b/crates/pdfboss-text/src/lib.rs
@@ -222,6 +222,38 @@ mod tests {
         assert_eq!(page_text(&doc, 0), "\u{3B1}");
     }
 
+    /// A conforming file may make any dictionary value indirect (ISO 32000-1
+    /// 7.3.8.1), `/Subtype` included. The form dispatch resolves it rather
+    /// than requiring a direct name — a form declared through a reference
+    /// used to be dropped as "not a form", burning its invocation-budget
+    /// slot and silently losing its whole text subtree.
+    #[test]
+    fn a_form_whose_subtype_is_indirect_still_extracts() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> /XObject << /Fx 6 0 R >> >> \
+             /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"/Fx Do");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        b.stream(
+            6,
+            "/Type /XObject /Subtype 8 0 R /BBox [0 0 612 792]",
+            b"BT /F1 12 Tf 72 720 Td (via ref) Tj ET",
+        );
+        b.object(8, "/Form");
+        let doc = Document::load(b.build(1)).unwrap();
+        assert_eq!(page_text(&doc, 0), "via ref");
+    }
+
     /// The same chain rule for a nested form: an inner form named only in the
     /// page's `/XObject` must be reachable from a form that has its own
     /// `/Resources` without an `/XObject` entry.

--- a/crates/pdfboss-text/src/lib.rs
+++ b/crates/pdfboss-text/src/lib.rs
@@ -8,6 +8,8 @@ mod sfnt;
 
 use pdfboss_core::{block_on, AsyncObjectSource, Document, Immediate, Page, Result};
 
+pub use extract::{ExtractReport, SkipCause, SkippedText, SkippedTextKind};
+
 /// A positioned run of extracted text.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TextSpan {
@@ -26,6 +28,11 @@ pub struct TextSpan {
 /// Extracts the page's text with positional layout applied: spans grouped
 /// into lines, lines ordered top to bottom and joined with `\n`, spaces
 /// inserted at horizontal gaps.
+///
+/// Lenient the way rendering is: content that will not fetch, decode, or
+/// parse yields no text rather than an error, so one unreadable stream
+/// never costs a caller the rest of the document. Use
+/// [`extract_text_reporting`] to see what (if anything) was left out.
 pub fn extract_text(doc: &Document, page: &Page) -> Result<String> {
     block_on(extract_text_with(Immediate(doc), page))
 }
@@ -43,12 +50,31 @@ pub fn extract_text(doc: &Document, page: &Page) -> Result<String> {
 /// created inside the consumer's own `async move` block, which owns the page.
 /// See `pdfboss_core::source`'s "Signing a shared algorithm".
 pub async fn extract_text_with<S: AsyncObjectSource>(src: S, page: &Page) -> Result<String> {
-    let spans = extract::page_spans_with(src, page).await?;
-    Ok(extract::layout(&spans))
+    let (text, _) = extract_text_reporting_with(src, page).await?;
+    Ok(text)
+}
+
+/// [`extract_text`] with the report of what could not be read: an
+/// [`ExtractReport`] whose entries name each skipped stream and why —
+/// unsupported filters (the passthrough image codecs included), undecodable
+/// bytes, unparseable content, missing resources, exhausted form limits.
+/// An empty text with an empty report really is an empty page.
+pub fn extract_text_reporting(doc: &Document, page: &Page) -> Result<(String, ExtractReport)> {
+    block_on(extract_text_reporting_with(Immediate(doc), page))
+}
+
+/// [`extract_text_reporting`] against any object source. Signed like
+/// [`extract_text_with`], for the same reasons.
+pub async fn extract_text_reporting_with<S: AsyncObjectSource>(
+    src: S,
+    page: &Page,
+) -> Result<(String, ExtractReport)> {
+    let (spans, report) = extract::page_spans_with(src, page).await;
+    Ok((extract::layout(&spans), report))
 }
 
 /// Extracts the page's raw text spans (position, size and font per span),
-/// before any layout pass.
+/// before any layout pass. Lenient like [`extract_text`].
 pub fn extract_spans(doc: &Document, page: &Page) -> Result<Vec<TextSpan>> {
     block_on(extract_spans_with(Immediate(doc), page))
 }
@@ -60,8 +86,8 @@ pub async fn extract_spans_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
 ) -> Result<Vec<TextSpan>> {
-    Ok(extract::page_spans_with(src, page)
-        .await?
+    let (spans, _) = extract::page_spans_with(src, page).await;
+    Ok(spans
         .into_iter()
         .map(|s| TextSpan {
             text: s.text,
@@ -220,6 +246,202 @@ mod tests {
         );
         let doc = Document::load(b.build(1)).unwrap();
         assert_eq!(page_text(&doc, 0), "\u{3B1}");
+    }
+
+    /// Hex-encodes `data` for an `/ASCIIHexDecode` stream — the benign
+    /// trailing filter of the pass-through tests: refusal must be about the
+    /// image codecs, not about `/Filter` being present at all.
+    fn hex(data: &[u8]) -> Vec<u8> {
+        data.iter()
+            .flat_map(|b| format!("{b:02X}").into_bytes())
+            .chain([b'>'])
+            .collect()
+    }
+
+    /// One page whose `/Contents` (object 4) carries `stream_dict` around
+    /// `content`, with `/F1` a WinAnsi Helvetica.
+    fn contents_doc(stream_dict: &str, content: &[u8]) -> Document {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, stream_dict, content);
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        Document::load(b.build(1)).unwrap()
+    }
+
+    /// A page `/Contents` whose trailing `/Filter` is an image codec is
+    /// refused, and the refusal is a report entry, not an error: the page
+    /// yields no text instead of costing a document-level caller every
+    /// other page. The bytes are deliberately valid operators to prove the
+    /// refusal happens on the label.
+    #[test]
+    fn image_codec_page_contents_yield_no_text_and_one_report_entry() {
+        let doc = contents_doc(
+            "/Filter /JPXDecode",
+            b"BT /F1 12 Tf 72 720 Td (ghost) Tj ET",
+        );
+        let page = doc.page(0).unwrap();
+        let (text, report) = extract_text_reporting(&doc, &page).unwrap();
+        assert_eq!(text, "", "the passthrough bytes must not be parsed");
+        assert_eq!(
+            report.skipped,
+            vec![SkippedText {
+                kind: SkippedTextKind::PageContents,
+                cause: SkipCause::UnsupportedFilter("JPXDecode".to_string()),
+            }],
+        );
+        // The plain entry point is the same leniency without the report.
+        assert_eq!(extract_text(&doc, &page).unwrap(), "");
+    }
+
+    /// The inverse: a benign trailing filter the decoder can run must keep
+    /// decoding. Over-refusal here would silently drop the text of every
+    /// compressed page while the suite stayed green.
+    #[test]
+    fn a_filtered_page_contents_still_extracts() {
+        let doc = contents_doc(
+            "/Filter /ASCIIHexDecode",
+            &hex(b"BT /F1 12 Tf 72 720 Td (plain sight) Tj ET"),
+        );
+        let page = doc.page(0).unwrap();
+        let (text, report) = extract_text_reporting(&doc, &page).unwrap();
+        assert_eq!(text, "plain sight");
+        assert!(report.is_complete(), "nothing was skipped: {report:?}");
+    }
+
+    /// A form XObject whose trailing `/Filter` is an image codec is refused
+    /// with a report entry — the same accountable skip rendering records —
+    /// while the rest of the page still extracts. Before the report channel
+    /// existed this text vanished with zero signal.
+    #[test]
+    fn image_codec_form_content_is_refused_and_reported() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> /XObject << /Fx 6 0 R >> >> \
+             /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td (kept) Tj ET /Fx Do");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        b.stream(
+            6,
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Filter /DCTDecode",
+            b"BT /F1 12 Tf 72 700 Td (ghost) Tj ET",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let (text, report) = extract_text_reporting(&doc, &page).unwrap();
+        assert_eq!(text, "kept", "the page's own text survives the refusal");
+        assert_eq!(
+            report.skipped,
+            vec![SkippedText {
+                kind: SkippedTextKind::Form,
+                cause: SkipCause::UnsupportedFilter("DCTDecode".to_string()),
+            }],
+        );
+    }
+
+    /// The form-level inverse: a benign trailing filter on a form decodes
+    /// and its text extracts, with a complete report.
+    #[test]
+    fn a_filtered_form_still_extracts() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> /XObject << /Fx 6 0 R >> >> \
+             /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"/Fx Do");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        b.stream(
+            6,
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Filter /ASCIIHexDecode",
+            &hex(b"BT /F1 12 Tf 72 720 Td (decoded) Tj ET"),
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let (text, report) = extract_text_reporting(&doc, &page).unwrap();
+        assert_eq!(text, "decoded");
+        assert!(report.is_complete(), "nothing was skipped: {report:?}");
+    }
+
+    /// A self-invoking form recurses to the depth cap, and the cap is a
+    /// report entry rather than a silent stop.
+    #[test]
+    fn exhausted_form_depth_is_reported() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> /XObject << /Fx 6 0 R >> >> \
+             /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"/Fx Do");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        // No own /Resources: the page's names itself, so each level invokes
+        // the next until the depth cap bites at the innermost one.
+        b.stream(
+            6,
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792]",
+            b"BT /F1 12 Tf 72 720 Td (x) Tj ET /Fx Do",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let (text, report) = extract_text_reporting(&doc, &page).unwrap();
+        assert!(!text.is_empty(), "the levels above the cap still extract");
+        assert_eq!(
+            report.skipped,
+            vec![SkippedText {
+                kind: SkippedTextKind::Form,
+                cause: SkipCause::LimitExceeded,
+            }],
+        );
+    }
+
+    /// A `Do` whose name resolves to nothing usable is reported: whether it
+    /// held text cannot be known, so a complete report must not pretend so.
+    #[test]
+    fn a_missing_xobject_is_reported() {
+        let doc = contents_doc("", b"BT /F1 12 Tf 72 720 Td (here) Tj ET /Nope Do");
+        let page = doc.page(0).unwrap();
+        let (text, report) = extract_text_reporting(&doc, &page).unwrap();
+        assert_eq!(text, "here");
+        assert_eq!(
+            report.skipped,
+            vec![SkippedText {
+                kind: SkippedTextKind::XObject,
+                cause: SkipCause::Missing,
+            }],
+        );
     }
 
     /// A conforming file may make any dictionary value indirect (ISO 32000-1

--- a/crates/pdfboss-text/src/lib.rs
+++ b/crates/pdfboss-text/src/lib.rs
@@ -254,7 +254,7 @@ mod tests {
     fn hex(data: &[u8]) -> Vec<u8> {
         data.iter()
             .flat_map(|b| format!("{b:02X}").into_bytes())
-            .chain([b'>'])
+            .chain(*b">")
             .collect()
     }
 

--- a/crates/pdfboss-tui/src/app.rs
+++ b/crates/pdfboss-tui/src/app.rs
@@ -238,9 +238,11 @@ impl App {
                         InspectorPayload::Object { r, object } => {
                             self.inspector.set_object(r, object)
                         }
-                        InspectorPayload::Decoded { r, data } => {
-                            self.inspector.set_decoded(r, data)
-                        }
+                        InspectorPayload::Decoded {
+                            r,
+                            data,
+                            passthrough,
+                        } => self.inspector.set_decoded(r, data, passthrough),
                     }
                 }
                 Vec::new()

--- a/crates/pdfboss-tui/src/inspector.rs
+++ b/crates/pdfboss-tui/src/inspector.rs
@@ -24,8 +24,15 @@ pub enum InspectorMode {
 pub enum InspectorPayload {
     /// The parsed object (streams carry raw data in `Object::Stream`).
     Object { r: ObjRef, object: Object },
-    /// Decoded stream data for the Decoded/Ops views.
-    Decoded { r: ObjRef, data: Vec<u8> },
+    /// Decoded stream data for the Decoded/Ops views. `passthrough` names
+    /// the trailing image codec when `decode_stream` left the bytes encoded
+    /// for the image layer — the Ops view labels those instead of
+    /// disassembling a codestream into fabricated operators.
+    Decoded {
+        r: ObjRef,
+        data: Vec<u8>,
+        passthrough: Option<String>,
+    },
 }
 
 /// Inspector pane model.
@@ -33,6 +40,9 @@ pub struct InspectorState {
     pub title: String,
     pub object: Option<(ObjRef, Object)>,
     pub decoded: Option<Vec<u8>>,
+    /// The trailing image codec the decoded bytes are still encoded in,
+    /// when there is one; see [`InspectorPayload::Decoded`].
+    pub decoded_passthrough: Option<String>,
     pub mode: InspectorMode,
     pub scroll: u16,
     pub lines: Vec<String>,
@@ -48,6 +58,7 @@ impl InspectorState {
             title: String::new(),
             object: None,
             decoded: None,
+            decoded_passthrough: None,
             mode: InspectorMode::Pretty,
             scroll: 0,
             lines: Vec::new(),
@@ -90,7 +101,7 @@ impl InspectorState {
 
     /// Installs decoded stream data (ignored unless it matches the shown
     /// object) and refreshes decoded-backed views.
-    pub fn set_decoded(&mut self, r: ObjRef, data: Vec<u8>) {
+    pub fn set_decoded(&mut self, r: ObjRef, data: Vec<u8>, passthrough: Option<String>) {
         let matches_current = self
             .object
             .as_ref()
@@ -99,6 +110,7 @@ impl InspectorState {
             return;
         }
         self.decoded = Some(data);
+        self.decoded_passthrough = passthrough;
         if matches!(self.mode, InspectorMode::Decoded | InspectorMode::Ops) {
             self.rebuild();
         }
@@ -207,9 +219,20 @@ impl InspectorState {
                 self.ref_cursor = None;
             }
             InspectorMode::Ops => {
-                self.lines = match self.decoded.as_deref() {
-                    Some(data) => ops_lines(data),
-                    None => vec!["decoding\u{2026}".to_string()],
+                // A passthrough codestream is not operators: disassembling
+                // it fabricates ops out of encoded image bytes, misleading
+                // exactly the person debugging the mislabel.
+                self.lines = match (self.decoded.as_deref(), self.decoded_passthrough.as_deref()) {
+                    (Some(_), Some(codec)) => vec![
+                        format!(
+                            "passthrough /{codec} codestream: these bytes are \
+                             image data left encoded for the image layer, \
+                             not content operators"
+                        ),
+                        "(the decoded view shows the bytes)".to_string(),
+                    ],
+                    (Some(data), None) => ops_lines(data),
+                    (None, ..) => vec!["decoding\u{2026}".to_string()],
                 };
                 self.refs = Vec::new();
                 self.ref_cursor = None;
@@ -377,7 +400,7 @@ mod tests {
         assert!(inspector.cycle_mode(), "decoded view needs data");
         assert_eq!(inspector.mode, InspectorMode::Decoded);
         assert_eq!(inspector.lines, vec!["decoding\u{2026}"]);
-        inspector.set_decoded(ObjRef { num: 4, gen: 0 }, b"BT /F1 12 Tf ET".to_vec());
+        inspector.set_decoded(ObjRef { num: 4, gen: 0 }, b"BT /F1 12 Tf ET".to_vec(), None);
         assert_eq!(inspector.lines, vec!["BT /F1 12 Tf ET"]);
         assert!(!inspector.cycle_mode(), "ops reuses decoded data");
         assert_eq!(inspector.mode, InspectorMode::Ops);
@@ -395,11 +418,42 @@ mod tests {
         inspector.set_object(ObjRef { num: 4, gen: 0 }, content_stream());
         inspector.cycle_mode();
         inspector.cycle_mode();
-        inspector.set_decoded(ObjRef { num: 9, gen: 0 }, b"junk".to_vec());
+        inspector.set_decoded(ObjRef { num: 9, gen: 0 }, b"junk".to_vec(), None);
         assert_eq!(
             inspector.lines,
             vec!["decoding\u{2026}"],
             "wrong object dropped"
+        );
+    }
+
+    /// A passthrough codestream is not operators: the Ops view labels it
+    /// instead of disassembling encoded image bytes into fabricated ops —
+    /// which would mislead exactly the person debugging the mislabel. The
+    /// bytes here are deliberately valid operator syntax, so the label (not
+    /// the content) is proven to decide; the Decoded view still shows them.
+    #[test]
+    fn ops_view_labels_a_passthrough_codestream() {
+        let mut inspector = InspectorState::new();
+        inspector.set_object(ObjRef { num: 4, gen: 0 }, content_stream());
+        inspector.cycle_mode(); // Raw
+        inspector.cycle_mode(); // Decoded
+        inspector.set_decoded(
+            ObjRef { num: 4, gen: 0 },
+            b"BT /F1 12 Tf ET".to_vec(),
+            Some("DCTDecode".to_string()),
+        );
+        assert_eq!(
+            inspector.lines,
+            vec!["BT /F1 12 Tf ET"],
+            "the decoded view still shows the bytes"
+        );
+        assert!(!inspector.cycle_mode());
+        assert_eq!(inspector.mode, InspectorMode::Ops);
+        assert_eq!(inspector.lines.len(), 2);
+        assert!(
+            inspector.lines[0].starts_with("passthrough /DCTDecode codestream"),
+            "{:?}",
+            inspector.lines
         );
     }
 

--- a/crates/pdfboss-tui/src/lib.rs
+++ b/crates/pdfboss-tui/src/lib.rs
@@ -161,9 +161,13 @@ fn execute_cmd(
         Cmd::DecodeStream { generation, r } => {
             tokio::spawn(async move {
                 let message = match decoded_stream_data(&doc, r).await {
-                    Ok(data) => Msg::InspectorLoaded {
+                    Ok((data, passthrough)) => Msg::InspectorLoaded {
                         generation,
-                        payload: InspectorPayload::Decoded { r, data },
+                        payload: InspectorPayload::Decoded {
+                            r,
+                            data,
+                            passthrough,
+                        },
                     },
                     Err(error) => Msg::InspectorFailed { generation, error },
                 };
@@ -310,15 +314,26 @@ async fn page_contents(doc: &AsyncDocument, r: ObjRef) -> Result<Vec<ObjRef>, St
     Ok(refs)
 }
 
-/// Decoded data of stream object `r`.
-async fn decoded_stream_data(doc: &AsyncDocument, r: ObjRef) -> Result<Vec<u8>, String> {
+/// Decoded data of stream object `r`, plus the trailing image codec's name
+/// when `decode_stream` leaves the bytes encoded for the image layer — the
+/// Ops view labels such a passthrough instead of disassembling it.
+async fn decoded_stream_data(
+    doc: &AsyncDocument,
+    r: ObjRef,
+) -> Result<(Vec<u8>, Option<String>), String> {
     let object = doc.get_object(r).await.map_err(|error| error.to_string())?;
     let Some(stream) = object.as_stream() else {
         return Err(format!("object {} {} is not a stream", r.num, r.gen));
     };
-    doc.decode_stream(stream)
+    let passthrough = pdfboss_core::filters::trailing_filter_with(doc, &stream.dict)
         .await
-        .map_err(|error| error.to_string())
+        .filter(|name| pdfboss_core::filters::is_image_codec(&name.0))
+        .map(|name| name.0);
+    let data = doc
+        .decode_stream(stream)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok((data, passthrough))
 }
 
 /// Loads one hex window: a `read_span` window of a file span, or the whole
@@ -342,7 +357,7 @@ async fn load_hex(
         }
         HexSource::DecodedObjStm { container } => {
             match decoded_stream_data(&doc, container).await {
-                Ok(bytes) => Ok((0, bytes.len() as u64, bytes)),
+                Ok((bytes, _)) => Ok((0, bytes.len() as u64, bytes)),
                 Err(error) => Err(error),
             }
         }


### PR DESCRIPTION
Fixes all 15 findings of the max-effort code review that followed the form-XObject chokepoint commit. The review's headline was that the image-codec refusal existed but leaked at the edges: three more raw fetches feeding parsers, a resolution-depth gap a crafted chain could slip through, and a document-level text API that lost a whole document over one refused page.

## Core — the gate itself

- **`/Filter` chains resolve to one shared depth.** The gate (`trailing_filter_with`) chased references up to `MAX_RESOLVE_DEPTH` (32) while `decode_stream`'s own `resolve_value` gave up after 8, so a 9–32-hop chain was a stream the gate vouched for but the decoder leniently returned still encoded. Both sides now share the one constant, pinned by a 9-hop-chain test.
- **`decoded_stream_data_with` — one checked fetch for every non-image consumer.** The refusal only had a content-specific name, so each new non-content consumer reached for raw `stream_data` and re-shipped the same bug. The general name states the guarantee (the bytes are decoded), `content_stream_data_with` delegates to it, and the docs on `is_image_codec` now say where every non-image consumer must fetch. Raw `stream_data` remains correct in exactly one place: the image layer.
- **Direct `/Filter` values skip the boxed resolve.** The gate runs in front of every content fetch (up to once per form invocation); a bare name or array of bare names is now read straight off the dictionary, with the resolve reserved for actual references — pinned by a resolve-counting test.

## Text — lenient like rendering, and accountable for it

- **`ExtractReport`.** The same refusal used to surface three ways: silently swallowed at the form level, hard-failing the whole page at the page level, and a reported skip in render. Extraction now absorbs content-level failures exactly as rendering does — no text, one report entry (`PageContents`/`Form`/`XObject` × unsupported-filter-with-name/unreadable/parse/missing/limit-exceeded). `extract_text` keeps its signature; `extract_text_reporting` hands the report to completeness auditors. A mislabelled-but-valid stream is skipped on its label, same as render — the report entry is what keeps that narrowing visible.
- **Document-level APIs no longer lose the document.** The 500-page-file-with-one-mislabelled-page case: `doc.extract_text()` (py, sync and async) and `pdfboss text` now yield the 499 good pages; the CLI prints one stderr warning per skipped stream.
- **Font programs and `/ToUnicode` fetch through the checked fetch.** An sfnt whose trailing filter is an image codec no longer lets codestream bytes decide the WinAnsi high-code guess; a mislabelled ToUnicode is refused instead of token-scanned. Hex-encoded inverses pin that benign trailing filters keep decoding.
- **`/Subtype` may be indirect** (ISO 32000-1 7.3.8.1): the form dispatch resolves it in both text and render instead of dropping a conforming form as "not a form".
- **The form stream is moved, not deep-copied** (dict + whole raw body per invocation, up to 4096/page).
- **`form_frame`'s contract doc** now enumerates every `None`-cause, the refusal included.

## Render

- **`/CIDToGIDMap` goes through the checked fetch.** A refused or unreadable map keeps the font loaded over an *empty* table: every CID lands on gid 0, so each drawn code becomes a reported `NoGlyph` skip with its advance intact — instead of a nonsense GID table painting every glyph wrong under a clean report (raw fetch), a silent whole-font drop (failing the load), or wrong ink (Identity fallback).
- **`stream_bytes`** — the fetch under every embedded font program in the glyph loader — uses the checked fetch too; all of its callers are font parsers.

## TUI

- **The Ops view labels passthrough codestreams** ("passthrough /DCTDecode codestream: … not content operators") instead of disassembling encoded image bytes into fabricated operators; the Decoded and Hex views still show the raw bytes, which is an inspector's job.

## Test coverage the review demanded

pdfboss-text previously had no fixture with any `/Filter` on any stream. It now pins both directions in its own suite: image-codec refusal on page contents, forms, ToUnicode, and font programs (all with deliberately valid payloads, proving the *label* decides), and ASCIIHex inverses that must keep decoding. Render pins the CIDToGIDMap refusal/report and its filtered inverse; the TUI pins the passthrough label.

## Verification

- `cargo fmt` / `cargo clippy --workspace --all-targets`: clean
- `cargo test --workspace`: all suites green
- pytest (maturin develop build): green

One design note: the review's deepest suggestion — making an ungated fetch-then-parse unrepresentable at compile time (a `ContentBytes` newtype or a trait-level inversion where `stream_data` refuses by default and the image layer opts in) — is a broader API break than this PR. `decoded_stream_data_with` + the documented policy is the incremental step; the trait-level inversion is the candidate follow-up if the class leaks again.
