### PR TITLE
feat(output): ruled-border table detection from content-stream drawing operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+.DEFAULT_GOAL := help
+
+##@ Development
+
+.PHONY: build
+build: ## Build the whole workspace
+	cargo build --workspace
+
+.PHONY: test
+test: ## Run the full workspace test suite
+	cargo test --workspace
+
+.PHONY: fmt
+fmt: ## Format all crates
+	cargo fmt --all
+
+.PHONY: lint
+lint: ## Clippy over all targets with warnings denied
+	cargo clippy --workspace --all-targets -- -D warnings
+
+##@ Python
+
+.PHONY: wheel
+wheel: ## Build the release wheel with maturin
+	maturin build --release
+
+.PHONY: develop
+develop: ## Install the Python package into the active venv
+	maturin develop
+
+##@ Install
+
+.PHONY: install
+install: ## Install the pdfboss CLI to ~/.cargo/bin
+	cargo install --path crates/pdfboss-cli --locked --force
+
+##@ Help
+
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)

--- a/crates/pdfboss-cli/src/input.rs
+++ b/crates/pdfboss-cli/src/input.rs
@@ -8,7 +8,7 @@ use futures_core::Stream as _;
 use pdfboss_aio::AsyncDocument;
 use pdfboss_core::elements::{Element, ElementOpts, Span};
 use pdfboss_core::{Document, Stream};
-use pdfboss_text::TextSpan;
+use pdfboss_text::{Ruling, TextSpan};
 
 /// Whether stdout should carry ANSI colors: only on a tty, and never when
 /// `NO_COLOR` is set (any value, per the NO_COLOR convention).
@@ -99,25 +99,30 @@ impl Input {
         }
     }
 
-    /// Extracts one page's text spans -- the input `pdfboss-output`'s
-    /// layout pass builds a `PageLayout` from.
-    pub fn page_spans(&self, index: usize) -> Result<Vec<TextSpan>, String> {
+    /// Extracts one page's text spans and rulings -- the input
+    /// `pdfboss-output`'s layout pass builds a `PageLayout` from, drawn
+    /// grids included.
+    pub fn page_spans_and_rulings(
+        &self,
+        index: usize,
+    ) -> Result<(Vec<TextSpan>, Vec<Ruling>), String> {
         match self {
             Input::Local { doc } => {
                 let page = doc.page(index).map_err(|e| e.to_string())?;
-                let (spans, _) =
-                    pdfboss_text::extract_spans_reporting(doc, &page).map_err(|e| e.to_string())?;
-                Ok(spans)
+                let (spans, rulings, _) =
+                    pdfboss_text::extract_spans_and_rulings_reporting(doc, &page)
+                        .map_err(|e| e.to_string())?;
+                Ok((spans, rulings))
             }
             Input::Remote { rt, doc } => {
                 let page = doc.page(index).map_err(|e| e.to_string())?;
-                let (spans, _) = rt
-                    .block_on(pdfboss_text::extract_spans_reporting_with(
+                let (spans, rulings, _) = rt
+                    .block_on(pdfboss_text::extract_spans_and_rulings_reporting_with(
                         doc.clone(),
                         &page,
                     ))
                     .map_err(|e| e.to_string())?;
-                Ok(spans)
+                Ok((spans, rulings))
             }
         }
     }

--- a/crates/pdfboss-cli/src/json.rs
+++ b/crates/pdfboss-cli/src/json.rs
@@ -54,17 +54,17 @@ fn layout_value(input: &Input, pages: &Option<Vec<usize>>) -> Result<Value, Stri
             numbers.dedup();
             let mut layouts = Vec::with_capacity(numbers.len());
             for n in numbers {
-                let spans = input.page_spans(n - 1)?;
-                layouts.push(pdfboss_output::page_layout(&spans));
+                let (spans, rulings) = input.page_spans_and_rulings(n - 1)?;
+                layouts.push(pdfboss_output::page_layout_with_rulings(&spans, &rulings));
             }
             layouts
         }
         None => {
-            let mut spans = Vec::with_capacity(count);
+            let mut pages = Vec::with_capacity(count);
             for index in 0..count {
-                spans.push(input.page_spans(index)?);
+                pages.push(input.page_spans_and_rulings(index)?);
             }
-            pdfboss_output::document_layout(&spans)
+            pdfboss_output::document_layout_with_rulings(&pages)
         }
     };
     serde_json::to_value(&layouts).map_err(|e| e.to_string())

--- a/crates/pdfboss-cli/src/main.rs
+++ b/crates/pdfboss-cli/src/main.rs
@@ -435,10 +435,12 @@ fn cmd_md(file: &Path, page: Option<usize>) -> Result<(), String> {
         Some(n) => {
             let index = page_index(n, doc.page_count())?;
             let page = doc.page(index).map_err(|e| e.to_string())?;
-            let (spans, report) =
-                pdfboss_text::extract_spans_reporting(&doc, &page).map_err(|e| e.to_string())?;
+            let (spans, rulings, report) =
+                pdfboss_text::extract_spans_and_rulings_reporting(&doc, &page)
+                    .map_err(|e| e.to_string())?;
             warn_skips(n, &report);
-            pdfboss_output::Markdown.render(&[pdfboss_output::page_layout(&spans)])
+            pdfboss_output::Markdown
+                .render(&[pdfboss_output::page_layout_with_rulings(&spans, &rulings)])
         }
         None => {
             let (md, reports) =

--- a/crates/pdfboss-output/src/lib.rs
+++ b/crates/pdfboss-output/src/lib.rs
@@ -134,9 +134,25 @@ mod tests {
         extract_text(doc, &page).unwrap()
     }
 
-    /// The Text adapter over the IR must reproduce the pre-IR string builder
-    /// exactly — the local form of the corpus parity gate.
+    /// Non-whitespace token runs, counted — the content-preservation
+    /// currency of the ruled oracle branch.
+    fn token_counts(text: &str) -> std::collections::BTreeMap<&str, usize> {
+        let mut counts = std::collections::BTreeMap::new();
+        for token in text.split_whitespace() {
+            *counts.entry(token).or_default() += 1;
+        }
+        counts
+    }
+
+    /// The Text adapter over a ruling-free layout must reproduce the pre-IR
+    /// string builder exactly — the local form of the corpus parity gate.
     /// [`structure::layout_reference`] is that builder, kept as the oracle.
+    ///
+    /// A ruling-fed layout genuinely reorders text — a merged logical row
+    /// reads cell-major where the flat flow reads line-major — so the ruled
+    /// branch asserts content preservation instead: the multiset of
+    /// non-whitespace token runs equals the flat flow's, counted exactly.
+    /// Loss, duplication, and fused tokens all break the count.
     #[test]
     fn text_adapter_matches_layout_on_fixtures() {
         let mut headings = 0usize;
@@ -171,11 +187,16 @@ mod tests {
                 ruled_tables += fixture_tables;
             }
             let via_ir = Text.render(&[layout]);
-            assert_eq!(
-                via_ir,
-                structure::layout_reference(&spans),
-                "content: {content}"
-            );
+            let flat = structure::layout_reference(&spans);
+            if rulings.is_empty() {
+                assert_eq!(via_ir, flat, "content: {content}");
+            } else {
+                assert_eq!(
+                    token_counts(&via_ir),
+                    token_counts(&flat),
+                    "content: {content}\nvia IR: {via_ir}\nflat flow: {flat}"
+                );
+            }
         }
         // A fixture set that classifies nothing would pass this test without
         // ever reaching the code it guards.
@@ -431,6 +452,59 @@ mod tests {
                 "| first item |\n| --- |\n| second item |\n| third item |\n| fourth item |"
             ),
             "md: {md}"
+        );
+    }
+
+    /// One ruled band holding three visual lines is one logical row: the
+    /// wrapped cell's fragments join with single spaces and the other cells
+    /// stay intact.
+    #[test]
+    fn a_wrapped_band_merges_into_one_logical_row() {
+        let md = markdown_of_drawn(&structure::tests::ruled_wrapped_band_content());
+        assert!(
+            md.contains("| h1 | h2 | h3 |\n| --- | --- | --- |\n| m1 | m2 | m3 |"),
+            "md: {md}"
+        );
+        assert!(
+            md.contains("| wrap one wrap two wrap three | solo | tail |"),
+            "the band's lines merge into one row: {md}"
+        );
+        assert!(
+            !md.contains("| wrap two |"),
+            "no fragmentary row survives: {md}"
+        );
+    }
+
+    /// A drawn grid no longer claims its whole segment: the whitespace-laned
+    /// rows below it still become a table of their own — exactly the table
+    /// the lane path alone emits — and blocks stay in reading order.
+    #[test]
+    fn a_ruled_grid_and_a_lane_grid_share_a_segment() {
+        let content = structure::tests::ruled_grid_above_lane_grid_content();
+        let md = markdown_of_drawn(&content);
+        assert!(
+            md.contains("| a1 | b1 |\n| --- | --- |\n| a2 | b2 |"),
+            "the drawn grid stays a table: {md}"
+        );
+        let lane_table = [
+            "| r0c0 | r0c1 | r0c2 |",
+            "| --- | --- | --- |",
+            "| r1c0 | r1c1 | r1c2 |",
+            "| r2c0 | r2c1 | r2c2 |",
+            "| r3c0 | r3c1 | r3c2 |",
+        ]
+        .join("\n");
+        assert!(
+            md.contains(&lane_table),
+            "the laned rows stay a table: {md}"
+        );
+        assert!(
+            md.find("| a1 |").unwrap() < md.find("| r0c0 |").unwrap(),
+            "reading order: {md}"
+        );
+        assert!(
+            markdown_of(&content).contains(&lane_table),
+            "the lane path alone emits the same table"
         );
     }
 

--- a/crates/pdfboss-output/src/lib.rs
+++ b/crates/pdfboss-output/src/lib.rs
@@ -11,8 +11,10 @@ use pdfboss_core::{block_on, AsyncObjectSource, Document, Immediate, Page, Resul
 pub use ir::{BBox, Block, Cell, Inline, Line, ListItem, Marker, PageLayout, Role};
 pub use markdown::Markdown;
 pub use output::{Output, Text};
-pub use pdfboss_text::{ExtractReport, SkipCause, SkippedText, SkippedTextKind, TextSpan};
-pub use structure::{document_layout, layout, page_layout};
+pub use pdfboss_text::{ExtractReport, Ruling, SkipCause, SkippedText, SkippedTextKind, TextSpan};
+pub use structure::{
+    document_layout, document_layout_with_rulings, layout, page_layout, page_layout_with_rulings,
+};
 
 /// Extracts the page's text with positional layout applied: spans grouped
 /// into lines, lines ordered top to bottom and joined with `\n`, spaces
@@ -78,16 +80,22 @@ pub fn extract_markdown(doc: &Document) -> Result<String> {
 }
 
 /// [`extract_markdown`] with one [`ExtractReport`] per page, in page order.
+///
+/// Each page's rulings ride along with its spans: a table whose structure is
+/// drawn as borders is read from them ahead of lane occupancy.
 pub fn extract_markdown_reporting(doc: &Document) -> Result<(String, Vec<ExtractReport>)> {
-    let per_page = pdfboss_core::map_pages(doc, pdfboss_text::extract_spans_reporting);
+    let per_page = pdfboss_core::map_pages(doc, pdfboss_text::extract_spans_and_rulings_reporting);
     let mut pages = Vec::with_capacity(per_page.len());
     let mut reports = Vec::with_capacity(per_page.len());
     for outcome in per_page {
-        let (spans, report) = outcome?;
-        pages.push(spans);
+        let (spans, rulings, report) = outcome?;
+        pages.push((spans, rulings));
         reports.push(report);
     }
-    Ok((Markdown.render(&document_layout(&pages)), reports))
+    Ok((
+        Markdown.render(&document_layout_with_rulings(&pages)),
+        reports,
+    ))
 }
 
 /// One page as Markdown, ranking heading sizes against that page alone.
@@ -101,15 +109,17 @@ pub fn extract_page_markdown(doc: &Document, page: &Page) -> Result<String> {
 /// [`extract_text_with`], for the same reasons.
 ///
 /// There is no document-level `_with`: an asynchronous caller collects each
-/// page's spans with `pdfboss_text::extract_spans_reporting_with` and then
-/// calls the pure [`document_layout`] and [`Markdown`], which is the same
-/// document-wide ranking without a second I/O path to keep in step.
+/// page's spans and rulings with
+/// `pdfboss_text::extract_spans_and_rulings_reporting_with` and then calls
+/// the pure [`document_layout_with_rulings`] and [`Markdown`], which is the
+/// same document-wide ranking without a second I/O path to keep in step.
 pub async fn extract_page_markdown_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
 ) -> Result<String> {
-    let (spans, _) = pdfboss_text::extract_spans_reporting_with(src, page).await?;
-    Ok(Markdown.render(&[page_layout(&spans)]))
+    let (spans, rulings, _) =
+        pdfboss_text::extract_spans_and_rulings_reporting_with(src, page).await?;
+    Ok(Markdown.render(&[page_layout_with_rulings(&spans, &rulings)]))
 }
 
 #[cfg(test)]
@@ -132,12 +142,14 @@ mod tests {
         let mut headings = 0usize;
         let mut splits = 0usize;
         let mut tables = 0usize;
+        let mut ruled_tables = 0usize;
         for content in structure::tests::fixture_contents() {
             let doc = Document::load(doc_with_graphics(&content)).unwrap();
             let page = doc.page(0).unwrap();
-            let (spans, report) = pdfboss_text::extract_spans_reporting(&doc, &page).unwrap();
+            let (spans, rulings, report) =
+                pdfboss_text::extract_spans_and_rulings_reporting(&doc, &page).unwrap();
             assert!(report.is_complete(), "unexpected skips: {report:?}");
-            let layout = page_layout(&spans);
+            let layout = page_layout_with_rulings(&spans, &rulings);
             headings += layout
                 .blocks
                 .iter()
@@ -149,11 +161,15 @@ mod tests {
                 .filter(|block| matches!(block, Block::Paragraph { .. }))
                 .count();
             splits += usize::from(paragraphs > 1);
-            tables += layout
+            let fixture_tables = layout
                 .blocks
                 .iter()
                 .filter(|block| matches!(block, Block::Table { .. }))
                 .count();
+            tables += fixture_tables;
+            if !rulings.is_empty() {
+                ruled_tables += fixture_tables;
+            }
             let via_ir = Text.render(&[layout]);
             assert_eq!(
                 via_ir,
@@ -166,6 +182,7 @@ mod tests {
         assert!(headings > 0, "no fixture produced a heading block");
         assert!(splits > 0, "no fixture split into several paragraphs");
         assert!(tables > 0, "no fixture produced a table block");
+        assert!(ruled_tables > 0, "no fixture produced a ruled table block");
     }
 
     /// Markdown of a one-page document with `content` as its raw content
@@ -384,6 +401,68 @@ mod tests {
         assert!(md.contains("<table>"), "md: {md}");
         assert!(md.contains("colspan=\"2\""), "md: {md}");
         assert!(!md.contains("| r1c0 |"), "one table, one dialect: {md}");
+    }
+
+    /// Markdown of a one-page document whose content stream draws rulings,
+    /// through the real document entry point, which threads them.
+    fn markdown_of_drawn(content: &str) -> String {
+        let doc = Document::load(doc_with_graphics(content)).unwrap();
+        extract_markdown(&doc).unwrap()
+    }
+
+    /// A drawn 2x2 grid leaves one lane, which the lane gates can never
+    /// admit; the rulings alone make it a table.
+    #[test]
+    fn a_ruled_grid_becomes_a_pipe_table() {
+        let md = markdown_of_drawn(&structure::tests::ruled_grid_content());
+        assert!(
+            md.contains("| a1 | b1 |\n| --- | --- |\n| a2 | b2 |"),
+            "md: {md}"
+        );
+    }
+
+    /// The corpus failure the ruled path fixes: a single-column boxed list
+    /// is a one-column table, which no lane-occupancy gate could ever admit.
+    #[test]
+    fn a_single_column_boxed_list_becomes_a_table() {
+        let md = markdown_of_drawn(&structure::tests::ruled_boxed_list_content());
+        assert!(
+            md.contains(
+                "| first item |\n| --- |\n| second item |\n| third item |\n| fourth item |"
+            ),
+            "md: {md}"
+        );
+    }
+
+    /// A grid boundary inside a sub-word gap would split a word the flat
+    /// flow writes whole: the grid is rejected and the segment stays prose.
+    #[test]
+    fn a_ruling_inside_a_sub_word_gap_rejects_the_grid() {
+        let md = markdown_of_drawn(&structure::tests::ruled_sub_word_gap_content());
+        assert!(!md.contains('|'), "no table: {md}");
+        assert!(!md.contains("<table>"), "no table: {md}");
+        assert!(md.contains("world"), "the word survives whole: {md}");
+    }
+
+    /// The spans-only entry points delegate with no rulings: a page whose
+    /// only table is drawn stays prose through them, exactly as before.
+    #[test]
+    fn spans_only_layout_ignores_drawn_grids() {
+        let doc = Document::load(doc_with_graphics(
+            &structure::tests::ruled_boxed_list_content(),
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let (spans, report) = pdfboss_text::extract_spans_reporting(&doc, &page).unwrap();
+        assert!(report.is_complete(), "unexpected skips: {report:?}");
+        let layout = page_layout(&spans);
+        assert!(
+            layout
+                .blocks
+                .iter()
+                .all(|block| !matches!(block, Block::Table { .. })),
+            "no rulings, no table: {layout:?}"
+        );
     }
 
     /// A lone page of huge text must not become all headings under per-page

--- a/crates/pdfboss-output/src/structure.rs
+++ b/crates/pdfboss-output/src/structure.rs
@@ -82,7 +82,10 @@ const TABLE_ROW_GAP: f32 = 2.0;
 
 /// How close two rulings must sit to read as one drawn line: collinear
 /// segments cluster within it, and a lattice crossing may miss by it.
-const RULING_SNAP_TOLERANCE: f32 = 2.0;
+/// Six points, because tables are often drawn one row box at a time with
+/// the side borders stopping five and a half points short of the next
+/// row's rule — the corners must still weld into one lattice.
+const RULING_SNAP_TOLERANCE: f32 = 6.0;
 /// The narrowest lattice that reads as a ruled grid: two verticals and three
 /// horizontals are one boxed column of two cells. Lane-occupancy gates do not
 /// apply here — the structure is drawn, not implied by white space.

--- a/crates/pdfboss-output/src/structure.rs
+++ b/crates/pdfboss-output/src/structure.rs
@@ -3,7 +3,7 @@
 
 use crate::ir::{BBox, Block, Cell, Inline, Line, ListItem, Marker, PageLayout, Role};
 use crate::output::{line_text, Output, Text};
-use pdfboss_text::TextSpan;
+use pdfboss_text::{Ruling, TextSpan};
 
 /// Fraction of the device font size a horizontal gap must exceed to read
 /// as a word break. The ceiling is justified LaTeX's shrunk inter-word
@@ -80,6 +80,19 @@ const TABLE_MIN_ROW_CELLS: usize = 2;
 /// space between blocks rather than the next row.
 const TABLE_ROW_GAP: f32 = 2.0;
 
+/// How close two rulings must sit to read as one drawn line: collinear
+/// segments cluster within it, and a lattice crossing may miss by it.
+const RULING_SNAP_TOLERANCE: f32 = 2.0;
+/// The narrowest lattice that reads as a ruled grid: two verticals and three
+/// horizontals are one boxed column of two cells. Lane-occupancy gates do not
+/// apply here — the structure is drawn, not implied by white space.
+const RULED_GRID_MIN_VERTICALS: usize = 2;
+const RULED_GRID_MIN_HORIZONTALS: usize = 3;
+/// Populated bands a fully boxed grid needs; an unboxed lattice needs
+/// [`TABLE_MIN_ROWS`], since stray separators reach three lines more easily
+/// than a drawn border box does.
+const RULED_BOXED_MIN_ROWS: usize = 2;
+
 /// Minimum pages before a repeated edge line reads as a running line rather than
 /// coincidence: two documents opening with the same word is unremarkable,
 /// three or more sharing a whole line is not.
@@ -102,17 +115,43 @@ pub fn layout(spans: &[TextSpan]) -> String {
 /// alone. Prefer [`document_layout`] whenever the whole document is at
 /// hand: a page of nothing but large type has no body size of its own.
 pub fn page_layout(spans: &[TextSpan]) -> PageLayout {
-    page_layout_with_stats(spans, &size_stats(&[spans]))
+    page_layout_with_rulings(spans, &[])
+}
+
+/// [`page_layout`] with the page's rulings: a lattice of drawn borders is
+/// read as a table ahead of lane occupancy. With no rulings the two are the
+/// same function.
+pub fn page_layout_with_rulings(spans: &[TextSpan], rulings: &[Ruling]) -> PageLayout {
+    page_layout_with_stats(spans, rulings, &size_stats(&[spans]))
 }
 
 /// Every page's spans as structure, ranking heading sizes against the whole
 /// document, so one oversized page cannot redefine what body text is.
 pub fn document_layout(pages: &[Vec<TextSpan>]) -> Vec<PageLayout> {
-    let borrowed: Vec<&[TextSpan]> = pages.iter().map(Vec::as_slice).collect();
+    let paired: Vec<(&[TextSpan], &[Ruling])> = pages
+        .iter()
+        .map(|spans| (spans.as_slice(), &[][..]))
+        .collect();
+    layouts_of(&paired)
+}
+
+/// [`document_layout`] with each page's rulings, so drawn grids become
+/// tables document-wide. With no rulings the two are the same function.
+pub fn document_layout_with_rulings(pages: &[(Vec<TextSpan>, Vec<Ruling>)]) -> Vec<PageLayout> {
+    let paired: Vec<(&[TextSpan], &[Ruling])> = pages
+        .iter()
+        .map(|(spans, rulings)| (spans.as_slice(), rulings.as_slice()))
+        .collect();
+    layouts_of(&paired)
+}
+
+/// Every page's layout over shared document-wide size statistics.
+fn layouts_of(pages: &[(&[TextSpan], &[Ruling])]) -> Vec<PageLayout> {
+    let borrowed: Vec<&[TextSpan]> = pages.iter().map(|(spans, _)| *spans).collect();
     let stats = size_stats(&borrowed);
     let mut layouts: Vec<PageLayout> = pages
         .iter()
-        .map(|spans| page_layout_with_stats(spans, &stats))
+        .map(|(spans, rulings)| page_layout_with_stats(spans, rulings, &stats))
         .collect();
     tag_page_roles(&mut layouts);
     layouts
@@ -307,10 +346,20 @@ fn split_edge(layout: &mut PageLayout, top: bool, role: Role) {
 /// headings and paragraph runs, in order. The classification is a partition
 /// — no line is reordered, merged away, or dropped — which is what keeps
 /// the [`Text`] adapter byte-equal to positional extraction.
-fn page_layout_with_stats(spans: &[TextSpan], stats: &SizeStats) -> PageLayout {
+fn page_layout_with_stats(spans: &[TextSpan], rulings: &[Ruling], stats: &SizeStats) -> PageLayout {
+    let grids = ruled_grids(rulings);
     let mut blocks = Vec::new();
     for segment in segments(spans) {
         if segment.is_empty() {
+            continue;
+        }
+        if let Some((band, bbox)) = ruled_band(&segment, &grids) {
+            push_blocks(&band.above, stats, &mut blocks);
+            blocks.push(Block::Table {
+                bbox,
+                rows: band.rows,
+            });
+            push_blocks(&band.below, stats, &mut blocks);
             continue;
         }
         if let Some(band) = table_band(&segment) {
@@ -699,6 +748,267 @@ struct TableBand {
     above: Vec<Assembled>,
     rows: Vec<Vec<Cell>>,
     below: Vec<Assembled>,
+}
+
+/// A lattice of drawn rulings: the x positions of its vertical lines and the
+/// y positions of its horizontal lines, ascending, joined by their crossings
+/// into one connected region. Built by [`ruled_grids`].
+struct RuledGrid {
+    xs: Vec<f32>,
+    ys: Vec<f32>,
+    /// Whether all four outer borders are drawn end to end.
+    boxed: bool,
+}
+
+impl RuledGrid {
+    /// The x ranges between consecutive vertical lines: the grid's cell
+    /// columns, in the shape [`table_row`] takes.
+    fn columns(&self) -> Vec<std::ops::Range<f32>> {
+        self.xs.windows(2).map(|pair| pair[0]..pair[1]).collect()
+    }
+
+    /// True when a baseline at `y` sits inside the grid: on or above the
+    /// bottom border, strictly below the top one — a baseline exactly on a
+    /// ruling has its glyphs in the band above it.
+    fn holds(&self, y: f32) -> bool {
+        self.ys[0] <= y && y < self.ys[self.ys.len() - 1]
+    }
+
+    /// The index of the band between consecutive horizontal rulings a
+    /// baseline at `y` falls in; callers check [`RuledGrid::holds`] first.
+    fn band_of(&self, y: f32) -> usize {
+        self.ys.partition_point(|ruling_y| *ruling_y <= y) - 1
+    }
+
+    /// The grid's drawn border box.
+    fn bbox(&self) -> BBox {
+        BBox {
+            x0: self.xs[0],
+            y0: self.ys[0],
+            x1: self.xs[self.xs.len() - 1],
+            y1: self.ys[self.ys.len() - 1],
+        }
+    }
+}
+
+/// Collinear rulings merged into one drawn line: the position on the
+/// constant axis and the extent covered along the other.
+struct GridLine {
+    position: f32,
+    extent: std::ops::Range<f32>,
+}
+
+/// The page's ruled grids: vertical and horizontal rulings clustered into
+/// drawn lines, lines joined where they cross, and every connected lattice
+/// of at least [`RULED_GRID_MIN_VERTICALS`] verticals and
+/// [`RULED_GRID_MIN_HORIZONTALS`] horizontals kept, topmost first. A ruling
+/// is vertical when it runs farther in y than in x; extraction already
+/// snapped it exactly axis-aligned.
+fn ruled_grids(rulings: &[Ruling]) -> Vec<RuledGrid> {
+    if rulings.is_empty() {
+        return Vec::new();
+    }
+    let vertical = |r: &&Ruling| r.end.y - r.start.y > r.end.x - r.start.x;
+    let verticals = grid_lines(
+        rulings
+            .iter()
+            .filter(vertical)
+            .map(|r| (r.start.x, r.start.y..r.end.y)),
+    );
+    let horizontals = grid_lines(
+        rulings
+            .iter()
+            .filter(|r| !vertical(r))
+            .map(|r| (r.start.y, r.start.x..r.end.x)),
+    );
+    let mut parent: Vec<usize> = (0..verticals.len() + horizontals.len()).collect();
+    for (v, vertical) in verticals.iter().enumerate() {
+        for (h, horizontal) in horizontals.iter().enumerate() {
+            if crosses(vertical, horizontal) {
+                union(&mut parent, v, verticals.len() + h);
+            }
+        }
+    }
+    let mut components: std::collections::BTreeMap<usize, (Vec<usize>, Vec<usize>)> =
+        std::collections::BTreeMap::new();
+    for v in 0..verticals.len() {
+        let root = find(&mut parent, v);
+        components.entry(root).or_default().0.push(v);
+    }
+    for h in 0..horizontals.len() {
+        let root = find(&mut parent, verticals.len() + h);
+        components.entry(root).or_default().1.push(h);
+    }
+    let mut grids: Vec<RuledGrid> = components
+        .values()
+        .filter_map(|(v_indices, h_indices)| {
+            let component_verticals: Vec<&GridLine> =
+                v_indices.iter().map(|&i| &verticals[i]).collect();
+            let component_horizontals: Vec<&GridLine> =
+                h_indices.iter().map(|&i| &horizontals[i]).collect();
+            lattice(&component_verticals, &component_horizontals)
+        })
+        .collect();
+    grids.sort_by(|a, b| b.ys[b.ys.len() - 1].total_cmp(&a.ys[a.ys.len() - 1]));
+    grids
+}
+
+/// Rulings on one axis as drawn lines: grouped by their constant coordinate
+/// within [`RULING_SNAP_TOLERANCE`], each group's near-touching extents
+/// merged. Extents farther apart stay separate lines at the same position —
+/// the x two stacked tables' borders share must not weld them into one
+/// lattice.
+fn grid_lines(rulings: impl Iterator<Item = (f32, std::ops::Range<f32>)>) -> Vec<GridLine> {
+    let mut all: Vec<(f32, std::ops::Range<f32>)> = rulings.collect();
+    all.sort_by(|a, b| a.0.total_cmp(&b.0));
+    let mut lines: Vec<GridLine> = Vec::new();
+    let mut cluster: Vec<(f32, std::ops::Range<f32>)> = Vec::new();
+    for line in all {
+        if let Some(last) = cluster.last() {
+            if line.0 - last.0 > RULING_SNAP_TOLERANCE {
+                lines.append(&mut merged_cluster(std::mem::take(&mut cluster)));
+            }
+        }
+        cluster.push(line);
+    }
+    lines.append(&mut merged_cluster(cluster));
+    lines
+}
+
+/// One position cluster's segments as [`GridLine`]s at the cluster's mean
+/// position: extents that overlap or come within [`RULING_SNAP_TOLERANCE`]
+/// merge, the rest stay separate lines.
+fn merged_cluster(mut cluster: Vec<(f32, std::ops::Range<f32>)>) -> Vec<GridLine> {
+    if cluster.is_empty() {
+        return Vec::new();
+    }
+    let position = cluster.iter().map(|(p, _)| *p).sum::<f32>() / cluster.len() as f32;
+    cluster.sort_by(|a, b| a.1.start.total_cmp(&b.1.start));
+    let mut lines: Vec<GridLine> = Vec::new();
+    for (_, extent) in cluster {
+        match lines.last_mut() {
+            Some(last) if extent.start <= last.extent.end + RULING_SNAP_TOLERANCE => {
+                last.extent.end = last.extent.end.max(extent.end);
+            }
+            _ => lines.push(GridLine { position, extent }),
+        }
+    }
+    lines
+}
+
+/// True when a vertical and a horizontal line cross within
+/// [`RULING_SNAP_TOLERANCE`]: an L corner, a T junction, or a + crossing.
+fn crosses(vertical: &GridLine, horizontal: &GridLine) -> bool {
+    vertical.position >= horizontal.extent.start - RULING_SNAP_TOLERANCE
+        && vertical.position <= horizontal.extent.end + RULING_SNAP_TOLERANCE
+        && horizontal.position >= vertical.extent.start - RULING_SNAP_TOLERANCE
+        && horizontal.position <= vertical.extent.end + RULING_SNAP_TOLERANCE
+}
+
+/// The set representative, with path halving.
+fn find(parent: &mut [usize], mut node: usize) -> usize {
+    while parent[node] != node {
+        parent[node] = parent[parent[node]];
+        node = parent[node];
+    }
+    node
+}
+
+/// Joins the two nodes' sets.
+fn union(parent: &mut [usize], a: usize, b: usize) {
+    let root_a = find(parent, a);
+    let root_b = find(parent, b);
+    parent[root_a] = root_b;
+}
+
+/// One connected component as a grid, or `None` when it is too sparse to be
+/// one: a lone separator, an underline, a pair of column rules with nothing
+/// across them.
+fn lattice(verticals: &[&GridLine], horizontals: &[&GridLine]) -> Option<RuledGrid> {
+    let xs = distinct_positions(verticals);
+    let ys = distinct_positions(horizontals);
+    if xs.len() < RULED_GRID_MIN_VERTICALS || ys.len() < RULED_GRID_MIN_HORIZONTALS {
+        return None;
+    }
+    let (x_lo, x_hi) = (xs[0], xs[xs.len() - 1]);
+    let (y_lo, y_hi) = (ys[0], ys[ys.len() - 1]);
+    let boxed = covers(verticals, x_lo, y_lo, y_hi)
+        && covers(verticals, x_hi, y_lo, y_hi)
+        && covers(horizontals, y_lo, x_lo, x_hi)
+        && covers(horizontals, y_hi, x_lo, x_hi);
+    Some(RuledGrid { xs, ys, boxed })
+}
+
+/// The lines' positions, ascending, neighbours within
+/// [`RULING_SNAP_TOLERANCE`] collapsed to the first.
+fn distinct_positions(lines: &[&GridLine]) -> Vec<f32> {
+    let mut positions: Vec<f32> = lines.iter().map(|line| line.position).collect();
+    positions.sort_by(f32::total_cmp);
+    positions.dedup_by(|next, kept| *next - *kept <= RULING_SNAP_TOLERANCE);
+    positions
+}
+
+/// True when the lines at `position` cover `lo..hi` end to end, gaps and
+/// shortfalls no wider than [`RULING_SNAP_TOLERANCE`]: whether a border is
+/// drawn along the whole of one edge.
+fn covers(lines: &[&GridLine], position: f32, lo: f32, hi: f32) -> bool {
+    let mut extents: Vec<&std::ops::Range<f32>> = lines
+        .iter()
+        .filter(|line| (line.position - position).abs() <= RULING_SNAP_TOLERANCE)
+        .map(|line| &line.extent)
+        .collect();
+    extents.sort_by(|a, b| a.start.total_cmp(&b.start));
+    let mut reached = lo;
+    for extent in extents {
+        if extent.start > reached + RULING_SNAP_TOLERANCE {
+            return false;
+        }
+        reached = reached.max(extent.end);
+    }
+    reached >= hi - RULING_SNAP_TOLERANCE
+}
+
+/// The segment's lines read against the page's drawn grids: the first grid,
+/// topmost first, that holds the segment's interior lines as rows, as a
+/// [`TableBand`] plus the grid's drawn border box. Lane-occupancy gates do
+/// not apply — a drawn single-column box is a table no lane could show — but
+/// every row still passes [`table_row`]'s word-gap cell gate, so a `None`
+/// falls through to the lane path with the flat flow intact.
+fn ruled_band(segment: &[&TextSpan], grids: &[RuledGrid]) -> Option<(TableBand, BBox)> {
+    if grids.is_empty() {
+        return None;
+    }
+    let groups = line_groups(segment);
+    grids.iter().find_map(|grid| grid_band(&groups, grid))
+}
+
+/// `groups` against one grid: the contiguous stretch of lines whose
+/// baselines fall inside the grid becomes its rows; the lines above and
+/// below stay prose. `None` when a line will not sit in the grid's columns,
+/// when a column boundary lands inside a sub-word gap — the row would split
+/// a word the flat flow wrote whole — or when the populated bands between
+/// horizontal rulings number under [`TABLE_MIN_ROWS`], or under
+/// [`RULED_BOXED_MIN_ROWS`] for a grid with all four borders drawn.
+fn grid_band(groups: &[Group], grid: &RuledGrid) -> Option<(TableBand, BBox)> {
+    let lo = groups.iter().position(|group| grid.holds(group.y))?;
+    let inside = groups[lo..]
+        .iter()
+        .take_while(|group| grid.holds(group.y))
+        .count();
+    let hi = lo + inside;
+    let columns = grid.columns();
+    let mut rows = Vec::with_capacity(inside);
+    let mut bands = std::collections::BTreeSet::new();
+    for group in &groups[lo..hi] {
+        rows.push(table_row(group, &columns)?);
+        bands.insert(grid.band_of(group.y));
+    }
+    if bands.len() < TABLE_MIN_ROWS && !(grid.boxed && bands.len() >= RULED_BOXED_MIN_ROWS) {
+        return None;
+    }
+    let above = groups[..lo].iter().map(assembled).collect();
+    let below = groups[hi..].iter().map(assembled).collect();
+    Some((TableBand { above, rows, below }, grid.bbox()))
 }
 
 /// The longest stretch of the segment's lines that reads as a grid, or `None`
@@ -1364,7 +1674,46 @@ pub(crate) mod tests {
         contents.push(lane_grid_content());
         contents.push(grid_with_edge_lines_content());
         contents.push(margin_number_grid_content());
+        contents.push(ruled_grid_content());
+        contents.push(ruled_boxed_list_content());
+        contents.push(ruled_sub_word_gap_content());
         contents
+    }
+
+    /// A drawn 2x2 grid — boxed border, one interior vertical, one interior
+    /// horizontal — with a word in each cell. Two cell columns leave a single
+    /// lane, so only the ruled path can read it as a table.
+    pub(crate) fn ruled_grid_content() -> String {
+        String::from(
+            "70 670 360 40 re S 250 670 m 250 710 l S 70 690 m 430 690 l S \
+             BT /F1 10 Tf 1 0 0 1 80 695 Tm (a1) Tj 1 0 0 1 260 695 Tm (b1) Tj \
+             1 0 0 1 80 675 Tm (a2) Tj 1 0 0 1 260 675 Tm (b2) Tj ET",
+        )
+    }
+
+    /// The corpus shape the ruled path exists for: a single-column boxed
+    /// list — two verticals, five horizontals, one item per band. No lane
+    /// structure at all: the lane path needs two lanes and this has none.
+    pub(crate) fn ruled_boxed_list_content() -> String {
+        String::from(
+            "70 630 360 80 re S 70 690 m 430 690 l S 70 670 m 430 670 l S 70 650 m 430 650 l S \
+             BT /F1 10 Tf 1 0 0 1 80 695 Tm (first item) Tj \
+             1 0 0 1 80 675 Tm (second item) Tj \
+             1 0 0 1 80 655 Tm (third item) Tj \
+             1 0 0 1 80 635 Tm (fourth item) Tj ET",
+        )
+    }
+
+    /// [`ruled_grid_content`]'s lattice with one row's word split across the
+    /// interior vertical at x=250 by a sub-word gap: "worl" ends at 249.4,
+    /// "d" starts at 250.5. Reading the rulings as columns would cut "world"
+    /// in two, so the grid must be rejected and the page must stay prose.
+    pub(crate) fn ruled_sub_word_gap_content() -> String {
+        String::from(
+            "70 670 360 40 re S 250 670 m 250 710 l S 70 690 m 430 690 l S \
+             BT /F1 10 Tf 1 0 0 1 80 695 Tm (a1) Tj 1 0 0 1 260 695 Tm (b1) Tj \
+             1 0 0 1 229.4 675 Tm (worl) Tj 1 0 0 1 250.5 675 Tm (d) Tj ET",
+        )
     }
 
     /// Four rows of three cells on three lanes: the shape that reads as a
@@ -1592,6 +1941,85 @@ pub(crate) mod tests {
         let lines: Vec<&str> = text.lines().collect();
         assert_eq!(lines.len(), 30);
         assert_eq!(lines[0], "Rowname0 12345 678 90");
+    }
+
+    /// An already-normalized ruling, the shape extraction emits.
+    fn ruling(x0: f32, y0: f32, x1: f32, y1: f32) -> Ruling {
+        Ruling {
+            start: pdfboss_text::Point { x: x0, y: y0 },
+            end: pdfboss_text::Point { x: x1, y: y1 },
+            width: 1.0,
+        }
+    }
+
+    /// The four borders of a box plus one interior horizontal through its
+    /// middle: the smallest lattice that qualifies as a grid.
+    fn boxed_grid_rulings(x0: f32, y0: f32, x1: f32, y1: f32) -> Vec<Ruling> {
+        let mid = (y0 + y1) / 2.0;
+        vec![
+            ruling(x0, y0, x0, y1),
+            ruling(x1, y0, x1, y1),
+            ruling(x0, y0, x1, y0),
+            ruling(x0, y1, x1, y1),
+            ruling(x0, mid, x1, mid),
+        ]
+    }
+
+    #[test]
+    fn a_boxed_lattice_clusters_into_one_grid() {
+        let grids = ruled_grids(&boxed_grid_rulings(70.0, 630.0, 430.0, 710.0));
+        assert_eq!(grids.len(), 1);
+        assert_eq!(grids[0].xs, vec![70.0, 430.0]);
+        assert_eq!(grids[0].ys, vec![630.0, 670.0, 710.0]);
+        assert!(grids[0].boxed);
+    }
+
+    /// Two boxes stacked on the page share their border x positions; the gap
+    /// between their extents must keep them two lattices, topmost first.
+    #[test]
+    fn stacked_boxes_sharing_their_x_stay_two_grids() {
+        let mut rulings = boxed_grid_rulings(70.0, 600.0, 430.0, 680.0);
+        rulings.extend(boxed_grid_rulings(70.0, 300.0, 430.0, 380.0));
+        let grids = ruled_grids(&rulings);
+        assert_eq!(grids.len(), 2);
+        assert_eq!(grids[0].ys, vec![600.0, 640.0, 680.0], "topmost first");
+        assert_eq!(grids[1].ys, vec![300.0, 340.0, 380.0]);
+    }
+
+    /// A plain box has only its two border horizontals — a frame, not a
+    /// grid — and a lone separator line is nothing at all.
+    #[test]
+    fn a_plain_box_is_not_a_grid() {
+        let rulings = vec![
+            ruling(70.0, 630.0, 70.0, 710.0),
+            ruling(430.0, 630.0, 430.0, 710.0),
+            ruling(70.0, 630.0, 430.0, 630.0),
+            ruling(70.0, 710.0, 430.0, 710.0),
+        ];
+        assert!(ruled_grids(&rulings).is_empty());
+        assert!(ruled_grids(&[ruling(70.0, 400.0, 430.0, 400.0)]).is_empty());
+    }
+
+    /// A ruling that crosses nothing in the lattice — an underline elsewhere
+    /// on the page — must not join it or open a phantom column.
+    #[test]
+    fn an_unconnected_ruling_stays_out_of_the_lattice() {
+        let mut rulings = boxed_grid_rulings(70.0, 600.0, 430.0, 680.0);
+        rulings.push(ruling(70.0, 100.0, 200.0, 100.0));
+        let grids = ruled_grids(&rulings);
+        assert_eq!(grids.len(), 1);
+        assert_eq!(grids[0].ys, vec![600.0, 640.0, 680.0]);
+    }
+
+    /// The spans-only layout ignores drawn borders — the flat flow of the
+    /// ruled fixtures is what the Text adapter must keep rendering.
+    #[test]
+    fn ruled_fixtures_keep_the_flat_flow() {
+        assert_eq!(
+            text_of(&ruled_boxed_list_content()),
+            "first item\nsecond item\nthird item\nfourth item"
+        );
+        assert_eq!(text_of(&ruled_sub_word_gap_content()), "a1 b1\nworld");
     }
 
     /// A table's narrow number column beside a wide text column is not a

--- a/crates/pdfboss-output/src/structure.rs
+++ b/crates/pdfboss-output/src/structure.rs
@@ -346,9 +346,11 @@ fn split_edge(layout: &mut PageLayout, top: bool, role: Role) {
 }
 
 /// The page's blocks: each reading-order segment's lines classified into
-/// headings and paragraph runs, in order. The classification is a partition
-/// — no line is reordered, merged away, or dropped — which is what keeps
-/// the [`Text`] adapter byte-equal to positional extraction.
+/// headings and paragraph runs, in order. On a ruling-free layout the
+/// classification is a partition — no line is reordered, merged away, or
+/// dropped — which is what keeps the [`Text`] adapter byte-equal to
+/// positional extraction. A drawn grid's bands merge into logical rows,
+/// which preserves every token but reads cell-major.
 fn page_layout_with_stats(spans: &[TextSpan], rulings: &[Ruling], stats: &SizeStats) -> PageLayout {
     let grids = ruled_grids(rulings);
     let mut blocks = Vec::new();
@@ -356,27 +358,69 @@ fn page_layout_with_stats(spans: &[TextSpan], rulings: &[Ruling], stats: &SizeSt
         if segment.is_empty() {
             continue;
         }
-        if let Some((band, bbox)) = ruled_band(&segment, &grids) {
-            push_blocks(&band.above, stats, &mut blocks);
-            blocks.push(Block::Table {
-                bbox,
-                rows: band.rows,
-            });
-            push_blocks(&band.below, stats, &mut blocks);
-            continue;
-        }
-        if let Some(band) = table_band(&segment) {
-            push_blocks(&band.above, stats, &mut blocks);
-            blocks.push(Block::Table {
-                bbox: table_bbox(&band.rows),
-                rows: band.rows,
-            });
-            push_blocks(&band.below, stats, &mut blocks);
-            continue;
-        }
-        push_blocks(&assemble_lines(&segment), stats, &mut blocks);
+        push_segment_blocks(&segment, &grids, stats, &mut blocks);
     }
     PageLayout { blocks }
+}
+
+/// One segment's blocks. A segment no grid claims — every segment, when the
+/// page has no rulings — takes the single lane attempt it always has.
+/// Otherwise the segment is walked top-down: each claimed stretch becomes a
+/// table and every uncovered remainder stretch gets that same lane attempt,
+/// so a drawn grid and a whitespace-laned table can share a segment.
+fn push_segment_blocks(
+    segment: &[&TextSpan],
+    grids: &[RuledGrid],
+    stats: &SizeStats,
+    out: &mut Vec<Block>,
+) {
+    if grids.is_empty() {
+        push_lane_blocks(segment, stats, out);
+        return;
+    }
+    let groups = line_groups(segment);
+    let claims = grid_claims(&groups, grids);
+    if claims.is_empty() {
+        push_lane_blocks(segment, stats, out);
+        return;
+    }
+    let mut next = 0usize;
+    for claim in claims {
+        push_stretch(&groups[next..claim.range.start], stats, out);
+        out.push(Block::Table {
+            bbox: claim.bbox,
+            rows: claim.rows,
+        });
+        next = claim.range.end;
+    }
+    push_stretch(&groups[next..], stats, out);
+}
+
+/// The lane path: one [`table_band`] attempt over the spans, else prose.
+fn push_lane_blocks(spans: &[&TextSpan], stats: &SizeStats, out: &mut Vec<Block>) {
+    let Some(band) = table_band(spans) else {
+        push_blocks(&assemble_lines(spans), stats, out);
+        return;
+    };
+    push_blocks(&band.above, stats, out);
+    out.push(Block::Table {
+        bbox: table_bbox(&band.rows),
+        rows: band.rows,
+    });
+    push_blocks(&band.below, stats, out);
+}
+
+/// A remainder stretch between grid claims, back as spans, through the same
+/// lane attempt a whole segment gets.
+fn push_stretch(groups: &[Group], stats: &SizeStats, out: &mut Vec<Block>) {
+    if groups.is_empty() {
+        return;
+    }
+    let spans: Vec<&TextSpan> = groups
+        .iter()
+        .flat_map(|group| group.spans.iter().copied())
+        .collect();
+    push_lane_blocks(&spans, stats, out);
 }
 
 /// Character-weighted histogram of span sizes rounded to half a point. Body
@@ -971,28 +1015,49 @@ fn covers(lines: &[&GridLine], position: f32, lo: f32, hi: f32) -> bool {
     reached >= hi - RULING_SNAP_TOLERANCE
 }
 
-/// The segment's lines read against the page's drawn grids: the first grid,
-/// topmost first, that holds the segment's interior lines as rows, as a
-/// [`TableBand`] plus the grid's drawn border box. Lane-occupancy gates do
-/// not apply — a drawn single-column box is a table no lane could show — but
-/// every row still passes [`table_row`]'s word-gap cell gate, so a `None`
-/// falls through to the lane path with the flat flow intact.
-fn ruled_band(segment: &[&TextSpan], grids: &[RuledGrid]) -> Option<(TableBand, BBox)> {
-    if grids.is_empty() {
-        return None;
+/// One drawn grid's claim on a segment: the contiguous stretch of line
+/// groups whose baselines fall inside the grid, the logical rows they merge
+/// into, and the grid's drawn border box.
+struct GridClaim {
+    range: std::ops::Range<usize>,
+    rows: Vec<Vec<Cell>>,
+    bbox: BBox,
+}
+
+/// Every grid's claim on the segment's lines, disjoint and top-down. Grids
+/// are tried topmost first, so of two lattices claiming the same lines the
+/// higher wins; a grid that fails its gates claims nothing and its lines
+/// stay available to the lane attempt. Lane-occupancy gates do not apply to
+/// a claim — a drawn single-column box is a table no lane could show — but
+/// every line still passes [`table_row`]'s word-gap cell gate.
+fn grid_claims(groups: &[Group], grids: &[RuledGrid]) -> Vec<GridClaim> {
+    let mut claims: Vec<GridClaim> = Vec::new();
+    for grid in grids {
+        let Some(claim) = grid_claim(groups, grid) else {
+            continue;
+        };
+        let taken = claims
+            .iter()
+            .any(|held| held.range.start < claim.range.end && claim.range.start < held.range.end);
+        if taken {
+            continue;
+        }
+        claims.push(claim);
     }
-    let groups = line_groups(segment);
-    grids.iter().find_map(|grid| grid_band(&groups, grid))
+    claims.sort_by_key(|claim| claim.range.start);
+    claims
 }
 
 /// `groups` against one grid: the contiguous stretch of lines whose
-/// baselines fall inside the grid becomes its rows; the lines above and
-/// below stay prose. `None` when a line will not sit in the grid's columns,
-/// when a column boundary lands inside a sub-word gap — the row would split
-/// a word the flat flow wrote whole — or when the populated bands between
-/// horizontal rulings number under [`TABLE_MIN_ROWS`], or under
-/// [`RULED_BOXED_MIN_ROWS`] for a grid with all four borders drawn.
-fn grid_band(groups: &[Group], grid: &RuledGrid) -> Option<(TableBand, BBox)> {
+/// baselines fall inside the grid becomes the claim, one logical row per
+/// populated band — the y-range between consecutive horizontal rulings.
+/// `None` when a line will not sit in the grid's columns, when a column
+/// boundary lands inside a sub-word gap — the row would split a word the
+/// flat flow wrote whole — or when the populated bands number under
+/// [`TABLE_MIN_ROWS`], or under [`RULED_BOXED_MIN_ROWS`] for a grid with
+/// all four borders drawn. Every line passes [`table_row`] before any
+/// band's lines merge.
+fn grid_claim(groups: &[Group], grid: &RuledGrid) -> Option<GridClaim> {
     let lo = groups.iter().position(|group| grid.holds(group.y))?;
     let inside = groups[lo..]
         .iter()
@@ -1000,18 +1065,116 @@ fn grid_band(groups: &[Group], grid: &RuledGrid) -> Option<(TableBand, BBox)> {
         .count();
     let hi = lo + inside;
     let columns = grid.columns();
-    let mut rows = Vec::with_capacity(inside);
-    let mut bands = std::collections::BTreeSet::new();
-    for group in &groups[lo..hi] {
-        rows.push(table_row(group, &columns)?);
-        bands.insert(grid.band_of(group.y));
+    let mut rows = Vec::new();
+    for band in groups[lo..hi].chunk_by(|a, b| grid.band_of(a.y) == grid.band_of(b.y)) {
+        let mut lines = Vec::with_capacity(band.len());
+        for group in band {
+            lines.push(table_row(group, &columns)?);
+        }
+        rows.push(logical_row(lines, columns.len()));
     }
-    if bands.len() < TABLE_MIN_ROWS && !(grid.boxed && bands.len() >= RULED_BOXED_MIN_ROWS) {
+    if rows.len() < TABLE_MIN_ROWS && !(grid.boxed && rows.len() >= RULED_BOXED_MIN_ROWS) {
         return None;
     }
-    let above = groups[..lo].iter().map(assembled).collect();
-    let below = groups[hi..].iter().map(assembled).collect();
-    Some((TableBand { above, rows, below }, grid.bbox()))
+    Some(GridClaim {
+        range: lo..hi,
+        rows,
+        bbox: grid.bbox(),
+    })
+}
+
+/// One band's visual lines as its logical row. Cells whose column intervals
+/// overlap across the band's lines are fragments of one drawn cell — ink
+/// crossing a vertical inside the band means the drawn cell is merged
+/// there — so their lines merge, in reading order, into one cell over the
+/// union of the columns. With no cell crossing a vertical that is plain
+/// per-column merging, and a band of one line rebuilds into the same cells.
+fn logical_row(lines: Vec<Vec<Cell>>, columns: usize) -> Vec<Cell> {
+    let mut fragments: Vec<(std::ops::Range<usize>, Line)> = Vec::new();
+    for cells in lines {
+        let mut column = 0usize;
+        for cell in cells {
+            let width = cell.colspan as usize;
+            if let Some(line) = cell.line {
+                fragments.push((column..column + width, line));
+            }
+            column += width;
+        }
+    }
+    let mut intervals: Vec<std::ops::Range<usize>> = fragments
+        .iter()
+        .map(|(interval, _)| interval.clone())
+        .collect();
+    intervals.sort_by_key(|interval| interval.start);
+    let mut merged: Vec<std::ops::Range<usize>> = Vec::new();
+    for interval in intervals {
+        match merged.last_mut() {
+            Some(last) if interval.start < last.end => last.end = last.end.max(interval.end),
+            _ => merged.push(interval),
+        }
+    }
+    let mut row = Vec::with_capacity(columns);
+    let mut next = 0usize;
+    for interval in merged {
+        for _ in next..interval.start {
+            row.push(empty_cell());
+        }
+        let cell_lines: Vec<&Line> = fragments
+            .iter()
+            .filter(|(held, _)| interval.start <= held.start && held.end <= interval.end)
+            .map(|(_, line)| line)
+            .collect();
+        row.push(Cell {
+            line: Some(merged_line(&cell_lines)),
+            colspan: (interval.end - interval.start) as u8,
+            rowspan: 1,
+        });
+        next = interval.end;
+    }
+    for _ in next..columns {
+        row.push(empty_cell());
+    }
+    row
+}
+
+/// One cell's fragment lines — reading order — as the single line ground
+/// truth wants for a wrapped cell: inlines concatenated with one plain
+/// space at each fragment boundary. The space lands at the end of the run
+/// before the boundary, the way [`push_span`] carries a word gap, and only
+/// then does a same-styled boundary extend that run — the space keeps the
+/// two fragments' tokens from fusing. Geometry is the fragments' union;
+/// `y` stays the first fragment's.
+fn merged_line(fragments: &[&Line]) -> Line {
+    let mut inlines: Vec<Inline> = Vec::new();
+    let mut x = f32::INFINITY;
+    let mut end_x = f32::NEG_INFINITY;
+    let mut size = 0.0f32;
+    for (index, fragment) in fragments.iter().enumerate() {
+        x = x.min(fragment.x);
+        end_x = end_x.max(fragment.end_x);
+        size = size.max(fragment.size);
+        for (position, inline) in fragment.inlines.iter().enumerate() {
+            let Some(last) = inlines.last_mut() else {
+                inlines.push(inline.clone());
+                continue;
+            };
+            if index > 0 && position == 0 {
+                last.text.push(' ');
+            }
+            if last.bold == inline.bold && last.italic == inline.italic {
+                last.text.push_str(&inline.text);
+                continue;
+            }
+            inlines.push(inline.clone());
+        }
+    }
+    Line {
+        inlines,
+        y: fragments.first().map_or(0.0, |line| line.y),
+        x,
+        end_x,
+        size,
+    }
 }
 
 /// The longest stretch of the segment's lines that reads as a grid, or `None`
@@ -1680,6 +1843,8 @@ pub(crate) mod tests {
         contents.push(ruled_grid_content());
         contents.push(ruled_boxed_list_content());
         contents.push(ruled_sub_word_gap_content());
+        contents.push(ruled_wrapped_band_content());
+        contents.push(ruled_grid_above_lane_grid_content());
         contents
     }
 
@@ -1717,6 +1882,38 @@ pub(crate) mod tests {
              BT /F1 10 Tf 1 0 0 1 80 695 Tm (a1) Tj 1 0 0 1 260 695 Tm (b1) Tj \
              1 0 0 1 229.4 675 Tm (worl) Tj 1 0 0 1 250.5 675 Tm (d) Tj ET",
         )
+    }
+
+    /// A boxed three-column grid whose bottom band wraps its first cell over
+    /// three visual lines — the shape that shattered into fragmentary rows
+    /// when every visual line was its own row. Ground truth wants one
+    /// logical row per band, the wrapped text joined inside the cell.
+    pub(crate) fn ruled_wrapped_band_content() -> String {
+        String::from(
+            "70 600 390 100 re S 200 600 m 200 700 l S 330 600 m 330 700 l S \
+             70 660 m 460 660 l S 70 680 m 460 680 l S \
+             BT /F1 10 Tf 1 0 0 1 80 685 Tm (h1) Tj 1 0 0 1 210 685 Tm (h2) Tj \
+             1 0 0 1 340 685 Tm (h3) Tj \
+             1 0 0 1 80 665 Tm (m1) Tj 1 0 0 1 210 665 Tm (m2) Tj \
+             1 0 0 1 340 665 Tm (m3) Tj \
+             1 0 0 1 80 645 Tm (wrap one) Tj 1 0 0 1 210 645 Tm (solo) Tj \
+             1 0 0 1 340 645 Tm (tail) Tj \
+             1 0 0 1 80 625 Tm (wrap two) Tj 1 0 0 1 80 605 Tm (wrap three) Tj ET",
+        )
+    }
+
+    /// The doc-81 shape: a small fully boxed grid above a whitespace-laned
+    /// grid in one segment. The drawn grid claims only its own stretch; the
+    /// laned rows below it must still become a table of their own.
+    pub(crate) fn ruled_grid_above_lane_grid_content() -> String {
+        let mut content = format!("{} BT /F1 10 Tf ", ruled_grid_content());
+        for (row, y) in [(0, 560.0), (1, 540.0), (2, 520.0), (3, 500.0)] {
+            for (col, x) in [(0, 72.0), (1, 250.0), (2, 430.0)] {
+                content += &format!("1 0 0 1 {x} {y} Tm (r{row}c{col}) Tj ");
+            }
+        }
+        content += "ET";
+        content
     }
 
     /// Four rows of three cells on three lanes: the shape that reads as a

--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -920,12 +920,14 @@ impl AsyncDocument {
             let mut pages = Vec::new();
             for i in 0..inner.page_count() {
                 let page = inner.page(i).map_err(aio_err)?;
-                let (spans, _) = pdfboss_text::extract_spans_reporting_with(inner.clone(), &page)
-                    .await
-                    .map_err(pdf_err)?;
-                pages.push(spans);
+                let (spans, rulings, _) =
+                    pdfboss_text::extract_spans_and_rulings_reporting_with(inner.clone(), &page)
+                        .await
+                        .map_err(pdf_err)?;
+                pages.push((spans, rulings));
             }
-            Ok(pdfboss_output::Markdown.render(&pdfboss_output::document_layout(&pages)))
+            Ok(pdfboss_output::Markdown
+                .render(&pdfboss_output::document_layout_with_rulings(&pages)))
         })
     }
 

--- a/crates/pdfboss-text/src/extract.rs
+++ b/crates/pdfboss-text/src/extract.rs
@@ -2,7 +2,7 @@
 //! Ts), glyph advances, and form XObject recursion.
 
 use crate::font::Font;
-use crate::TextSpan;
+use crate::{Ruling, TextSpan};
 use pdfboss_core::content::{parse_content, Op, TextItem};
 use pdfboss_core::{
     content_stream_data_with, page_content_with, AsyncObjectSource, Dict, Matrix, Object, Page,
@@ -18,6 +18,18 @@ const MAX_FORM_DEPTH: usize = 16;
 /// does not bound work: a chain of forms in which each level invokes the
 /// next N times fans out to N^depth executions from a tiny file.
 const MAX_FORM_INVOCATIONS: usize = 4096;
+
+/// Maximum device-space cross-axis deviation over a path segment for it to
+/// count as axis-aligned after the CTM.
+const RULING_AXIS_EPSILON: f32 = 0.5;
+
+/// Minimum device-space length of a ruling. Shorter marks (tick marks,
+/// dashes of glyph decoration) are not table structure.
+const RULING_MIN_LENGTH: f32 = 8.0;
+
+/// Maximum thin dimension of a filled rectangle that reads as a drawn line;
+/// anything fatter is a shaded box, not a ruling.
+const RULING_MAX_FILL_THICKNESS: f32 = 3.0;
 
 /// What extraction could not read. Extraction is lenient the way rendering
 /// is — content that will not fetch, decode, or parse yields no text rather
@@ -112,8 +124,9 @@ fn cause_for(error: &pdfboss_core::Error) -> SkipCause {
 }
 
 /// Runs the page's content stream (and any form XObjects) and collects
-/// every shown string as a [`TextSpan`], in emission order, along with the
-/// report of what could not be read.
+/// every shown string as a [`TextSpan`] and every axis-aligned drawn line
+/// as a [`Ruling`], each in emission order, along with the report of what
+/// could not be read.
 ///
 /// Lenient like rendering: a `/Contents` that will not fetch, decode, or
 /// parse contributes no spans and one report entry, never an error — the
@@ -123,10 +136,10 @@ fn cause_for(error: &pdfboss_core::Error) -> SkipCause {
 /// `page` is borrowed, which does not stand in the way, because a caller that
 /// owns its page creates the borrow inside its own `async move` block. See
 /// `pdfboss_core::source`'s "Signing a shared algorithm".
-pub async fn page_spans_with<S: AsyncObjectSource>(
+pub async fn page_spans_and_rulings_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
-) -> (Vec<TextSpan>, ExtractReport) {
+) -> (Vec<TextSpan>, Vec<Ruling>, ExtractReport) {
     let mut report = ExtractReport::default();
     let content = match page_content_with(&src, page).await {
         Ok(content) => content,
@@ -145,6 +158,7 @@ pub async fn page_spans_with<S: AsyncObjectSource>(
     let mut exec = Executor {
         src: &src,
         spans: Vec::new(),
+        rulings: Vec::new(),
         fallback: Arc::new(Font::fallback()),
         forms: 0,
         report,
@@ -156,7 +170,7 @@ pub async fn page_spans_with<S: AsyncObjectSource>(
         0,
     );
     exec.run(root).await;
-    (exec.spans, exec.report)
+    (exec.spans, exec.rulings, exec.report)
 }
 
 /// The graphics-state parameters text extraction cares about. Saved and
@@ -173,6 +187,8 @@ struct GState {
     font: Option<Arc<Font>>,
     font_name: String,
     size: f32,
+    /// `w` and ExtGState `/LW`; scales rulings' stroke width.
+    line_width: f32,
 }
 
 impl GState {
@@ -187,6 +203,7 @@ impl GState {
             font: None,
             font_name: String::new(),
             size: 0.0,
+            line_width: 1.0,
         }
     }
 }
@@ -194,6 +211,111 @@ impl GState {
 /// True when every matrix component is finite.
 fn finite(m: &Matrix) -> bool {
     [m.a, m.b, m.c, m.d, m.e, m.f].iter().all(|v| v.is_finite())
+}
+
+/// Isotropic scale factor of `m`: `sqrt(|det|)`, 1.0 when degenerate — the
+/// same rule rendering uses to carry a line width into device space.
+fn ctm_scale(m: &Matrix) -> f32 {
+    let det = (m.a * m.d - m.b * m.c).abs();
+    if det.is_finite() && det > 0.0 {
+        return det.sqrt();
+    }
+    1.0
+}
+
+/// Classifies one device-space segment: `Some` when it is axis-aligned
+/// within [`RULING_AXIS_EPSILON`] and at least [`RULING_MIN_LENGTH`] long.
+fn ruling_from_segment(a: Point, b: Point, width: f32) -> Option<Ruling> {
+    if [a.x, a.y, b.x, b.y, width].iter().any(|v| !v.is_finite()) {
+        return None;
+    }
+    let dx = (b.x - a.x).abs();
+    let dy = (b.y - a.y).abs();
+    if dy <= RULING_AXIS_EPSILON && dx >= RULING_MIN_LENGTH {
+        let y = (a.y + b.y) / 2.0;
+        return Some(Ruling {
+            start: Point::new(a.x.min(b.x), y),
+            end: Point::new(a.x.max(b.x), y),
+            width,
+        });
+    }
+    if dx <= RULING_AXIS_EPSILON && dy >= RULING_MIN_LENGTH {
+        let x = (a.x + b.x) / 2.0;
+        return Some(Ruling {
+            start: Point::new(x, a.y.min(b.y)),
+            end: Point::new(x, a.y.max(b.y)),
+            width,
+        });
+    }
+    None
+}
+
+/// The centerline of a thin filled rectangle: a closed 4-vertex subpath in
+/// device space whose edges are all axis-aligned, with a thin dimension at
+/// most [`RULING_MAX_FILL_THICKNESS`] and a long dimension at least
+/// [`RULING_MIN_LENGTH`]. Width is 0.0 — a fill has no stroke width.
+fn filled_rect_ruling(device: &[Point]) -> Option<Ruling> {
+    let corners = match device {
+        [a, b, c, d] => [*a, *b, *c, *d],
+        [a, b, c, d, e]
+            if (e.x - a.x).abs() <= RULING_AXIS_EPSILON
+                && (e.y - a.y).abs() <= RULING_AXIS_EPSILON =>
+        {
+            [*a, *b, *c, *d]
+        }
+        _ => return None,
+    };
+    if corners.iter().any(|p| !p.x.is_finite() || !p.y.is_finite()) {
+        return None;
+    }
+    let axis_aligned = |a: Point, b: Point| {
+        (b.x - a.x).abs() <= RULING_AXIS_EPSILON || (b.y - a.y).abs() <= RULING_AXIS_EPSILON
+    };
+    for i in 0..4 {
+        if !axis_aligned(corners[i], corners[(i + 1) % 4]) {
+            return None;
+        }
+    }
+    let x0 = corners.iter().map(|p| p.x).fold(f32::INFINITY, f32::min);
+    let x1 = corners
+        .iter()
+        .map(|p| p.x)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let y0 = corners.iter().map(|p| p.y).fold(f32::INFINITY, f32::min);
+    let y1 = corners
+        .iter()
+        .map(|p| p.y)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let w = x1 - x0;
+    let h = y1 - y0;
+    if w.min(h) > RULING_MAX_FILL_THICKNESS || w.max(h) < RULING_MIN_LENGTH {
+        return None;
+    }
+    if h <= w {
+        let y = (y0 + y1) / 2.0;
+        return Some(Ruling {
+            start: Point::new(x0, y),
+            end: Point::new(x1, y),
+            width: 0.0,
+        });
+    }
+    let x = (x0 + x1) / 2.0;
+    Some(Ruling {
+        start: Point::new(x, y0),
+        end: Point::new(x, y1),
+        width: 0.0,
+    })
+}
+
+/// One subpath under construction, in the frame's untransformed user space.
+///
+/// A curve operator poisons it — glyph outlines and diagrams are not
+/// rulings — but still advances the endpoint, so a following `l` extends
+/// the poisoned subpath instead of corrupting the next one.
+struct Subpath {
+    points: Vec<Point>,
+    closed: bool,
+    poisoned: bool,
 }
 
 /// One suspended operator stream: what to execute, how far it has got, and
@@ -223,6 +345,10 @@ struct Frame {
     saved: Vec<GState>,
     tm: Matrix,
     tlm: Matrix,
+    /// Path accumulation for rulings, per operator stream like `tm`/`tlm`:
+    /// the last element is the active subpath. Not part of [`GState`] —
+    /// `q`/`Q` do not save or restore the path.
+    subpaths: Vec<Subpath>,
     /// Loaded fonts, per operator stream: every form invocation starts with an
     /// empty cache, as it did when each invocation was its own `run` call.
     fonts: HashMap<String, Arc<Font>>,
@@ -239,14 +365,71 @@ impl Frame {
             saved: Vec::new(),
             tm: Matrix::identity(),
             tlm: Matrix::identity(),
+            subpaths: Vec::new(),
             fonts: HashMap::new(),
         }
+    }
+
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.subpaths.push(Subpath {
+            points: vec![Point::new(x, y)],
+            closed: false,
+            poisoned: false,
+        });
+    }
+
+    /// Extends the active subpath by one segment. Appending to a closed
+    /// subpath begins a new one at the closed subpath's starting point
+    /// (ISO 32000-1 §8.5.2.1); with no current point at all the operator
+    /// is ignored.
+    fn segment_to(&mut self, x: f32, y: f32, poisons: bool) {
+        let Some(active) = self.subpaths.last_mut() else {
+            return;
+        };
+        if active.closed {
+            let start = active.points[0];
+            self.subpaths.push(Subpath {
+                points: vec![start, Point::new(x, y)],
+                closed: false,
+                poisoned: poisons,
+            });
+            return;
+        }
+        active.points.push(Point::new(x, y));
+        if poisons {
+            active.poisoned = true;
+        }
+    }
+
+    fn close_subpath(&mut self) {
+        if let Some(active) = self.subpaths.last_mut() {
+            active.closed = true;
+        }
+    }
+
+    /// Appends `re` as the closed subpath rendering's path builder makes of
+    /// it: the `(x, y)` corner, then the three others in `re`'s own order.
+    /// Raw corners even for negative `w`/`h` — the current point a
+    /// follow-on segment continues from is `(x, y)` — normalization happens
+    /// when the committed rectangle's bounding box is measured.
+    fn rect_subpath(&mut self, x: f32, y: f32, w: f32, h: f32) {
+        self.subpaths.push(Subpath {
+            points: vec![
+                Point::new(x, y),
+                Point::new(x + w, y),
+                Point::new(x + w, y + h),
+                Point::new(x, y + h),
+            ],
+            closed: true,
+            poisoned: false,
+        });
     }
 }
 
 struct Executor<'a, S> {
     src: &'a S,
     spans: Vec<TextSpan>,
+    rulings: Vec<Ruling>,
     fallback: Arc<Font>,
     /// Form-XObject invocations so far, checked against
     /// `MAX_FORM_INVOCATIONS`.
@@ -331,6 +514,11 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                         frame.gs.font_name = name.0.clone();
                         frame.gs.size = *size;
                     }
+                    Op::SetExtGState(name) => {
+                        if let Some(lw) = self.ext_gstate_line_width(&frame.chain, &name.0).await {
+                            frame.gs.line_width = lw;
+                        }
+                    }
                     Op::XObject(name) => {
                         let entered = self
                             .form_frame(&name.0, &frame.chain, &frame.gs, frame.depth)
@@ -351,9 +539,22 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         }
     }
 
-    /// Applies one operator that needs no I/O — everything except `Tf` and `Do`.
-    /// `q`/`Q` and `cm` maintain the CTM; text operators maintain Tm/Tlm; shown
-    /// strings become spans.
+    /// The `/LW` entry of the named `/ExtGState` resource (ISO 32000-1
+    /// Table 58) — the one ExtGState parameter ruling extraction reads.
+    /// Negative values are ignored, matching the renderer; non-finite ones
+    /// too, because an infinite line width would otherwise silently drop
+    /// every later stroked ruling at the segment gate.
+    async fn ext_gstate_line_width(&self, chain: &[Arc<Dict>], name: &str) -> Option<f32> {
+        let resolved = self.find_res(chain, "ExtGState", name).await?;
+        let dict = resolved.as_dict()?;
+        let lw = self.src.resolve(dict.get("LW")?).await.ok()?.as_f64()? as f32;
+        (lw.is_finite() && lw >= 0.0).then_some(lw)
+    }
+
+    /// Applies one operator that needs no I/O — everything except `Tf`,
+    /// `gs`, and `Do`. `q`/`Q` and `cm` maintain the CTM; text operators
+    /// maintain Tm/Tlm; shown strings become spans; path operators feed the
+    /// frame's subpaths and paint operators commit them as rulings.
     fn step(&mut self, frame: &mut Frame, op: &Op) {
         match op {
             Op::Save => frame.saved.push(frame.gs.clone()),
@@ -415,9 +616,66 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                 frame.tm = frame.tlm;
                 self.emit(frame, s);
             }
+            Op::SetLineWidth(w) => {
+                if w.is_finite() && *w >= 0.0 {
+                    frame.gs.line_width = *w;
+                }
+            }
+            Op::MoveTo(x, y) => frame.move_to(*x, *y),
+            Op::LineTo(x, y) => frame.segment_to(*x, *y, false),
+            Op::CurveTo(_, _, _, _, x, y) | Op::CurveToV(_, _, x, y) | Op::CurveToY(_, _, x, y) => {
+                frame.segment_to(*x, *y, true)
+            }
+            Op::ClosePath => frame.close_subpath(),
+            Op::Rect(x, y, w, h) => frame.rect_subpath(*x, *y, *w, *h),
+            Op::Stroke => self.commit_rulings(frame, true, false),
+            Op::CloseStroke => {
+                frame.close_subpath();
+                self.commit_rulings(frame, true, false);
+            }
+            Op::Fill | Op::FillEvenOdd => self.commit_rulings(frame, false, true),
+            Op::FillStroke | Op::FillStrokeEvenOdd => self.commit_rulings(frame, true, true),
+            Op::CloseFillStroke | Op::CloseFillStrokeEvenOdd => {
+                frame.close_subpath();
+                self.commit_rulings(frame, true, true);
+            }
+            // `W`/`W*` never commit by themselves: the paint operator that
+            // must follow them does, and after a clip that operator is `n`.
+            Op::EndPath => frame.subpaths.clear(),
             // Text render mode 3 (invisible) is still extracted, so `Tr` and
             // everything else is a no-op here.
             _ => {}
+        }
+    }
+
+    /// Commits the accumulated path on a painting operator and clears it.
+    /// Stroked subpaths yield one ruling per axis-aligned segment at the
+    /// device-space line width; filled subpaths yield the centerline of a
+    /// thin axis-aligned rectangle. Poisoned subpaths yield nothing.
+    fn commit_rulings(&mut self, frame: &mut Frame, stroke: bool, fill: bool) {
+        let ctm = frame.gs.ctm;
+        let width = frame.gs.line_width * ctm_scale(&ctm);
+        for sub in frame.subpaths.drain(..) {
+            if sub.poisoned {
+                continue;
+            }
+            let device: Vec<Point> = sub.points.iter().map(|p| ctm.apply(*p)).collect();
+            if stroke {
+                let segments = device.windows(2).map(|pair| (pair[0], pair[1]));
+                // A closed 2-point subpath draws one doubled edge, not two.
+                let closing =
+                    (sub.closed && device.len() > 2).then(|| (device[device.len() - 1], device[0]));
+                for (a, b) in segments.chain(closing) {
+                    if let Some(ruling) = ruling_from_segment(a, b, width) {
+                        self.rulings.push(ruling);
+                    }
+                }
+            }
+            if fill {
+                if let Some(ruling) = filled_rect_ruling(&device) {
+                    self.rulings.push(ruling);
+                }
+            }
         }
     }
 
@@ -595,14 +853,21 @@ mod tests {
     use pdfboss_testkit::doc_with_graphics;
 
     /// The synchronous spans accessor. Production has no use for one — the public
-    /// entry points in `lib.rs` wrap [`page_spans_with`] themselves — but it is
-    /// the same `block_on` over `Immediate`, so every test below still asserts on
-    /// exactly what a synchronous caller receives. The report is asserted
-    /// complete: no test here expects to lose content.
+    /// entry points in `lib.rs` wrap [`page_spans_and_rulings_with`] themselves —
+    /// but it is the same `block_on` over `Immediate`, so every test below still
+    /// asserts on exactly what a synchronous caller receives. The report is
+    /// asserted complete: no test here expects to lose content.
     fn page_spans(doc: &Document, page: &Page) -> Vec<TextSpan> {
-        let (spans, report) = block_on(page_spans_with(Immediate(doc), page));
+        let (spans, _, report) = block_on(page_spans_and_rulings_with(Immediate(doc), page));
         assert!(report.is_complete(), "unexpected skips: {report:?}");
         spans
+    }
+
+    /// The synchronous rulings accessor, the twin of [`page_spans`].
+    fn page_rulings(doc: &Document, page: &Page) -> Vec<Ruling> {
+        let (_, rulings, report) = block_on(page_spans_and_rulings_with(Immediate(doc), page));
+        assert!(report.is_complete(), "unexpected skips: {report:?}");
+        rulings
     }
 
     /// Raw spans of a one-page document with `content` as its raw content
@@ -611,6 +876,23 @@ mod tests {
         let doc = Document::load(doc_with_graphics(content)).unwrap();
         let page = doc.page(0).unwrap();
         page_spans(&doc, &page)
+    }
+
+    /// Raw rulings of a one-page document with `content` as its raw content
+    /// stream.
+    fn rulings_of(content: &str) -> Vec<Ruling> {
+        let doc = Document::load(doc_with_graphics(content)).unwrap();
+        let page = doc.page(0).unwrap();
+        page_rulings(&doc, &page)
+    }
+
+    #[track_caller]
+    fn assert_ruling(r: &Ruling, x0: f32, y0: f32, x1: f32, y1: f32) {
+        let close = (r.start.x - x0).abs() < 1e-3
+            && (r.start.y - y0).abs() < 1e-3
+            && (r.end.x - x1).abs() < 1e-3
+            && (r.end.y - y1).abs() < 1e-3;
+        assert!(close, "{r:?} is not ({x0},{y0})-({x1},{y1})");
     }
 
     #[test]
@@ -712,7 +994,7 @@ mod tests {
         let page = doc.page(0).unwrap();
         // Raw call: exhausting the budget is this test's point, so the
         // report is legitimately incomplete here.
-        let (spans, report) = block_on(page_spans_with(Immediate(&doc), &page));
+        let (spans, _, report) = block_on(page_spans_and_rulings_with(Immediate(&doc), &page));
         assert!(!spans.is_empty()); // nested forms still extract text
         assert!(
             spans.len() <= MAX_FORM_INVOCATIONS,
@@ -798,5 +1080,133 @@ mod tests {
         assert_send_sync::<Font>();
         assert_send_sync::<Arc<Font>>();
         assert_send_sync::<GState>();
+    }
+
+    /// A stroked 2x2 grid: the `re` contributes its four border edges in
+    /// construction order (bottom, right, top, left — the order rendering's
+    /// path builder decomposes `re` into), then the two inner dividers in
+    /// stream order, all at the default 1.0 line width.
+    #[test]
+    fn stroked_grid_yields_rulings_with_correct_endpoints() {
+        let rulings = rulings_of("72 600 200 100 re S 172 600 m 172 700 l S 72 650 m 272 650 l S");
+        assert_eq!(rulings.len(), 6, "{rulings:?}");
+        assert_ruling(&rulings[0], 72.0, 600.0, 272.0, 600.0);
+        assert_ruling(&rulings[1], 272.0, 600.0, 272.0, 700.0);
+        assert_ruling(&rulings[2], 72.0, 700.0, 272.0, 700.0);
+        assert_ruling(&rulings[3], 72.0, 600.0, 72.0, 700.0);
+        assert_ruling(&rulings[4], 172.0, 600.0, 172.0, 700.0);
+        assert_ruling(&rulings[5], 72.0, 650.0, 272.0, 650.0);
+        assert!(rulings.iter().all(|r| (r.width - 1.0).abs() < 1e-3));
+    }
+
+    #[test]
+    fn w_sets_the_stroke_width() {
+        let rulings = rulings_of("0.5 w 72 700 m 272 700 l S");
+        assert_eq!(rulings.len(), 1);
+        assert!((rulings[0].width - 0.5).abs() < 1e-3);
+    }
+
+    /// A negative or non-finite `w` operand leaves the line width alone, the
+    /// way the renderer treats it. The 39-digit literal lexes as a real and
+    /// overflows `f32` to infinity; unguarded, that width would fail the
+    /// segment gate and silently drop the stroke.
+    #[test]
+    fn negative_or_nonfinite_w_is_ignored() {
+        let rulings = rulings_of("-5 w 72 700 m 272 700 l S");
+        assert_eq!(rulings.len(), 1, "{rulings:?}");
+        assert!((rulings[0].width - 1.0).abs() < 1e-3);
+        let rulings = rulings_of("400000000000000000000000000000000000000 w 72 700 m 272 700 l S");
+        assert_eq!(rulings.len(), 1, "{rulings:?}");
+        assert!((rulings[0].width - 1.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn ext_gstate_lw_sets_the_stroke_width() {
+        use pdfboss_testkit::PdfBuilder;
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /ExtGState << /G1 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"/G1 gs 72 700 m 272 700 l S");
+        b.object(5, "<< /Type /ExtGState /LW 2.5 >>");
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let rulings = page_rulings(&doc, &page);
+        assert_eq!(rulings.len(), 1);
+        assert!((rulings[0].width - 2.5).abs() < 1e-3);
+    }
+
+    #[test]
+    fn thin_filled_rect_yields_its_centerline() {
+        let rulings = rulings_of("72 700 200 0.8 re f");
+        assert_eq!(rulings.len(), 1, "{rulings:?}");
+        assert_ruling(&rulings[0], 72.0, 700.4, 272.0, 700.4);
+        assert_eq!(rulings[0].width, 0.0, "a fill has no stroke width");
+    }
+
+    #[test]
+    fn fat_filled_rect_yields_no_rulings() {
+        assert!(rulings_of("72 600 200 40 re f").is_empty());
+    }
+
+    /// Axis alignment is judged after the CTM: a 90° rotation turns a
+    /// horizontal segment into a vertical ruling, while a 30° rotation
+    /// leaves it diagonal and drops it.
+    #[test]
+    fn cm_rotation_keeps_axis_aligned_segments_only() {
+        let rotated90 = rulings_of("q 0 1 -1 0 300 100 cm 0 0 m 100 0 l S Q");
+        assert_eq!(rotated90.len(), 1, "{rotated90:?}");
+        assert_ruling(&rotated90[0], 300.0, 100.0, 300.0, 200.0);
+        let rotated30 = rulings_of("q 0.866 0.5 -0.5 0.866 0 0 cm 72 700 m 172 700 l S Q");
+        assert!(rotated30.is_empty(), "{rotated30:?}");
+    }
+
+    /// The curve poisons its own subpath — including the straight `l` that
+    /// continues it — but not the sibling subpath committed by the same `S`.
+    #[test]
+    fn curves_poison_only_their_own_subpath() {
+        let rulings =
+            rulings_of("72 500 m 100 550 150 550 172 500 c 200 500 l 72 700 m 272 700 l S");
+        assert_eq!(rulings.len(), 1, "{rulings:?}");
+        assert_ruling(&rulings[0], 72.0, 700.0, 272.0, 700.0);
+    }
+
+    /// `n` discards the path whether it stands alone or finishes a `W`
+    /// clip: clipping never commits rulings.
+    #[test]
+    fn end_path_discards_the_accumulated_path() {
+        assert!(rulings_of("72 700 m 272 700 l n").is_empty());
+        assert!(rulings_of("72 600 200 100 re W n").is_empty());
+    }
+
+    /// A form's `/Matrix` concatenates into the CTM its content runs under,
+    /// so its rulings land in page space like its spans do.
+    #[test]
+    fn form_matrix_lands_rulings_in_page_space() {
+        use pdfboss_testkit::PdfBuilder;
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /XObject << /Fx 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"/Fx Do");
+        b.stream(
+            5,
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] \
+             /Matrix [1 0 0 1 0 -20]",
+            b"72 720 m 272 720 l S",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let rulings = page_rulings(&doc, &page);
+        assert_eq!(rulings.len(), 1, "{rulings:?}");
+        assert_ruling(&rulings[0], 72.0, 700.0, 272.0, 700.0);
     }
 }

--- a/crates/pdfboss-text/src/lib.rs
+++ b/crates/pdfboss-text/src/lib.rs
@@ -9,6 +9,7 @@ mod sfnt;
 use pdfboss_core::{block_on, AsyncObjectSource, Document, Immediate, Page, Result};
 
 pub use extract::{ExtractReport, SkipCause, SkippedText, SkippedTextKind};
+pub use pdfboss_core::Point;
 
 /// A positioned run of extracted text.
 #[derive(Debug, Clone, PartialEq)]
@@ -33,6 +34,22 @@ pub struct TextSpan {
     /// `/Flags` Italic or a nonzero `/ItalicAngle`, else an `Italic` or
     /// `Oblique` substring in `/BaseFont` (ISO 32000-1 Table 123).
     pub italic: bool,
+}
+
+/// An axis-aligned line segment a page draws, in the same y-up user space as
+/// `TextSpan`: a table border, a separator, an underline.
+///
+/// Endpoints are normalized (`start.x <= end.x`, `start.y <= end.y`) and
+/// exactly axis-aligned: the near-constant coordinate is snapped to its
+/// midpoint over the segment.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ruling {
+    pub start: Point,
+    pub end: Point,
+    /// Stroke width in device space. Zero does not say how the ruling was
+    /// drawn: a hairline stroke (`0 w`) and a thin filled rectangle's
+    /// centerline both carry 0.0.
+    pub width: f32,
 }
 
 /// Extracts the page's raw text spans (position, size and font per span).
@@ -61,7 +78,7 @@ pub async fn extract_spans_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
 ) -> Result<Vec<TextSpan>> {
-    let (spans, _) = extract::page_spans_with(src, page).await;
+    let (spans, _, _) = extract::page_spans_and_rulings_with(src, page).await;
     Ok(spans)
 }
 
@@ -83,8 +100,32 @@ pub async fn extract_spans_reporting_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
 ) -> Result<(Vec<TextSpan>, ExtractReport)> {
-    let (spans, report) = extract::page_spans_with(src, page).await;
+    let (spans, _, report) = extract::page_spans_and_rulings_with(src, page).await;
     Ok((spans, report))
+}
+
+/// [`extract_spans_reporting`] plus the page's rulings: every axis-aligned
+/// segment the content strokes, and the centerline of every thin filled
+/// rectangle, in the same y-up user space as the spans. See [`Ruling`] for
+/// the normalization the returned segments carry.
+pub fn extract_spans_and_rulings_reporting(
+    doc: &Document,
+    page: &Page,
+) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
+    block_on(extract_spans_and_rulings_reporting_with(
+        Immediate(doc),
+        page,
+    ))
+}
+
+/// [`extract_spans_and_rulings_reporting`] against any object source. Signed
+/// like [`extract_spans_with`], for the same reasons.
+pub async fn extract_spans_and_rulings_reporting_with<S: AsyncObjectSource>(
+    src: S,
+    page: &Page,
+) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
+    let (spans, rulings, report) = extract::page_spans_and_rulings_with(src, page).await;
+    Ok((spans, rulings, report))
 }
 
 #[cfg(test)]
@@ -141,6 +182,23 @@ mod tests {
         assert!((s.y - 720.0).abs() < 1e-3);
         assert!((s.size - 12.0).abs() < 1e-3);
         assert_eq!(s.font, "F1");
+    }
+
+    /// The combined entry point carries the spans, the drawn rulings, and
+    /// the completeness report through in one call.
+    #[test]
+    fn extract_spans_and_rulings_reports_both() {
+        let doc = Document::load(pdfboss_testkit::doc_with_graphics(
+            "BT /F1 12 Tf 72 720 Td (Hi) Tj ET 72 700 m 272 700 l S",
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let (spans, rulings, report) = extract_spans_and_rulings_reporting(&doc, &page).unwrap();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "Hi");
+        assert_eq!(rulings.len(), 1);
+        assert!((rulings[0].start.y - 700.0).abs() < 1e-3);
+        assert!(report.is_complete());
     }
 
     #[test]


### PR DESCRIPTION
Detects tables whose structure is drawn as borders rather than implied by text-lane occupancy. On the opendataloader corpus, 13 of 200 documents scored zero TEDS because their ground-truth tables are ruled boxes with no lane structure (single-column boxed lists, flowcharts of linked boxes) — invisible to span-based detection by construction.

**How it works.** pdfboss-text's existing content-stream walker now accumulates path segments per frame and commits axis-aligned segments as `Ruling`s under the CTM on painting operators: stroked subpaths carry `line_width × ctm_scale`, thin filled rectangles (≤3pt) yield their centerline, curves poison their subpath, `n` discards. A new seam `extract_spans_and_rulings_reporting(_with)` exposes both; the four existing `extract_spans*` entry points keep byte-identical signatures. In pdfboss-output, rulings cluster into drawn lines (snap tolerance), union-find over line crossings builds connected lattices, and `ruled_band` runs ahead of the lane detector — reusing `table_row`, so every ruled row passes the same spaced-cells word-gap gate. Single-column grids qualify (the corpus failure being fixed); a ruling boundary inside a sub-word gap rejects the grid and the page falls back to prose. Markdown entry points (Rust, Python, TUI) and CLI `json --layout` pick the rulings up internally with zero signature changes. Also includes a repo Makefile with colored autogenerated help and an install target.

**Corpus results** (opendataloader, 200 docs, after tuning `RULING_SNAP_TOLERANCE` 2pt → 6pt via a paired sweep recorded in the tuning commit):

| metric | before | after |
|---|---|---|
| overall | 0.770275 | **0.775005** |
| TEDS | 0.279284 | **0.328716** |
| MHS | 0.657876 | **0.666035** |
| NID | 0.866718 | 0.863909 |

Five of the 13 zero-TEDS targets now score: doc 149 (boxed list) 0 → **1.000**, 146 → 0.541, 150 → 0.262, 90 → 0.131, 120 → 0.106. The remaining 8 need more than borders (flowchart semantics, side-by-side layouts).

**Zero regression on plain text**: the Text adapter's 200-doc corpus output is byte-identical to the pre-change baseline (`diff -r` clean, NID exactly 0.8683497128245466), enforced by the strengthened byte-identity oracle over all fixtures including the three new ruled ones.

**Known trade-offs**, attributed by bit-identical paired runs: the small NID dip and doc 81's TEDS drop (0.690 → 0.267) come from the detection feature itself (a lane-detected table now detected differently), not the tuning; prose beside a boxed table in the same segment conservatively suppresses ruled detection. Both are candidates for a follow-up pass.

**Verification** (independent reviewer re-ran everything on the final tree): `cargo fmt --check` clean, `clippy --workspace --all-targets -D warnings` clean, `cargo test --workspace` 1599 passed across 36 suites; every review round's findings fixed and re-verified (3 adversarial reviews across the 3 tasks, approved with zero blocking findings each).
