### PR TITLE
feat(tui): markdown preview pane behind the m key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,6 +1301,7 @@ dependencies = [
  "futures-util",
  "pdfboss-aio",
  "pdfboss-core",
+ "pdfboss-output",
  "pdfboss-render",
  "pdfboss-testkit",
  "ratatui",

--- a/crates/pdfboss-tui/Cargo.toml
+++ b/crates/pdfboss-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdfboss-tui"
-description = "Terminal explorer for PDF internals: element tree, object inspector, hex view and page preview"
+description = "Terminal explorer for PDF internals: element tree, object inspector, hex view, page preview and Markdown preview"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,6 +11,7 @@ keywords.workspace = true
 [dependencies]
 pdfboss-aio = { workspace = true }
 pdfboss-core = { workspace = true }
+pdfboss-output = { workspace = true }
 pdfboss-render = { workspace = true }
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/crates/pdfboss-tui/src/app.rs
+++ b/crates/pdfboss-tui/src/app.rs
@@ -12,6 +12,7 @@ use pdfboss_core::ObjRef;
 use crate::hexview::{HexSource, HexState};
 use crate::input::{action_for, Action};
 use crate::inspector::{InspectorPayload, InspectorState};
+use crate::markdown::MarkdownState;
 use crate::preview::{PreviewFrame, PreviewState, RESIZE_DEBOUNCE_TICKS};
 use crate::search::{SearchHit, SearchState};
 use crate::tree::{LoadState, NodeId, NodeKind, TreeReq, TreeState};
@@ -81,6 +82,11 @@ pub enum Msg {
         generation: u64,
         result: Result<PreviewFrame, String>,
     },
+    /// A page's Markdown extraction finished (or failed).
+    MarkdownReady {
+        generation: u64,
+        result: Result<String, String>,
+    },
 }
 
 /// Side effects `update` requests; the event loop executes them by
@@ -116,6 +122,8 @@ pub enum Cmd {
         /// Cached whole-file bytes from an earlier render, if any.
         file_bytes: Option<Arc<Vec<u8>>>,
     },
+    /// Extract page `page` as Markdown.
+    ExtractMarkdown { generation: u64, page: usize },
 }
 
 /// The whole TUI state.
@@ -125,6 +133,7 @@ pub struct App {
     pub inspector: InspectorState,
     pub hex: HexState,
     pub preview: PreviewState,
+    pub markdown: MarkdownState,
     pub search: SearchState,
     pub focus: Pane,
     pub history: Vec<NodeId>,
@@ -146,6 +155,7 @@ impl App {
             inspector: InspectorState::new(),
             hex: HexState::new(),
             preview: PreviewState::new(),
+            markdown: MarkdownState::new(),
             search: SearchState::new(),
             focus: Pane::Tree,
             history: Vec::new(),
@@ -178,7 +188,7 @@ impl App {
             return message.clone();
         }
         format!(
-            "{} \u{b7} {} \u{b7} [/] search  [p] preview  [q] quit",
+            "{} \u{b7} {} \u{b7} [/] search  [p] preview  [m] markdown  [q] quit",
             self.title,
             self.tree.breadcrumb()
         )
@@ -295,6 +305,14 @@ impl App {
                 }
                 Vec::new()
             }
+            Msg::MarkdownReady { generation, result } => {
+                if self.markdown.apply_ready(generation, result) {
+                    if let Some(error) = self.markdown.error.clone() {
+                        self.toast(format!("markdown: {error}"));
+                    }
+                }
+                Vec::new()
+            }
         }
     }
 
@@ -305,6 +323,7 @@ impl App {
                 self.toast = None;
             }
         }
+        self.markdown.tick();
         if self.preview.tick() {
             return self.request_preview();
         }
@@ -366,8 +385,20 @@ impl App {
                     self.preview.active = false;
                     Vec::new()
                 } else {
+                    // Both render into the right-top pane.
+                    self.markdown.active = false;
                     self.preview.active = true;
                     self.request_preview()
+                }
+            }
+            Action::ToggleMarkdown => {
+                if self.markdown.active {
+                    self.markdown.active = false;
+                    Vec::new()
+                } else {
+                    self.preview.active = false;
+                    self.markdown.active = true;
+                    self.request_markdown()
                 }
             }
             Action::CycleView => {
@@ -418,6 +449,10 @@ impl App {
                     self.tree.select_top();
                     self.on_select(false)
                 }
+                Pane::Inspector if self.markdown.active => {
+                    self.markdown.scroll_to(0);
+                    Vec::new()
+                }
                 Pane::Inspector => {
                     self.inspector.scroll = 0;
                     self.inspector.ref_cursor = None;
@@ -432,6 +467,10 @@ impl App {
                 Pane::Tree => {
                     self.tree.select_bottom();
                     self.on_select(false)
+                }
+                Pane::Inspector if self.markdown.active => {
+                    self.markdown.scroll_to(u64::MAX);
+                    Vec::new()
                 }
                 Pane::Inspector => {
                     self.inspector.scroll = self.inspector.lines.len().saturating_sub(1) as u16;
@@ -455,6 +494,10 @@ impl App {
                     self.tree.select_next();
                 }
                 self.on_select(false)
+            }
+            Pane::Inspector if self.markdown.active => {
+                self.markdown.scroll_by(delta);
+                Vec::new()
             }
             Pane::Inspector => {
                 self.inspector.move_cursor(delta);
@@ -480,6 +523,10 @@ impl App {
                     }
                 }
                 self.on_select(false)
+            }
+            Pane::Inspector if self.markdown.active => {
+                self.markdown.scroll_by(direction * PAGE_JUMP as i32);
+                Vec::new()
             }
             Pane::Inspector => {
                 self.inspector.move_cursor(direction * PAGE_JUMP as i32);
@@ -753,6 +800,20 @@ impl App {
             max_h,
             file_bytes: self.preview.file_bytes.clone(),
         }]
+    }
+
+    /// Extracts the selected page as Markdown. Per page, not document-wide:
+    /// the document can be HTTP-range-backed, and the pane shows one page
+    /// at a time anyway.
+    fn request_markdown(&mut self) -> Vec<Cmd> {
+        if self.tree.page_count == 0 {
+            self.toast("document has no pages to extract");
+            self.markdown.active = false;
+            return Vec::new();
+        }
+        let page = self.tree.page_of(self.tree.selected).unwrap_or(0);
+        let generation = self.markdown.start_extract(page);
+        vec![Cmd::ExtractMarkdown { generation, page }]
     }
 
     /// The pixel budget `fit_scale` fits a page into: a `C`-column,
@@ -1116,6 +1177,100 @@ mod tests {
         ));
     }
 
+    /// Controller item: `m` and `p` paint the same pane, so activating one
+    /// must deactivate the other in both directions — otherwise the
+    /// three-way draw branch would show markdown while the user believes
+    /// they turned the raster preview on.
+    #[test]
+    fn markdown_and_preview_are_mutually_exclusive() {
+        let mut app = loaded_app();
+        let cmds = app.update(key(KeyCode::Char('m')));
+        assert!(app.markdown.active);
+        assert!(matches!(
+            cmds.as_slice(),
+            [Cmd::ExtractMarkdown { page: 0, .. }]
+        ));
+        let cmds = app.update(key(KeyCode::Char('p')));
+        assert!(app.preview.active);
+        assert!(!app.markdown.active, "preview replaces markdown");
+        assert!(matches!(
+            cmds.as_slice(),
+            [Cmd::RenderPreview { page: 0, .. }]
+        ));
+        app.update(key(KeyCode::Char('m')));
+        assert!(app.markdown.active);
+        assert!(!app.preview.active, "markdown replaces preview");
+        app.update(key(KeyCode::Char('m')));
+        assert!(!app.markdown.active, "m toggles back off");
+    }
+
+    /// Controller item: a superseded extraction finishing late must not
+    /// install its text over the newer request's.
+    #[test]
+    fn stale_markdown_extraction_is_dropped() {
+        let mut app = loaded_app();
+        let cmds = app.update(key(KeyCode::Char('m')));
+        let stale = match cmds.as_slice() {
+            [Cmd::ExtractMarkdown { generation, .. }] => *generation,
+            other => panic!("expected ExtractMarkdown, got {:?}", other),
+        };
+        app.update(key(KeyCode::Char('m'))); // off
+        let cmds = app.update(key(KeyCode::Char('m'))); // on again
+        let current = match cmds.as_slice() {
+            [Cmd::ExtractMarkdown { generation, .. }] => *generation,
+            other => panic!("expected ExtractMarkdown, got {:?}", other),
+        };
+        assert!(current > stale);
+        app.update(Msg::MarkdownReady {
+            generation: stale,
+            result: Ok("# stale".to_string()),
+        });
+        assert!(app.markdown.source.is_none(), "stale text is not installed");
+        assert!(
+            app.markdown.loading,
+            "the newer extraction is still awaited"
+        );
+        app.update(Msg::MarkdownReady {
+            generation: current,
+            result: Ok("# fresh".to_string()),
+        });
+        assert_eq!(app.markdown.source.as_deref(), Some("# fresh"));
+    }
+
+    /// Controller item: the markdown pane shares `Pane::Inspector` focus,
+    /// so while it is active the movement keys must scroll *it*, not move
+    /// the inspector's hidden ref cursor.
+    #[test]
+    fn movement_scrolls_the_markdown_pane_while_it_is_active() {
+        let mut app = loaded_app();
+        let cmds = app.update(key(KeyCode::Char('m')));
+        let generation = match cmds.as_slice() {
+            [Cmd::ExtractMarkdown { generation, .. }] => *generation,
+            other => panic!("expected ExtractMarkdown, got {:?}", other),
+        };
+        app.update(Msg::MarkdownReady {
+            generation,
+            result: Ok((0..40)
+                .map(|n| format!("line {n}"))
+                .collect::<Vec<String>>()
+                .join("\n")),
+        });
+        app.update(key(KeyCode::Tab));
+        assert_eq!(app.focus, Pane::Inspector);
+        app.update(key(KeyCode::Char('j')));
+        assert_eq!(app.markdown.scroll, 1);
+        app.update(key(KeyCode::PageDown));
+        assert_eq!(app.markdown.scroll, 11);
+        app.update(key(KeyCode::Char('G')));
+        assert_eq!(app.markdown.scroll, 39, "last of the 40 lines");
+        app.update(key(KeyCode::Char('g')));
+        assert_eq!(app.markdown.scroll, 0);
+        assert!(
+            app.inspector.ref_cursor.is_none(),
+            "the hidden inspector must not have moved"
+        );
+    }
+
     #[test]
     fn toast_expires_after_ticks() {
         let mut app = loaded_app();
@@ -1133,7 +1288,7 @@ mod tests {
         let mut app = loaded_app();
         assert_eq!(
             app.status_line(),
-            "t.pdf \u{b7} /Document \u{b7} [/] search  [p] preview  [q] quit"
+            "t.pdf \u{b7} /Document \u{b7} [/] search  [p] preview  [m] markdown  [q] quit"
         );
         app.update(key(KeyCode::Char('/')));
         app.update(key(KeyCode::Char('a')));

--- a/crates/pdfboss-tui/src/input.rs
+++ b/crates/pdfboss-tui/src/input.rs
@@ -18,6 +18,7 @@ pub enum Action {
     PageDown,
     CycleView,
     TogglePreview,
+    ToggleMarkdown,
     OpenSearch,
     SearchChar(char),
     SearchBackspace,
@@ -62,6 +63,7 @@ pub fn action_for(key: KeyEvent, search_input: bool) -> Action {
         KeyCode::PageDown => Action::PageDown,
         KeyCode::Char('d') => Action::CycleView,
         KeyCode::Char('p') => Action::TogglePreview,
+        KeyCode::Char('m') => Action::ToggleMarkdown,
         _ => Action::Noop,
     }
 }
@@ -114,6 +116,10 @@ mod tests {
         assert_eq!(
             action_for(press(KeyCode::Char('p')), false),
             Action::TogglePreview
+        );
+        assert_eq!(
+            action_for(press(KeyCode::Char('m')), false),
+            Action::ToggleMarkdown
         );
         assert_eq!(
             action_for(press(KeyCode::Char('n')), false),

--- a/crates/pdfboss-tui/src/lib.rs
+++ b/crates/pdfboss-tui/src/lib.rs
@@ -2,8 +2,8 @@
 //! ISO 32000 on top of `pdfboss-aio`'s async document model.
 //!
 //! State machine (`app`), pane models (`tree`, `inspector`, `hexview`,
-//! `preview`, `search`), key mapping (`input`) and rendering (`ui`) are
-//! pure and unit-testable; only [`run`] touches the real terminal. The
+//! `preview`, `markdown`, `search`), key mapping (`input`) and rendering
+//! (`ui`) are pure and unit-testable; only [`run`] touches the terminal. The
 //! event loop `tokio::select!`s over the crossterm event stream, a
 //! background-task message channel and a 100 ms tick, so long operations
 //! (element streaming, hex fetches, search, preview rasterization) never
@@ -13,6 +13,7 @@ pub mod app;
 pub mod hexview;
 pub mod input;
 pub mod inspector;
+pub mod markdown;
 pub mod preview;
 pub mod search;
 pub mod tree;
@@ -199,6 +200,9 @@ fn execute_cmd(
             tokio::spawn(render_preview(
                 doc, tx, generation, page, max_w, max_h, file_bytes,
             ));
+        }
+        Cmd::ExtractMarkdown { generation, page } => {
+            tokio::spawn(extract_markdown(doc, tx, generation, page));
         }
     }
 }
@@ -466,6 +470,25 @@ async fn render_preview(
     tx.send(Msg::PreviewReady { generation, result }).ok();
 }
 
+/// Extracts one page as Markdown. Unlike the preview this needs no
+/// whole-file fetch and no `spawn_blocking`: `extract_page_markdown_with`
+/// runs directly over the `AsyncDocument`, which is `Send` and fetches
+/// only the objects the page's text touches.
+async fn extract_markdown(
+    doc: AsyncDocument,
+    tx: UnboundedSender<Msg>,
+    generation: u64,
+    page: usize,
+) {
+    let result = match doc.page(page) {
+        Ok(page_object) => pdfboss_output::extract_page_markdown_with(doc, &page_object)
+            .await
+            .map_err(|error| error.to_string()),
+        Err(error) => Err(error.to_string()),
+    };
+    tx.send(Msg::MarkdownReady { generation, result }).ok();
+}
+
 /// Fetches the entire file via one `read_span` over
 /// `0..doc.file_len()` (the aio crate reports the length synchronously).
 async fn fetch_whole_file(doc: &AsyncDocument) -> Result<Vec<u8>, String> {
@@ -495,6 +518,45 @@ mod tests {
             "partial salvage: any real element wins over errors"
         );
         assert!(!pass_failed(3, 0), "clean pass with elements");
+    }
+
+    /// The markdown task end to end over the real async path: no
+    /// whole-file fetch, no `spawn_blocking`, and the page's text comes
+    /// back on the channel as a `MarkdownReady`.
+    #[tokio::test]
+    async fn extract_markdown_sends_the_page_text() {
+        let doc = AsyncDocument::from_bytes(pdfboss_testkit::simple_doc("Hello"))
+            .await
+            .expect("fixture opens");
+        let (tx, mut rx) = mpsc::unbounded_channel::<Msg>();
+        extract_markdown(doc, tx, 7, 0).await;
+        match rx.try_recv().expect("one message") {
+            Msg::MarkdownReady { generation, result } => {
+                assert_eq!(generation, 7, "the request's generation rides along");
+                assert!(
+                    result.expect("extraction succeeds").contains("Hello"),
+                    "the page's text must reach the pane"
+                );
+            }
+            other => panic!("expected MarkdownReady, got {:?}", other),
+        }
+    }
+
+    /// A page index the document does not have fails the task, not the
+    /// event loop: the error travels as the message's `Err`.
+    #[tokio::test]
+    async fn extract_markdown_reports_a_missing_page_as_an_error() {
+        let doc = AsyncDocument::from_bytes(pdfboss_testkit::simple_doc("Hello"))
+            .await
+            .expect("fixture opens");
+        let (tx, mut rx) = mpsc::unbounded_channel::<Msg>();
+        extract_markdown(doc, tx, 1, 99).await;
+        match rx.try_recv().expect("one message") {
+            Msg::MarkdownReady { result, .. } => {
+                assert!(result.is_err(), "page 99 does not exist");
+            }
+            other => panic!("expected MarkdownReady, got {:?}", other),
+        }
     }
 
     #[tokio::test]

--- a/crates/pdfboss-tui/src/markdown.rs
+++ b/crates/pdfboss-tui/src/markdown.rs
@@ -1,0 +1,367 @@
+//! Markdown preview: the per-page Markdown extraction as scrollable text.
+//! This module is pure state plus a line-oriented styling pass; the
+//! extraction itself runs off the event loop.
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use crate::preview::SPINNER;
+
+/// Markdown pane model.
+pub struct MarkdownState {
+    /// Whether the pane replaces the inspector (`m`).
+    pub active: bool,
+    pub page: Option<usize>,
+    pub source: Option<String>,
+    pub scroll: u16,
+    pub loading: bool,
+    pub spinner_frame: usize,
+    pub generation: u64,
+    pub error: Option<String>,
+}
+
+impl MarkdownState {
+    pub fn new() -> MarkdownState {
+        MarkdownState {
+            active: false,
+            page: None,
+            source: None,
+            scroll: 0,
+            loading: false,
+            spinner_frame: 0,
+            generation: 0,
+            error: None,
+        }
+    }
+
+    /// Marks an extraction in flight for `page`; returns its generation.
+    pub fn start_extract(&mut self, page: usize) -> u64 {
+        self.generation += 1;
+        self.page = Some(page);
+        self.loading = true;
+        self.source = None;
+        self.error = None;
+        self.scroll = 0;
+        self.generation
+    }
+
+    /// Applies a finished extraction; stale generations are dropped.
+    /// Returns whether the result was accepted. Nothing here outlives its
+    /// generation (unlike the preview's whole-file bytes), so the whole
+    /// body is gated on the generation matching.
+    pub fn apply_ready(&mut self, generation: u64, result: Result<String, String>) -> bool {
+        if generation != self.generation {
+            return false;
+        }
+        self.loading = false;
+        self.scroll = 0;
+        match result {
+            Ok(source) => {
+                self.source = Some(source);
+                self.error = None;
+            }
+            Err(message) => self.error = Some(message),
+        }
+        true
+    }
+
+    /// 100 ms heartbeat: advances the spinner while an extraction is in
+    /// flight.
+    pub fn tick(&mut self) {
+        if self.loading {
+            self.spinner_frame = (self.spinner_frame + 1) % SPINNER.len();
+        }
+    }
+
+    pub fn line_count(&self) -> usize {
+        match &self.source {
+            Some(source) => source.lines().count(),
+            None => 0,
+        }
+    }
+
+    /// Scrolls by `delta` lines, clamped to the extracted text.
+    pub fn scroll_by(&mut self, delta: i32) {
+        let target = i64::from(self.scroll) + i64::from(delta);
+        self.scroll_to(target.max(0) as u64);
+    }
+
+    pub fn scroll_to(&mut self, line: u64) {
+        let last = self.line_count().saturating_sub(1) as u64;
+        self.scroll = line.min(last).min(u64::from(u16::MAX)) as u16;
+    }
+}
+
+impl Default for MarkdownState {
+    fn default() -> MarkdownState {
+        MarkdownState::new()
+    }
+}
+
+/// The Markdown source as styled terminal lines: one output line per source
+/// line, no wrapping (every pane clips at its width). This is a
+/// presentation pass, not a parser — a line whose markers do not balance
+/// keeps its raw text.
+pub fn style_markdown(source: &str) -> Vec<Line<'static>> {
+    source.lines().map(style_line).collect()
+}
+
+fn style_line(line: &str) -> Line<'static> {
+    if let Some(level) = heading_level(line) {
+        let style = Style::default()
+            .fg(heading_color(level))
+            .add_modifier(Modifier::BOLD);
+        return Line::from(vec![Span::styled(line.to_string(), style)]);
+    }
+    if line.starts_with('|') {
+        return Line::from(vec![Span::styled(
+            line.to_string(),
+            Style::default().add_modifier(Modifier::DIM),
+        )]);
+    }
+    if let Some(marker_len) = list_marker_len(line) {
+        let (marker, rest) = line.split_at(marker_len);
+        let mut spans = vec![
+            Span::raw("  "),
+            Span::styled(marker.to_string(), Style::default().fg(Color::Yellow)),
+        ];
+        spans.extend(inline_spans(rest, Style::default()));
+        return Line::from(spans);
+    }
+    Line::from(inline_spans(line, Style::default()))
+}
+
+/// `1..=6` for an ATX heading. An escaped leading hash (`\#`, which the
+/// Markdown writer emits for body text that starts with one) is prose.
+fn heading_level(line: &str) -> Option<u8> {
+    let hashes = line.chars().take_while(|c| *c == '#').count();
+    if hashes == 0 || hashes > 6 {
+        return None;
+    }
+    if !line[hashes..].starts_with(' ') {
+        return None;
+    }
+    Some(hashes as u8)
+}
+
+fn heading_color(level: u8) -> Color {
+    match level {
+        1 => Color::Magenta,
+        2 => Color::Cyan,
+        _ => Color::Blue,
+    }
+}
+
+/// Length of a leading `- ` bullet or `12. ` number marker, if any.
+fn list_marker_len(line: &str) -> Option<usize> {
+    if line.starts_with("- ") {
+        return Some(2);
+    }
+    let digits = line.chars().take_while(char::is_ascii_digit).count();
+    if digits == 0 || !line[digits..].starts_with(". ") {
+        return None;
+    }
+    Some(digits + 2)
+}
+
+/// `**bold**` and `*italic*` runs as styled spans; a marker that does not
+/// close stays literal text.
+fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut plain = String::new();
+    let mut rest = text;
+    while !rest.is_empty() {
+        let Some(at) = rest.find('*') else {
+            plain.push_str(rest);
+            break;
+        };
+        let (marker, modifier) = if rest[at..].starts_with("**") {
+            ("**", Modifier::BOLD)
+        } else {
+            ("*", Modifier::ITALIC)
+        };
+        let after = at + marker.len();
+        match emphasis_end(&rest[after..], marker) {
+            None => {
+                plain.push_str(&rest[..after]);
+                rest = &rest[after..];
+            }
+            Some(offset) => {
+                plain.push_str(&rest[..at]);
+                if !plain.is_empty() {
+                    spans.push(Span::styled(std::mem::take(&mut plain), base));
+                }
+                spans.push(Span::styled(
+                    rest[after..after + offset].to_string(),
+                    base.add_modifier(modifier),
+                ));
+                rest = &rest[after + offset + marker.len()..];
+            }
+        }
+    }
+    if !plain.is_empty() {
+        spans.push(Span::styled(plain, base));
+    }
+    spans
+}
+
+/// Where the run opened by `marker` closes inside `text`, if it does. Both
+/// ends must hug their text — a marker with whitespace on the inside is
+/// arithmetic or a bullet glyph, not emphasis.
+fn emphasis_end(text: &str, marker: &str) -> Option<usize> {
+    if !text.starts_with(|c: char| !c.is_whitespace()) {
+        return None;
+    }
+    let mut from = 0usize;
+    while let Some(found) = text[from..].find(marker) {
+        let at = from + found;
+        if text[..at]
+            .chars()
+            .next_back()
+            .is_some_and(|c| !c.is_whitespace())
+        {
+            return Some(at);
+        }
+        from = at + marker.len();
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn texts(line: &Line<'_>) -> Vec<String> {
+        line.spans
+            .iter()
+            .map(|span| span.content.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn start_extract_bumps_generation_and_spins() {
+        let mut markdown = MarkdownState::new();
+        let first = markdown.start_extract(0);
+        let second = markdown.start_extract(1);
+        assert!(second > first);
+        assert_eq!(markdown.page, Some(1));
+        assert!(markdown.loading);
+        let before = markdown.spinner_frame;
+        markdown.tick();
+        assert_ne!(
+            markdown.spinner_frame, before,
+            "spinner advances while extracting"
+        );
+    }
+
+    #[test]
+    fn apply_ready_ignores_stale_generations() {
+        let mut markdown = MarkdownState::new();
+        let stale = markdown.start_extract(0);
+        let current = markdown.start_extract(0);
+        assert!(!markdown.apply_ready(stale, Ok("# stale".to_string())));
+        assert!(markdown.source.is_none(), "stale text is not installed");
+        assert!(markdown.loading, "stale result leaves the spinner on");
+        assert!(markdown.apply_ready(current, Ok("# fresh".to_string())));
+        assert!(!markdown.loading);
+        assert_eq!(markdown.source.as_deref(), Some("# fresh"));
+        assert!(markdown.apply_ready(current, Err("boom".to_string())));
+        assert_eq!(markdown.error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn scrolling_clamps_to_the_extracted_lines() {
+        let mut markdown = MarkdownState::new();
+        markdown.scroll_by(5);
+        assert_eq!(markdown.scroll, 0, "nothing extracted yet");
+        let generation = markdown.start_extract(0);
+        markdown.apply_ready(generation, Ok("a\nb\nc".to_string()));
+        assert_eq!(markdown.line_count(), 3);
+        markdown.scroll_by(10);
+        assert_eq!(markdown.scroll, 2, "clamped to the last line");
+        markdown.scroll_by(-10);
+        assert_eq!(markdown.scroll, 0, "clamped at the top");
+    }
+
+    #[test]
+    fn headings_are_bold_and_colored() {
+        let lines = style_markdown("# Title\n### Sub");
+        assert_eq!(texts(&lines[0]), vec!["# Title"]);
+        assert!(lines[0].spans[0]
+            .style
+            .add_modifier
+            .contains(Modifier::BOLD));
+        assert_eq!(lines[0].spans[0].style.fg, Some(Color::Magenta));
+        assert_eq!(lines[1].spans[0].style.fg, Some(Color::Blue));
+    }
+
+    #[test]
+    fn escaped_leading_hash_is_prose() {
+        let lines = style_markdown("\\# not a heading");
+        assert_eq!(texts(&lines[0]), vec!["\\# not a heading"]);
+        assert!(
+            !lines[0].spans[0]
+                .style
+                .add_modifier
+                .contains(Modifier::BOLD),
+            "an escaped hash is body text the writer escaped, not a heading"
+        );
+        let lines = style_markdown("#no space");
+        assert!(!lines[0].spans[0]
+            .style
+            .add_modifier
+            .contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn list_items_are_indented_behind_their_marker() {
+        let lines = style_markdown("- first\n12. twelfth\n-nomarker");
+        assert_eq!(texts(&lines[0]), vec!["  ", "- ", "first"]);
+        assert_eq!(texts(&lines[1]), vec!["  ", "12. ", "twelfth"]);
+        assert_eq!(texts(&lines[2]), vec!["-nomarker"], "no marker, no indent");
+    }
+
+    #[test]
+    fn pipe_rows_are_dimmed() {
+        let lines = style_markdown("| a | b |");
+        assert_eq!(texts(&lines[0]), vec!["| a | b |"]);
+        assert!(lines[0].spans[0].style.add_modifier.contains(Modifier::DIM));
+    }
+
+    #[test]
+    fn emphasis_runs_become_styled_spans() {
+        let lines = style_markdown("plain **bold** and *italic* tail");
+        assert_eq!(
+            texts(&lines[0]),
+            vec!["plain ", "bold", " and ", "italic", " tail"]
+        );
+        assert!(lines[0].spans[1]
+            .style
+            .add_modifier
+            .contains(Modifier::BOLD));
+        assert!(lines[0].spans[3]
+            .style
+            .add_modifier
+            .contains(Modifier::ITALIC));
+    }
+
+    #[test]
+    fn unbalanced_markers_stay_literal() {
+        let lines = style_markdown("2 * 3 = 6 and **dangling");
+        assert_eq!(texts(&lines[0]), vec!["2 * 3 = 6 and **dangling"]);
+        assert!(
+            !lines[0].spans[0]
+                .style
+                .add_modifier
+                .contains(Modifier::BOLD),
+            "an unmatched marker is arithmetic, not emphasis"
+        );
+    }
+
+    #[test]
+    fn plain_prose_is_one_unstyled_span() {
+        let lines = style_markdown("just words");
+        assert_eq!(texts(&lines[0]), vec!["just words"]);
+        assert_eq!(lines[0].spans[0].style, Style::default());
+    }
+}

--- a/crates/pdfboss-tui/src/ui.rs
+++ b/crates/pdfboss-tui/src/ui.rs
@@ -9,6 +9,7 @@ use ratatui::Frame;
 use crate::app::{App, Pane};
 use crate::hexview::{hex_line, highlight_cols, BYTES_PER_LINE};
 use crate::inspector::InspectorMode;
+use crate::markdown::style_markdown;
 use crate::preview::{cell_colors, SPINNER};
 
 /// The four screen regions.
@@ -41,7 +42,9 @@ pub fn panes(area: Rect) -> Panes {
 pub fn draw(app: &App, frame: &mut Frame) {
     let split = panes(frame.area());
     draw_tree(app, frame, split.tree);
-    if app.preview.active {
+    if app.markdown.active {
+        draw_markdown(app, frame, split.right_top);
+    } else if app.preview.active {
         draw_preview(app, frame, split.right_top);
     } else {
         draw_inspector(app, frame, split.right_top);
@@ -206,6 +209,39 @@ fn draw_preview(app: &App, frame: &mut Frame, area: Rect) {
         lines.push(Line::raw("no preview yet"));
     }
     frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
+}
+
+/// The extracted Markdown as scrollable styled text. Repeated page headers
+/// and footers (page numbers among them) are not part of the extraction, so
+/// the pane shows the page's body only.
+fn draw_markdown(app: &App, frame: &mut Frame, area: Rect) {
+    let title = match app.markdown.page {
+        Some(page) => format!("Markdown \u{b7} page {} (body only)", page + 1),
+        None => "Markdown".to_string(),
+    };
+    let block = pane_block(title, app.focus == Pane::Inspector);
+    let lines: Vec<Line> = if app.markdown.loading {
+        vec![Line::raw(format!(
+            "{} extracting\u{2026}",
+            SPINNER[app.markdown.spinner_frame]
+        ))]
+    } else if let Some(error) = &app.markdown.error {
+        vec![Line::raw(format!("error: {error}"))]
+    } else {
+        match app.markdown.source.as_deref() {
+            Some(source) if !source.trim().is_empty() => style_markdown(source),
+            // An image-only page really does extract to nothing; say so
+            // rather than leaving the pane silently blank.
+            Some(..) => vec![Line::raw("no text on this page")],
+            None => vec![Line::raw("no markdown yet")],
+        }
+    };
+    frame.render_widget(
+        Paragraph::new(Text::from(lines))
+            .scroll((app.markdown.scroll, 0))
+            .block(block),
+        area,
+    );
 }
 
 fn draw_status(app: &App, frame: &mut Frame, area: Rect) {

--- a/crates/pdfboss-tui/tests/snapshots.rs
+++ b/crates/pdfboss-tui/tests/snapshots.rs
@@ -8,6 +8,7 @@ use pdfboss_tui::app::{App, Msg};
 use pdfboss_tui::tree::TreeReq;
 use pdfboss_tui::ui;
 use ratatui::backend::TestBackend;
+use ratatui::style::Modifier;
 use ratatui::Terminal;
 
 fn key(code: KeyCode) -> Msg {
@@ -98,7 +99,7 @@ fn document_overview_frame() {
             "│                          ││                                                  │",
             "│                          ││                                                  │",
             "└──────────────────────────┘└──────────────────────────────────────────────────┘",
-            "fixture.pdf · /Document · [/] search  [p] preview  [q] quit",
+            "fixture.pdf · /Document · [/] search  [p] preview  [m] markdown  [q] quit",
         ],
     );
 }
@@ -175,7 +176,85 @@ fn object_inspection_frame() {
             "│                          ││00000037 │ 3e 0a 65 6e 64 6f 62 6a │ >·endobj     │",
             "│                          ││0000003f │ 0a                      │ ·            │",
             "└──────────────────────────┘└──────────────────────────────────────────────────┘",
-            "fixture.pdf · /Document/Objects/obj 1 0 · [/] search  [p] preview  [q] quit",
+            // A deep breadcrumb pushes the hints past 80 columns; the status
+            // bar clips like every other pane.
+            "fixture.pdf · /Document/Objects/obj 1 0 · [/] search  [p] preview  [m] markdown",
         ],
+    );
+}
+
+/// Frame D: the markdown pane toggled on with `m` — headings, list items
+/// and a table row in place of the inspector, page-numbered title. The
+/// extraction result is injected, so this frame exercises the pane and its
+/// styling pass without running text extraction.
+#[test]
+fn markdown_pane_frame() {
+    let data = pdfboss_testkit::simple_doc("Hello");
+    let doc = Document::load(data).expect("fixture loads");
+    let elements: Vec<Element> = doc
+        .elements(ElementOpts {
+            physical: true,
+            logical: false,
+            pages: None,
+            content_ops: false,
+        })
+        .filter_map(Result::ok)
+        .collect();
+    let mut app = App::new(
+        "fixture.pdf".to_string(),
+        doc.version(),
+        doc.page_count(),
+        (80, 24),
+    );
+    app.update(Msg::TreeBatch {
+        req: TreeReq::Physical,
+        elements,
+        errors: 0,
+        done: true,
+    });
+    app.update(key(KeyCode::Char('m')));
+    app.update(Msg::MarkdownReady {
+        generation: app.markdown.generation,
+        result: Ok("# Title\n\nBody with **bold**\n\n- one\n- two\n\n| a | b |".to_string()),
+    });
+    let terminal = draw(&app);
+    assert_frame(
+        &terminal,
+        &[
+            "┌Tree──────────────────────┐┌Markdown · page 1 (body only)─────────────────────┐",
+            "│▾ Document · PDF 1.7      ││# Title                                           │",
+            "│  ▸ Pages (1)             ││                                                  │",
+            "│  ▸ Objects (5)           ││Body with bold                                    │",
+            "│  ▸ Xref (1 secs)         ││                                                  │",
+            "│    Trailer               ││  - one                                           │",
+            "│                          ││  - two                                           │",
+            "│                          ││                                                  │",
+            "│                          ││| a | b |                                         │",
+            "│                          ││                                                  │",
+            "│                          ││                                                  │",
+            "│                          ││                                                  │",
+            "│                          ││                                                  │",
+            "│                          │└──────────────────────────────────────────────────┘",
+            "│                          │┌Hex───────────────────────────────────────────────┐",
+            "│                          ││                                                  │",
+            "│                          ││                                                  │",
+            "│                          ││                                                  │",
+            "│                          ││                                                  │",
+            "│                          ││                                                  │",
+            "│                          ││                                                  │",
+            "│                          ││                                                  │",
+            "└──────────────────────────┘└──────────────────────────────────────────────────┘",
+            "fixture.pdf · /Document · [/] search  [p] preview  [m] markdown  [q] quit",
+        ],
+    );
+    // The symbols alone cannot show the styling pass ran: the heading is
+    // bold and the emphasis run inside the paragraph is too, while the
+    // prose around it is not.
+    let buffer = terminal.backend().buffer();
+    assert!(buffer[(29, 1)].modifier.contains(Modifier::BOLD), "heading");
+    assert!(!buffer[(29, 3)].modifier.contains(Modifier::BOLD), "prose");
+    assert!(
+        buffer[(39, 3)].modifier.contains(Modifier::BOLD),
+        "the **bold** run keeps its emphasis once the markers are consumed"
     );
 }


### PR DESCRIPTION
Adds a markdown preview pane to the TUI, the last surface from the output-abstraction scope. Pressing `m` renders the current page through `pdfboss_output::extract_page_markdown_with` in a right-top pane titled `Markdown · page N (body only)` — "body only" because the markdown adapter drops page headers, footers, and page numbers by design. The pane is mutually exclusive with the render preview, scrolls with the usual keys plus `g`/`G`, and guards against stale results with a generation counter so rapid page flips never paint an outdated page.

Extraction runs as a plain `tokio::spawn` on the current-thread runtime: measured per-page extraction is ≤0.02s and the file backend's `read_at` already yields via its own `spawn_blocking`, so the UI stays responsive without a dedicated blocking pool.

Implementation is TUI-only (~200 lines): new `src/markdown.rs` with `MarkdownState` and a pure `style_markdown` (9 unit tests), `Action::ToggleMarkdown` wiring through input/app/lib/ui, and a new `markdown_pane_frame` snapshot.

Verification on this exact HEAD (rebased onto v0.13.0): `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` 1579 passed (36 suites).
