### PR TITLE
perf: faster text and markdown extraction with byte-identical output

### DIFF
--- a/crates/pdfboss-cli/src/main.rs
+++ b/crates/pdfboss-cli/src/main.rs
@@ -408,16 +408,20 @@ fn cmd_text(file: &Path, page: Option<usize>) -> Result<(), String> {
             // `map_pages` visits exactly the materializable pages (the
             // flattened tree, not the declared `/Count`, which on a damaged
             // file may not match what the tree yields) and returns them in
-            // page order.
-            let parts = pdfboss_core::map_pages(&doc, pdfboss_output::extract_text_reporting)
-                .into_iter()
-                .enumerate()
-                .map(|(index, outcome)| {
-                    let (text, report) = outcome.map_err(|e| e.to_string())?;
-                    warn_skips(index + 1, &report);
-                    Ok(text)
-                })
-                .collect::<Result<Vec<String>, String>>()?;
+            // page order. One font cache serves every worker, so a font
+            // loads once per document rather than once per page.
+            let fonts = pdfboss_output::FontCache::default();
+            let parts = pdfboss_core::map_pages(&doc, |doc, page| {
+                pdfboss_output::extract_text_reporting_cached(doc, page, &fonts)
+            })
+            .into_iter()
+            .enumerate()
+            .map(|(index, outcome)| {
+                let (text, report) = outcome.map_err(|e| e.to_string())?;
+                warn_skips(index + 1, &report);
+                Ok(text)
+            })
+            .collect::<Result<Vec<String>, String>>()?;
             parts.join("\u{c}")
         }
     };

--- a/crates/pdfboss-core/src/content.rs
+++ b/crates/pdfboss-core/src/content.rs
@@ -5,7 +5,7 @@
 use crate::elements::Span;
 use crate::error::{Error, Result};
 use crate::geom::Matrix;
-use crate::lexer::{is_whitespace, Lexer, Token};
+use crate::lexer::{is_whitespace, Lexer, RawToken, Token};
 use crate::object::{Dict, Name, Object};
 
 /// Maximum operand container (array/dictionary) nesting depth. Composing
@@ -206,18 +206,34 @@ pub enum Op {
 /// token boundary (or the declared `/L`ength when present, which is
 /// trusted).
 pub fn parse_content(data: &[u8]) -> Result<Vec<Op>> {
-    Ok(parse_content_spanned(data)?
-        .into_iter()
-        .map(|pair| pair.0)
-        .collect())
+    let mut ops = Vec::with_capacity(ops_estimate(data.len()));
+    parse_content_ops(data, |op, _| ops.push(op))?;
+    Ok(ops)
 }
 
 /// Like [`parse_content`], but also reports each operator's byte range —
 /// from the first token of its operand run through the operator keyword —
 /// within `data`.
 pub fn parse_content_spanned(data: &[u8]) -> Result<Vec<(Op, Span)>> {
+    let mut ops = Vec::with_capacity(ops_estimate(data.len()));
+    parse_content_ops(data, |op, span| ops.push((op, span)))?;
+    Ok(ops)
+}
+
+/// Initial operator-vector capacity for a content stream of `len` bytes.
+/// An operator run (operands, keyword, separators) averages well above 16
+/// bytes, so `len / 16` reserves slightly high instead of growing; the cap
+/// keeps a huge stream — usually mostly inline-image data — from
+/// pre-claiming space for operators it may never produce.
+fn ops_estimate(len: usize) -> usize {
+    (len / 16).min(1 << 17)
+}
+
+/// The parse loop behind both public entry points: one pass over the
+/// tokens, each finished operator handed to `emit` — so the span-less
+/// caller never materializes spans it will throw away.
+fn parse_content_ops(data: &[u8], mut emit: impl FnMut(Op, Span)) -> Result<()> {
     let mut lexer = Lexer::new(data);
-    let mut ops = Vec::new();
     let mut stack: Vec<Object> = Vec::new();
     // Start of the current operand run; cleared whenever the run dies
     // (an operator was emitted, an unknown operator dropped it, or a
@@ -226,51 +242,64 @@ pub fn parse_content_spanned(data: &[u8]) -> Result<Vec<(Op, Span)>> {
     loop {
         lexer.skip_whitespace_and_comments();
         let token_start = lexer.pos();
-        let token = lexer.next_token()?;
-        if !matches!(token, Token::Eof) && run_start.is_none() {
-            run_start = Some(token_start);
-        }
-        match token {
-            Token::Eof => break,
-            Token::Int(i) => stack.push(Object::Int(i)),
-            Token::Real(r) => stack.push(Object::Real(r)),
-            Token::Name(n) => stack.push(Object::Name(n)),
-            Token::LitString(s) | Token::HexString(s) => stack.push(Object::String(s)),
-            Token::ArrayOpen => {
-                let a = parse_array(&mut lexer, 0)?;
-                stack.push(a);
+        let kw = match lexer.next_raw_token()? {
+            RawToken::Keyword(kw) => {
+                if run_start.is_none() {
+                    run_start = Some(token_start);
+                }
+                kw
             }
-            Token::DictOpen => {
-                let d = parse_dict(&mut lexer, 0)?;
-                stack.push(Object::Dict(d));
+            RawToken::Owned(token) => {
+                if !matches!(token, Token::Eof) && run_start.is_none() {
+                    run_start = Some(token_start);
+                }
+                match token {
+                    Token::Eof => break,
+                    Token::Int(i) => stack.push(Object::Int(i)),
+                    Token::Real(r) => stack.push(Object::Real(r)),
+                    Token::Name(n) => stack.push(Object::Name(n)),
+                    Token::LitString(s) | Token::HexString(s) => stack.push(Object::String(s)),
+                    Token::ArrayOpen => {
+                        let a = parse_array(&mut lexer, 0)?;
+                        stack.push(a);
+                    }
+                    Token::DictOpen => {
+                        let d = parse_dict(&mut lexer, 0)?;
+                        stack.push(Object::Dict(d));
+                    }
+                    // Stray closers: malformed input, drop pending operands.
+                    Token::ArrayClose | Token::DictClose => {
+                        stack.clear();
+                        run_start = None;
+                    }
+                    Token::Keyword(_) => {
+                        unreachable!("next_raw_token yields keywords borrowed")
+                    }
+                }
+                continue;
             }
-            // Stray closers: malformed input, drop pending operands.
-            Token::ArrayClose | Token::DictClose => {
+        };
+        match kw {
+            b"true" => stack.push(Object::Bool(true)),
+            b"false" => stack.push(Object::Bool(false)),
+            b"null" => stack.push(Object::Null),
+            b"BI" => {
+                let start = run_start.take().unwrap_or(token_start);
+                if let Some(op) = parse_inline_image(&mut lexer) {
+                    emit(op, Span::new(start as u64, lexer.pos() as u64));
+                }
                 stack.clear();
-                run_start = None;
             }
-            Token::Keyword(kw) => match kw.as_slice() {
-                b"true" => stack.push(Object::Bool(true)),
-                b"false" => stack.push(Object::Bool(false)),
-                b"null" => stack.push(Object::Null),
-                b"BI" => {
-                    let start = run_start.take().unwrap_or(token_start);
-                    if let Some(op) = parse_inline_image(&mut lexer) {
-                        ops.push((op, Span::new(start as u64, lexer.pos() as u64)));
-                    }
-                    stack.clear();
+            _ => {
+                let start = run_start.take().unwrap_or(token_start);
+                if let Some(op) = dispatch(kw, &mut stack) {
+                    emit(op, Span::new(start as u64, lexer.pos() as u64));
                 }
-                _ => {
-                    let start = run_start.take().unwrap_or(token_start);
-                    if let Some(op) = dispatch(&kw, &stack) {
-                        ops.push((op, Span::new(start as u64, lexer.pos() as u64)));
-                    }
-                    stack.clear();
-                }
-            },
+                stack.clear();
+            }
         }
     }
-    Ok(ops)
+    Ok(())
 }
 
 /// Composes an array value; the opening `[` has already been consumed.
@@ -325,18 +354,19 @@ fn int1(stack: &[Object]) -> Option<i32> {
     }
 }
 
-/// The last operand as a name.
-fn name1(stack: &[Object]) -> Option<Name> {
-    match stack.last()? {
-        Object::Name(n) => Some(n.clone()),
+/// The last operand as a name, taken off the stack: the caller clears the
+/// stack after every dispatch, so operands are moved out, never cloned.
+fn name1(stack: &mut [Object]) -> Option<Name> {
+    match stack.last_mut()? {
+        Object::Name(n) => Some(Name(std::mem::take(&mut n.0))),
         _ => None,
     }
 }
 
-/// The last operand as a string's bytes.
-fn str1(stack: &[Object]) -> Option<Vec<u8>> {
-    match stack.last()? {
-        Object::String(s) => Some(s.clone()),
+/// The last operand as a string's bytes, taken off the stack like [`name1`].
+fn str1(stack: &mut [Object]) -> Option<Vec<u8>> {
+    match stack.last_mut()? {
+        Object::String(s) => Some(std::mem::take(s)),
         _ => None,
     }
 }
@@ -382,7 +412,12 @@ fn parse_dict(lexer: &mut Lexer, depth: usize) -> Result<Dict> {
 /// Maps an operator keyword plus its operand stack to a typed [`Op`].
 /// Returns `None` (operator skipped) for unknown keywords or operand
 /// arity/type mismatches.
-fn dispatch(kw: &[u8], stack: &[Object]) -> Option<Op> {
+///
+/// The stack is dispatch's to consume — the caller clears it after every
+/// keyword — so heap operands (strings, names) are moved into the `Op`
+/// rather than cloned, and a mismatch may leave the stack partially
+/// emptied.
+fn dispatch(kw: &[u8], stack: &mut [Object]) -> Option<Op> {
     Some(match kw {
         // Graphics state.
         b"q" => Op::Save,
@@ -452,7 +487,7 @@ fn dispatch(kw: &[u8], stack: &[Object]) -> Option<Op> {
 }
 
 /// Continuation of [`dispatch`]: color and text operators.
-fn dispatch_color_text(kw: &[u8], stack: &[Object]) -> Option<Op> {
+fn dispatch_color_text(kw: &[u8], stack: &mut [Object]) -> Option<Op> {
     Some(match kw {
         // Color.
         b"CS" => Op::SetStrokeColorSpace(name1(stack)?),
@@ -498,10 +533,11 @@ fn dispatch_color_text(kw: &[u8], stack: &[Object]) -> Option<Op> {
                 return None;
             }
             let size = num(&stack[stack.len() - 1])?;
-            let Object::Name(font) = &stack[stack.len() - 2] else {
+            let at = stack.len() - 2;
+            let Object::Name(font) = &mut stack[at] else {
                 return None;
             };
-            Op::SetFont(font.clone(), size)
+            Op::SetFont(Name(std::mem::take(&mut font.0)), size)
         }
         b"d0" => {
             let [wx, wy] = nums::<2>(stack)?;
@@ -525,13 +561,13 @@ fn dispatch_color_text(kw: &[u8], stack: &[Object]) -> Option<Op> {
         b"T*" => Op::TextNextLine,
         b"Tj" => Op::ShowText(str1(stack)?),
         b"TJ" => {
-            let Object::Array(items) = stack.last()? else {
+            let Object::Array(items) = stack.last_mut()? else {
                 return None;
             };
             let adjusted = items
-                .iter()
+                .iter_mut()
                 .filter_map(|o| match o {
-                    Object::String(s) => Some(TextItem::Str(s.clone())),
+                    Object::String(s) => Some(TextItem::Str(std::mem::take(s))),
                     other => num(other).map(TextItem::Offset),
                 })
                 .collect();
@@ -553,7 +589,7 @@ fn dispatch_color_text(kw: &[u8], stack: &[Object]) -> Option<Op> {
 
 /// Continuation of [`dispatch`]: XObject, shading, marked-content, and
 /// compatibility operators.
-fn dispatch_misc(kw: &[u8], stack: &[Object]) -> Option<Op> {
+fn dispatch_misc(kw: &[u8], stack: &mut [Object]) -> Option<Op> {
     Some(match kw {
         b"Do" => Op::XObject(name1(stack)?),
         b"sh" => Op::Shading(name1(stack)?),
@@ -586,31 +622,33 @@ fn nums_at<const N: usize>(stack: &[Object], start: usize) -> Option<[f32; N]> {
 }
 
 /// Operands of `SCN`/`scn`: numeric components optionally followed by a
-/// pattern name.
-fn color_n(stack: &[Object]) -> Option<(Vec<f32>, Option<Name>)> {
-    match stack.last() {
+/// pattern name (taken off the stack like [`name1`]).
+fn color_n(stack: &mut [Object]) -> Option<(Vec<f32>, Option<Name>)> {
+    match stack.last_mut() {
         Some(Object::Name(n)) => {
+            let pattern = Name(std::mem::take(&mut n.0));
             let comps = all_nums(&stack[..stack.len() - 1])?;
-            Some((comps, Some(n.clone())))
+            Some((comps, Some(pattern)))
         }
         _ => Some((all_nums(stack)?, None)),
     }
 }
 
 /// Operands of `DP`/`BDC`: a tag name and a properties value (an inline
-/// dictionary or a resource name).
-fn tag_props(stack: &[Object]) -> Option<(Name, Object)> {
+/// dictionary or a resource name), both taken off the stack like [`name1`].
+fn tag_props(stack: &mut [Object]) -> Option<(Name, Object)> {
     if stack.len() < 2 {
         return None;
     }
-    let props = match &stack[stack.len() - 1] {
-        o @ (Object::Dict(_) | Object::Name(_)) => o.clone(),
+    let last = stack.len() - 1;
+    let props = match &stack[last] {
+        Object::Dict(_) | Object::Name(_) => std::mem::replace(&mut stack[last], Object::Null),
         _ => return None,
     };
-    let Object::Name(tag) = &stack[stack.len() - 2] else {
+    let Object::Name(tag) = &mut stack[last - 1] else {
         return None;
     };
-    Some((tag.clone(), props))
+    Some((Name(std::mem::take(&mut tag.0)), props))
 }
 
 /// Parses an inline image; the `BI` keyword has already been consumed.

--- a/crates/pdfboss-core/src/filters/flate.rs
+++ b/crates/pdfboss-core/src/filters/flate.rs
@@ -59,7 +59,9 @@ fn inflate_tolerant(data: &[u8]) -> Result<Vec<u8>> {
 /// larger than `MAX_DECODED_LEN` (a decompression bomb) is an error.
 fn inflate(data: &[u8], zlib_header: bool) -> Result<(Vec<u8>, bool)> {
     let mut inflater = Decompress::new(zlib_header);
-    let mut out: Vec<u8> = Vec::with_capacity(data.len().saturating_mul(2).clamp(1024, 1 << 22));
+    // Typical PDF streams decompress 3-5x; starting at 4x (same 4 MiB cap)
+    // usually lands the whole stream without a realloc-and-copy cycle.
+    let mut out: Vec<u8> = Vec::with_capacity(data.len().saturating_mul(4).clamp(1024, 1 << 22));
     loop {
         let consumed = (inflater.total_in() as usize).min(data.len());
         let in_before = inflater.total_in();

--- a/crates/pdfboss-core/src/lexer.rs
+++ b/crates/pdfboss-core/src/lexer.rs
@@ -61,6 +61,13 @@ fn hex_val(b: u8) -> Option<u8> {
     }
 }
 
+/// Cap on the bytes pre-reserved for a hex string from its distance to the
+/// next `>`. On corrupt input a stray `<` can put that `>` (or end of input)
+/// megabytes away with few hex digits in between, so an uncapped reservation
+/// amplifies memory; genuine hex strings virtually never exceed this, and
+/// longer ones just grow from here.
+const HEX_STRING_PREALLOC_CAP: usize = 16 * 1024;
+
 /// Largest mantissa the exact real fast path accepts: 10^15, i.e. at most
 /// 15 significant digits, comfortably inside f64's 2^53 exact-integer range.
 const MAX_EXACT_MANTISSA: u64 = 1_000_000_000_000_000;
@@ -120,6 +127,22 @@ fn parse_number_fast(run: &[u8]) -> Option<Token> {
     Some(Token::Real(if negative { -magnitude } else { magnitude }))
 }
 
+/// A lexed token whose keyword bytes borrow the input.
+///
+/// This is the content parser's working form: an operator stream is mostly
+/// keywords, and copying each one into a [`Token::Keyword`] allocation just
+/// to match on it and drop it dominated content-parse allocation.
+/// [`Lexer::next_token`] wraps this, copying keyword bytes into the public
+/// [`Token`], so the two forms cannot lex differently.
+pub(crate) enum RawToken<'a> {
+    /// Any non-keyword token, carried as the public type. Never
+    /// [`Token::Keyword`]: keywords always come out borrowed.
+    Owned(Token),
+    /// A bare regular-character run — or a lenient stray delimiter —
+    /// borrowed from the input.
+    Keyword(&'a [u8]),
+}
+
 /// Tokenizer over a byte slice.
 pub struct Lexer<'a> {
     data: &'a [u8],
@@ -149,53 +172,63 @@ impl<'a> Lexer<'a> {
 
     /// Consumes and returns the next token.
     pub fn next_token(&mut self) -> Result<Token> {
+        Ok(match self.next_raw_token()? {
+            RawToken::Owned(token) => token,
+            RawToken::Keyword(kw) => Token::Keyword(kw.to_vec()),
+        })
+    }
+
+    /// [`Lexer::next_token`] with keyword bytes borrowed instead of copied.
+    /// This is the one lexing implementation; `next_token` merely copies the
+    /// borrow out.
+    pub(crate) fn next_raw_token(&mut self) -> Result<RawToken<'a>> {
         self.skip_whitespace_and_comments();
         let Some(&b) = self.data.get(self.pos) else {
-            return Ok(Token::Eof);
+            return Ok(RawToken::Owned(Token::Eof));
         };
         match b {
             b'[' => {
                 self.pos += 1;
-                Ok(Token::ArrayOpen)
+                Ok(RawToken::Owned(Token::ArrayOpen))
             }
             b']' => {
                 self.pos += 1;
-                Ok(Token::ArrayClose)
+                Ok(RawToken::Owned(Token::ArrayClose))
             }
             b'<' => {
                 if self.data.get(self.pos + 1) == Some(&b'<') {
                     self.pos += 2;
-                    Ok(Token::DictOpen)
+                    Ok(RawToken::Owned(Token::DictOpen))
                 } else {
                     self.pos += 1;
-                    Ok(self.lex_hex_string())
+                    Ok(RawToken::Owned(self.lex_hex_string()))
                 }
             }
             b'>' => {
                 if self.data.get(self.pos + 1) == Some(&b'>') {
                     self.pos += 2;
-                    Ok(Token::DictClose)
+                    Ok(RawToken::Owned(Token::DictClose))
                 } else {
                     // Stray `>`: surfaced leniently as a one-byte keyword.
                     self.pos += 1;
-                    Ok(Token::Keyword(vec![b'>']))
+                    Ok(RawToken::Keyword(&self.data[self.pos - 1..self.pos]))
                 }
             }
             b'(' => {
                 self.pos += 1;
-                Ok(self.lex_literal_string())
+                Ok(RawToken::Owned(self.lex_literal_string()))
             }
             b'/' => {
                 self.pos += 1;
-                Ok(self.lex_name())
+                Ok(RawToken::Owned(self.lex_name()))
             }
             // Stray delimiters with no token of their own: kept lenient.
             b')' | b'{' | b'}' => {
                 self.pos += 1;
-                Ok(Token::Keyword(vec![b]))
+                Ok(RawToken::Keyword(&self.data[self.pos - 1..self.pos]))
             }
             b'0'..=b'9' | b'+' | b'-' | b'.' => Ok(self.lex_number_or_keyword()),
-            _ => Ok(self.lex_keyword()),
+            _ => Ok(RawToken::Keyword(self.take_regular_run())),
         }
     }
 
@@ -243,20 +276,27 @@ impl<'a> Lexer<'a> {
 
     /// Lexes a run starting with a digit, sign, or period: a number when the
     /// run contains only numeric characters, otherwise a keyword (lenient).
-    fn lex_number_or_keyword(&mut self) -> Token {
+    fn lex_number_or_keyword(&mut self) -> RawToken<'a> {
         let run = self.take_regular_run();
         if !run
             .iter()
             .all(|&b| matches!(b, b'0'..=b'9' | b'+' | b'-' | b'.'))
         {
-            return Token::Keyword(run.to_vec());
+            return RawToken::Keyword(run);
         }
-        // Manual fast path first (the overwhelming majority of runs); its
-        // guards guarantee bit-identical results, and anything it declines
-        // goes through the standard parses below unchanged.
-        if let Some(token) = parse_number_fast(run) {
-            return token;
-        }
+        RawToken::Owned(number_token(run))
+    }
+}
+
+/// Lexes a run of only numeric characters into its token: the manual fast
+/// path first (the overwhelming majority of runs) — its guards guarantee
+/// bit-identical results — and anything it declines goes through the
+/// standard parses, then the lenient cleaner, unchanged.
+fn number_token(run: &[u8]) -> Token {
+    if let Some(token) = parse_number_fast(run) {
+        return token;
+    }
+    {
         // Standard parse for well-formed numbers past the fast path's bounds:
         // integers with no `.` go to `i64`; anything else (including
         // overflow) to `f64`. Malformed runs (multiple signs/dots, bare sign)
@@ -316,12 +356,9 @@ impl<'a> Lexer<'a> {
             Token::Real(if negative { -value } else { value })
         }
     }
+}
 
-    /// Lexes a keyword: any other run of regular characters.
-    fn lex_keyword(&mut self) -> Token {
-        Token::Keyword(self.take_regular_run().to_vec())
-    }
-
+impl<'a> Lexer<'a> {
     /// Lexes a name after the leading `/`, decoding `#xx` escapes. A `#`
     /// not followed by two hex digits is kept literally.
     fn lex_name(&mut self) -> Token {
@@ -363,6 +400,17 @@ impl<'a> Lexer<'a> {
     /// line continuation, and raw EOL normalized to `\n`. An unterminated
     /// string yields whatever was accumulated (lenient).
     fn lex_literal_string(&mut self) -> Token {
+        // Fast path: nothing before the closing `)` escapes (`\`), nests
+        // (`(`), or needs EOL normalization (`\r`), so the string's bytes
+        // are exactly the input's — one bounds-checked copy, no per-byte
+        // scan. Anything else falls through to the general loop unchanged.
+        let rest = &self.data[self.pos..];
+        if let Some(close) = memchr::memchr(b')', rest) {
+            if memchr::memchr3(b'\\', b'(', b'\r', &rest[..close]).is_none() {
+                self.pos += close + 1;
+                return Token::LitString(rest[..close].to_vec());
+            }
+        }
         let mut out = Vec::new();
         let mut depth = 1usize;
         while let Some(&b) = self.data.get(self.pos) {
@@ -433,7 +481,9 @@ impl<'a> Lexer<'a> {
     /// trailing odd digit is padded with `0`, non-hex bytes are skipped
     /// (lenient), and a missing `>` terminates at end of input.
     fn lex_hex_string(&mut self) -> Token {
-        let mut out = Vec::new();
+        let rest = &self.data[self.pos..];
+        let digits = memchr::memchr(b'>', rest).unwrap_or(rest.len());
+        let mut out = Vec::with_capacity(digits.div_ceil(2).min(HEX_STRING_PREALLOC_CAP));
         let mut pending: Option<u8> = None;
         while let Some(&b) = self.data.get(self.pos) {
             self.pos += 1;
@@ -794,6 +844,26 @@ mod tests {
         assert_eq!(one(b"(abc\\"), Token::LitString(b"abc".to_vec()));
     }
 
+    /// The copy fast path may only fire when nothing before the closing
+    /// paren escapes, nests, or normalizes: each byte in its gate set
+    /// (`\`, `(`, `\r`) placed before the first `)` must still produce the
+    /// general loop's exact output, and a raw `\n` (not in the gate set)
+    /// must pass through the fast path verbatim.
+    #[test]
+    fn literal_string_fast_path_gate() {
+        assert_eq!(one(b"(a\\)b)"), Token::LitString(b"a)b".to_vec()));
+        assert_eq!(one(b"(a(b)c)"), Token::LitString(b"a(b)c".to_vec()));
+        assert_eq!(one(b"(a\rb)"), Token::LitString(b"a\nb".to_vec()));
+        assert_eq!(one(b"(a\nb)"), Token::LitString(b"a\nb".to_vec()));
+        assert_eq!(
+            toks(b"(plain) (esc\\)aped)"),
+            vec![
+                Token::LitString(b"plain".to_vec()),
+                Token::LitString(b"esc)aped".to_vec()),
+            ]
+        );
+    }
+
     #[test]
     fn hex_strings() {
         assert_eq!(one(b"<>"), Token::HexString(Vec::new()));
@@ -812,6 +882,24 @@ mod tests {
         );
         // Missing `>` terminates at end of input (lenient).
         assert_eq!(one(b"<41"), Token::HexString(vec![0x41]));
+    }
+
+    /// The pre-reservation cap must not change what decodes: a hex string
+    /// past [`HEX_STRING_PREALLOC_CAP`] bytes grows to its full content, and
+    /// a stray `<` whose `>` lies far away (mostly non-hex bytes) still
+    /// decodes only the actual digits.
+    #[test]
+    fn hex_string_prealloc_cap_is_invisible() {
+        let long = "4F".repeat(HEX_STRING_PREALLOC_CAP + 17);
+        let src = format!("<{long}>");
+        assert_eq!(
+            one(src.as_bytes()),
+            Token::HexString(vec![0x4F; HEX_STRING_PREALLOC_CAP + 17])
+        );
+        let mut corrupt = b"<41".to_vec();
+        corrupt.resize(corrupt.len() + 100_000, b'(');
+        corrupt.extend_from_slice(b"42>");
+        assert_eq!(one(&corrupt), Token::HexString(vec![0x41, 0x42]));
     }
 
     #[test]

--- a/crates/pdfboss-core/src/lexer.rs
+++ b/crates/pdfboss-core/src/lexer.rs
@@ -61,6 +61,65 @@ fn hex_val(b: u8) -> Option<u8> {
     }
 }
 
+/// Largest mantissa the exact real fast path accepts: 10^15, i.e. at most
+/// 15 significant digits, comfortably inside f64's 2^53 exact-integer range.
+const MAX_EXACT_MANTISSA: u64 = 1_000_000_000_000_000;
+
+/// Powers of ten that are exactly representable in `f64` (10^0 ..= 10^22).
+const EXACT_POW10: [f64; 23] = [
+    1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16,
+    1e17, 1e18, 1e19, 1e20, 1e21, 1e22,
+];
+
+/// Manual parse of a well-formed numeric run (`sign? digits '.'? digits`
+/// with at least one digit): integers accumulate in `u64`; reals divide an
+/// exact mantissa (under [`MAX_EXACT_MANTISSA`]) by an exact power of ten,
+/// and IEEE 754 division of exact operands rounds to the same bits the
+/// standard library parser produces. Any other shape, a `u64` overflow, or
+/// a bound violation returns `None`, and the caller falls back to the
+/// standard parse.
+fn parse_number_fast(run: &[u8]) -> Option<Token> {
+    let (negative, digits) = match run.split_first() {
+        Some((&b'-', rest)) => (true, rest),
+        Some((&b'+', rest)) => (false, rest),
+        _ => (false, run),
+    };
+    let mut mantissa = 0u64;
+    let mut digit_count = 0usize;
+    let mut frac_len: Option<usize> = None;
+    for &b in digits {
+        match b {
+            b'0'..=b'9' => {
+                mantissa = mantissa.checked_mul(10)?.checked_add(u64::from(b - b'0'))?;
+                digit_count += 1;
+                if let Some(count) = frac_len.as_mut() {
+                    *count += 1;
+                }
+            }
+            b'.' if frac_len.is_none() => frac_len = Some(0),
+            _ => return None,
+        }
+    }
+    if digit_count == 0 {
+        return None;
+    }
+    let Some(frac) = frac_len else {
+        if !negative {
+            return i64::try_from(mantissa).ok().map(Token::Int);
+        }
+        if mantissa == 1u64 << 63 {
+            return Some(Token::Int(i64::MIN));
+        }
+        let magnitude = i64::try_from(mantissa).ok()?;
+        return Some(Token::Int(-magnitude));
+    };
+    if mantissa >= MAX_EXACT_MANTISSA || frac >= EXACT_POW10.len() {
+        return None;
+    }
+    let magnitude = mantissa as f64 / EXACT_POW10[frac];
+    Some(Token::Real(if negative { -magnitude } else { magnitude }))
+}
+
 /// Tokenizer over a byte slice.
 pub struct Lexer<'a> {
     data: &'a [u8],
@@ -192,11 +251,17 @@ impl<'a> Lexer<'a> {
         {
             return Token::Keyword(run.to_vec());
         }
-        // Fast path for well-formed numbers (the overwhelming majority):
-        // parse directly off the borrowed slice with no intermediate String.
-        // Integers with no `.` go to `i64`; anything else (including overflow)
-        // to `f64`. Malformed runs (multiple signs/dots, bare sign) fall
-        // through to the lenient cleaner below, preserving its exact result.
+        // Manual fast path first (the overwhelming majority of runs); its
+        // guards guarantee bit-identical results, and anything it declines
+        // goes through the standard parses below unchanged.
+        if let Some(token) = parse_number_fast(run) {
+            return token;
+        }
+        // Standard parse for well-formed numbers past the fast path's bounds:
+        // integers with no `.` go to `i64`; anything else (including
+        // overflow) to `f64`. Malformed runs (multiple signs/dots, bare sign)
+        // fall through to the lenient cleaner below, preserving its exact
+        // result.
         if let Ok(s) = std::str::from_utf8(run) {
             if !run.contains(&b'.') {
                 if let Ok(value) = s.parse::<i64>() {
@@ -430,6 +495,174 @@ mod tests {
         assert_eq!(one(b"0"), Token::Int(0));
         assert_eq!(one(b"123"), Token::Int(123));
         assert_eq!(one(b"0.0"), Token::Real(0.0));
+    }
+
+    /// Verbatim copy of the number lexing as it stood before
+    /// [`parse_number_fast`], kept as the differential oracle: the fast
+    /// path must never change what any numeric run produces.
+    fn reference_number_token(run: &[u8]) -> Token {
+        if !run
+            .iter()
+            .all(|&b| matches!(b, b'0'..=b'9' | b'+' | b'-' | b'.'))
+        {
+            return Token::Keyword(run.to_vec());
+        }
+        if let Ok(s) = std::str::from_utf8(run) {
+            if !run.contains(&b'.') {
+                if let Ok(value) = s.parse::<i64>() {
+                    return Token::Int(value);
+                }
+            }
+            if let Ok(value) = s.parse::<f64>() {
+                return Token::Real(value);
+            }
+        }
+        let mut bytes = run.iter().copied();
+        let negative = match run.first() {
+            Some(b'-') => {
+                bytes.next();
+                true
+            }
+            Some(b'+') => {
+                bytes.next();
+                false
+            }
+            _ => false,
+        };
+        let mut digits = String::new();
+        let mut seen_dot = false;
+        for b in bytes {
+            match b {
+                b'0'..=b'9' => digits.push(char::from(b)),
+                b'.' if !seen_dot => {
+                    seen_dot = true;
+                    digits.push('.');
+                }
+                _ => {}
+            }
+        }
+        if seen_dot {
+            let value = if digits == "." {
+                0.0
+            } else {
+                digits.parse::<f64>().unwrap_or(0.0)
+            };
+            Token::Real(if negative { -value } else { value })
+        } else if digits.is_empty() {
+            Token::Int(0)
+        } else if let Ok(value) = digits.parse::<i64>() {
+            Token::Int(if negative { -value } else { value })
+        } else {
+            let value = digits.parse::<f64>().unwrap_or(0.0);
+            Token::Real(if negative { -value } else { value })
+        }
+    }
+
+    /// Lexes `src` as one token and asserts it equals the reference —
+    /// reals bit-for-bit at `f64` and again after casting to `f32`, where
+    /// double rounding would hide.
+    fn assert_number_matches_reference(src: &str) {
+        let actual = one(src.as_bytes());
+        let expected = reference_number_token(src.as_bytes());
+        match (&actual, &expected) {
+            (Token::Real(a), Token::Real(b)) => {
+                assert_eq!(a.to_bits(), b.to_bits(), "f64 bits for {src:?}");
+                assert_eq!(
+                    (*a as f32).to_bits(),
+                    (*b as f32).to_bits(),
+                    "f32 bits for {src:?}"
+                );
+            }
+            _ => assert_eq!(actual, expected, "token for {src:?}"),
+        }
+    }
+
+    /// Differential fuzz over the numeric grammar: a digit-count grid across
+    /// the fast path's bounds (15/16/17 significant digits, fraction lengths
+    /// at and past the exact-power-of-ten table) crossed with signs and
+    /// leading zeros, plus literal corner cases (bare signs and dots,
+    /// multi-sign and multi-dot runs, `i64`/`u64` boundaries, and huge
+    /// literals whose `f32` cast overflows to infinity).
+    #[test]
+    fn numeric_fast_path_matches_reference() {
+        let corner_cases = [
+            "0",
+            "-0",
+            "+0",
+            "0.0",
+            "-0.0",
+            "+0.0",
+            ".5",
+            "5.",
+            "-.5",
+            "+.5",
+            "-5.",
+            "+5.",
+            ".",
+            "-.",
+            "+.",
+            "+",
+            "-",
+            "..",
+            "-..",
+            "1.2.3",
+            "1-2",
+            "--5",
+            "+-3",
+            "1..5",
+            "1+",
+            "9223372036854775807",
+            "9223372036854775808",
+            "-9223372036854775808",
+            "-9223372036854775809",
+            "18446744073709551615",
+            "18446744073709551616",
+            "184467440737095516150",
+            "999999999999999999999999999999999999999",
+            "400000000000000000000000000000000000000",
+            "340282366920938463463374607431768211455",
+            "-400000000000000000000000000000000000000",
+            "0.0000000000000000000001",
+            "0.00000000000000000000001",
+            "5.0000000000000000000001",
+            "1.00000000000000",
+            "1.000000000000000",
+            "1.0000000000000000000000000000",
+            "123.4500000000000000000000",
+            "12345678901234567890.12345",
+            "0.1",
+            "0.30000000000000004",
+        ];
+        let mut cases: Vec<String> = corner_cases.iter().map(|s| s.to_string()).collect();
+        let digit_cycle = |n: usize| -> String {
+            (0..n)
+                .map(|i| char::from(b'1' + (i % 9) as u8))
+                .collect::<String>()
+        };
+        let sig_counts = [1usize, 2, 7, 14, 15, 16, 17, 18, 19, 20, 21, 39];
+        let frac_counts = [0usize, 1, 2, 7, 14, 15, 16, 21, 22, 23, 28, 38];
+        for &sig in &sig_counts {
+            let body = digit_cycle(sig);
+            for &frac in &frac_counts {
+                if frac > sig {
+                    continue;
+                }
+                let mut with_dot = body.clone();
+                with_dot.insert(sig - frac, '.');
+                for sign in ["", "+", "-"] {
+                    for lead in ["", "0", "0000000000000000"] {
+                        cases.push(format!("{sign}{lead}{with_dot}"));
+                        if frac == 0 {
+                            cases.push(format!("{sign}{lead}{body}"));
+                        }
+                    }
+                }
+            }
+        }
+        for case in &cases {
+            assert_number_matches_reference(case);
+        }
+        eprintln!("differential cases: {}", cases.len());
     }
 
     #[test]

--- a/crates/pdfboss-output/src/lib.rs
+++ b/crates/pdfboss-output/src/lib.rs
@@ -11,7 +11,9 @@ use pdfboss_core::{block_on, AsyncObjectSource, Document, Immediate, Page, Resul
 pub use ir::{BBox, Block, Cell, Inline, Line, ListItem, Marker, PageLayout, Role};
 pub use markdown::Markdown;
 pub use output::{Output, Text};
-pub use pdfboss_text::{ExtractReport, Ruling, SkipCause, SkippedText, SkippedTextKind, TextSpan};
+pub use pdfboss_text::{
+    ExtractReport, FontCache, Ruling, SkipCause, SkippedText, SkippedTextKind, TextSpan,
+};
 pub use structure::{
     document_layout, document_layout_with_rulings, layout, page_layout, page_layout_with_rulings,
 };
@@ -64,6 +66,23 @@ pub async fn extract_text_reporting_with<S: AsyncObjectSource>(
     Ok((Text.render(&[page_layout(&spans)]), report))
 }
 
+/// [`extract_text_reporting`] with fonts cached across pages: a caller
+/// walking a whole document — `pdfboss_core::map_pages` included — passes one
+/// [`FontCache`] to every page and each font loads once for the document.
+/// The text is identical to the uncached call's, page for page.
+///
+/// There is no `_with` twin: an asynchronous caller composes
+/// `pdfboss_text::extract_spans_reporting_cached_with` with the pure
+/// [`page_layout`] and [`Text`], exactly as this function does.
+pub fn extract_text_reporting_cached(
+    doc: &Document,
+    page: &Page,
+    fonts: &FontCache,
+) -> Result<(String, ExtractReport)> {
+    let (spans, report) = pdfboss_text::extract_spans_reporting_cached(doc, page, fonts)?;
+    Ok((Text.render(&[page_layout(&spans)]), report))
+}
+
 /// Extracts the whole document as Markdown: ATX headings, paragraphs, and
 /// emphasis over the same positional layout [`extract_text`] renders flat.
 ///
@@ -84,7 +103,10 @@ pub fn extract_markdown(doc: &Document) -> Result<String> {
 /// Each page's rulings ride along with its spans: a table whose structure is
 /// drawn as borders is read from them ahead of lane occupancy.
 pub fn extract_markdown_reporting(doc: &Document) -> Result<(String, Vec<ExtractReport>)> {
-    let per_page = pdfboss_core::map_pages(doc, pdfboss_text::extract_spans_and_rulings_reporting);
+    let fonts = FontCache::default();
+    let per_page = pdfboss_core::map_pages(doc, |doc: &Document, page: &Page| {
+        pdfboss_text::extract_spans_and_rulings_reporting_cached(doc, page, &fonts)
+    });
     let mut pages = Vec::with_capacity(per_page.len());
     let mut reports = Vec::with_capacity(per_page.len());
     for outcome in per_page {

--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -353,8 +353,14 @@ impl Document {
             let doc = CoreDocument::from_seed(inner.lock().seed());
             // `map_pages` visits exactly the materializable pages — the
             // flattened tree, not the declared `/Count`, which on a damaged
-            // file can exceed (or fall short of) what the tree yields.
-            let texts = pdfboss_core::map_pages(&doc, pdfboss_output::extract_text);
+            // file can exceed (or fall short of) what the tree yields. One
+            // font cache serves every worker, so a font loads once per
+            // document rather than once per page.
+            let fonts = pdfboss_output::FontCache::default();
+            let texts = pdfboss_core::map_pages(&doc, |doc, page| {
+                let (text, _) = pdfboss_output::extract_text_reporting_cached(doc, page, &fonts)?;
+                Ok(text)
+            });
             let mut out = String::new();
             for (i, text) in texts.into_iter().enumerate() {
                 if i > 0 {

--- a/crates/pdfboss-text/src/cmap.rs
+++ b/crates/pdfboss-text/src/cmap.rs
@@ -2,7 +2,7 @@
 //! `beginbfrange` forms; destination hex is UTF-16BE and may be multi-char.
 
 use pdfboss_core::lexer::{Lexer, Token};
-use std::collections::HashMap;
+use pdfboss_core::FastMap;
 
 /// A parsed ToUnicode CMap mapping character codes to Unicode strings.
 ///
@@ -13,7 +13,7 @@ pub struct ToUnicode {
     /// `(byte_len, low, high)` from `begincodespacerange`.
     codespaces: Vec<(usize, u32, u32)>,
     /// Single-code mappings (`bfchar` and array-form `bfrange`).
-    singles: HashMap<u32, String>,
+    singles: FastMap<u32, String>,
     /// Increment-form `bfrange` entries: `(low, high, base UTF-16 units)`;
     /// the last unit increments with the code.
     ranges: Vec<(u32, u32, Vec<u16>)>,
@@ -300,6 +300,19 @@ mod tests {
         assert_eq!(cmap.lookup(0x20), None);
         assert_eq!(cmap.lookup(0x30), None);
         assert_eq!(cmap.lookup(0x31).as_deref(), Some("B"));
+    }
+
+    /// Duplicate source codes follow map insert semantics: the last mapping
+    /// wins, within a section and across sections.
+    #[test]
+    fn duplicate_code_keeps_last_mapping() {
+        let cmap = ToUnicode::parse(b"2 beginbfchar <41> <0058> <41> <0059> endbfchar");
+        assert_eq!(cmap.lookup(0x41).as_deref(), Some("Y"));
+        let across = ToUnicode::parse(
+            b"1 beginbfchar <41> <0058> endbfchar\n\
+              1 beginbfrange <41> <41> [<005A>] endbfrange",
+        );
+        assert_eq!(across.lookup(0x41).as_deref(), Some("Z"));
     }
 
     #[test]

--- a/crates/pdfboss-text/src/extract.rs
+++ b/crates/pdfboss-text/src/extract.rs
@@ -5,11 +5,11 @@ use crate::font::Font;
 use crate::{Ruling, TextSpan};
 use pdfboss_core::content::{parse_content, Op, TextItem};
 use pdfboss_core::{
-    content_stream_data_with, page_content_with, AsyncObjectSource, Dict, Matrix, Object, Page,
-    Point,
+    content_stream_data_with, page_content_with, AsyncObjectSource, Dict, Matrix, ObjRef, Object,
+    Page, Point,
 };
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Maximum form-XObject recursion depth.
 const MAX_FORM_DEPTH: usize = 16;
@@ -114,6 +114,37 @@ impl std::fmt::Display for SkipCause {
     }
 }
 
+/// Loaded fonts shared across page extractions of one document, keyed by the
+/// font dictionary's object reference.
+///
+/// The name→font binding is resource-scoped — `/F1` in one form and `/F1` in
+/// the page resources may be different fonts — so names are never keys here.
+/// The reference is: within a document (and its forks, which share the same
+/// bytes) an object reference resolves to the same dictionary every time, and
+/// loading that dictionary yields the same font. A font held as a direct
+/// dictionary has no reference and is never cached here.
+///
+/// `Send + Sync`, so one cache may serve every worker of a parallel
+/// page walk; the executor consults it at most once per page per distinct
+/// font reference.
+#[derive(Default)]
+pub struct FontCache {
+    fonts: Mutex<HashMap<ObjRef, Arc<Font>>>,
+}
+
+impl FontCache {
+    fn get(&self, r: ObjRef) -> Option<Arc<Font>> {
+        self.fonts.lock().unwrap().get(&r).cloned()
+    }
+
+    /// Stores `font` under `r`, keeping (and returning) an already-present
+    /// entry: concurrent workers may load the same font twice, and the copies
+    /// are interchangeable, so the first one in wins.
+    fn insert(&self, r: ObjRef, font: Arc<Font>) -> Arc<Font> {
+        self.fonts.lock().unwrap().entry(r).or_insert(font).clone()
+    }
+}
+
 /// Maps a fetch/decode error onto its cause, keeping the filter name — the
 /// one detail a caller can act on (the same split rendering reports).
 fn cause_for(error: &pdfboss_core::Error) -> SkipCause {
@@ -139,6 +170,7 @@ fn cause_for(error: &pdfboss_core::Error) -> SkipCause {
 pub async fn page_spans_and_rulings_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
+    fonts: Option<&FontCache>,
 ) -> (Vec<TextSpan>, Vec<Ruling>, ExtractReport) {
     let mut report = ExtractReport::default();
     let content = match page_content_with(&src, page).await {
@@ -162,6 +194,8 @@ pub async fn page_spans_and_rulings_with<S: AsyncObjectSource>(
         fallback: Arc::new(Font::fallback()),
         forms: 0,
         report,
+        loaded: HashMap::new(),
+        shared: fonts,
     };
     let root = Frame::new(
         ops.into(),
@@ -436,6 +470,14 @@ struct Executor<'a, S> {
     forms: usize,
     /// What could not be read; carried out alongside the spans.
     report: ExtractReport,
+    /// Fonts loaded during this page walk, keyed by their dictionary's
+    /// object reference — shared across every frame the walk pushes, so a
+    /// form invoked many times loads its fonts once. Never keyed by name:
+    /// that binding is per resource scope and stays in [`Frame::fonts`].
+    loaded: HashMap<ObjRef, Arc<Font>>,
+    /// Fonts carried across page walks, when the caller extracts a whole
+    /// document and passes one [`FontCache`] to every page.
+    shared: Option<&'a FontCache>,
 }
 
 impl<S: AsyncObjectSource> Executor<'_, S> {
@@ -467,7 +509,7 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
     /// Loads (with per-stream caching) the font resource `name` from the
     /// active resource chain, falling back to a default font.
     async fn font(
-        &self,
+        &mut self,
         chain: &[Arc<Dict>],
         name: &str,
         cache: &mut HashMap<String, Arc<Font>>,
@@ -475,15 +517,79 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         if let Some(f) = cache.get(name) {
             return f.clone();
         }
-        let resolved = self.find_res(chain, "Font", name).await;
-        let loaded = match resolved.as_ref().and_then(|o| o.as_dict()) {
-            Some(dict) => Arc::new(Font::load(self.src, dict).await),
-            // No such resource, or one that is not a dictionary: the fallback
-            // font keeps the text extractable rather than failing the page.
-            None => self.fallback.clone(),
-        };
+        let loaded = self.load_font(chain, name).await;
         cache.insert(name.to_string(), loaded.clone());
         loaded
+    }
+
+    /// Resolves `name` through the chain with [`Self::find_res`]'s exact
+    /// semantics — innermost scope first, a name whose value will not resolve
+    /// falls through to the outer scopes, the first value that resolves wins
+    /// whatever it turns out to be — and loads the font it lands on.
+    ///
+    /// A value held as an indirect reference is answered from the caches
+    /// before it is even resolved: within one document a reference resolves
+    /// to the same dictionary every time, so an already-loaded font is the
+    /// same font. Anything else — a direct dictionary, a value that is no
+    /// dictionary at all (the fallback), an exhausted chain (also the
+    /// fallback) — is loaded per use, cached only under its name in the
+    /// calling frame.
+    async fn load_font(&mut self, chain: &[Arc<Dict>], name: &str) -> Arc<Font> {
+        for res in chain {
+            let Some(cat) = res.get("Font") else {
+                continue;
+            };
+            let Ok(Object::Dict(dict)) = self.src.resolve(cat).await else {
+                continue;
+            };
+            let Some(value) = dict.get(name) else {
+                continue;
+            };
+            let key = match value {
+                Object::Ref(r) => Some(*r),
+                _ => None,
+            };
+            if let Some(f) = key.and_then(|r| self.hit(r)) {
+                return f;
+            }
+            let Ok(obj) = self.src.resolve(value).await else {
+                continue;
+            };
+            let Some(font_dict) = obj.as_dict() else {
+                // The name resolved to something that is not a dictionary:
+                // the fallback font keeps the text extractable rather than
+                // failing the page.
+                return self.fallback.clone();
+            };
+            let loaded = Arc::new(Font::load(self.src, font_dict).await);
+            return match key {
+                Some(r) => self.remember(r, loaded),
+                None => loaded,
+            };
+        }
+        self.fallback.clone()
+    }
+
+    /// An already-loaded font for the dictionary `r` refers to, if any walk
+    /// of this document has loaded it.
+    fn hit(&mut self, r: ObjRef) -> Option<Arc<Font>> {
+        if let Some(f) = self.loaded.get(&r) {
+            return Some(f.clone());
+        }
+        let f = self.shared?.get(r)?;
+        self.loaded.insert(r, f.clone());
+        Some(f)
+    }
+
+    /// Records a freshly loaded font under its dictionary's reference, in
+    /// this walk's cache and in the document-wide one when present.
+    fn remember(&mut self, r: ObjRef, font: Arc<Font>) -> Arc<Font> {
+        let font = match self.shared {
+            Some(shared) => shared.insert(r, font),
+            None => font,
+        };
+        self.loaded.insert(r, font.clone());
+        font
     }
 
     /// Executes an operator stream and every form XObject it invokes.
@@ -858,14 +964,15 @@ mod tests {
     /// asserts on exactly what a synchronous caller receives. The report is
     /// asserted complete: no test here expects to lose content.
     fn page_spans(doc: &Document, page: &Page) -> Vec<TextSpan> {
-        let (spans, _, report) = block_on(page_spans_and_rulings_with(Immediate(doc), page));
+        let (spans, _, report) = block_on(page_spans_and_rulings_with(Immediate(doc), page, None));
         assert!(report.is_complete(), "unexpected skips: {report:?}");
         spans
     }
 
     /// The synchronous rulings accessor, the twin of [`page_spans`].
     fn page_rulings(doc: &Document, page: &Page) -> Vec<Ruling> {
-        let (_, rulings, report) = block_on(page_spans_and_rulings_with(Immediate(doc), page));
+        let (_, rulings, report) =
+            block_on(page_spans_and_rulings_with(Immediate(doc), page, None));
         assert!(report.is_complete(), "unexpected skips: {report:?}");
         rulings
     }
@@ -994,7 +1101,8 @@ mod tests {
         let page = doc.page(0).unwrap();
         // Raw call: exhausting the budget is this test's point, so the
         // report is legitimately incomplete here.
-        let (spans, _, report) = block_on(page_spans_and_rulings_with(Immediate(&doc), &page));
+        let (spans, _, report) =
+            block_on(page_spans_and_rulings_with(Immediate(&doc), &page, None));
         assert!(!spans.is_empty()); // nested forms still extract text
         assert!(
             spans.len() <= MAX_FORM_INVOCATIONS,
@@ -1073,13 +1181,66 @@ mod tests {
     /// Nothing in this crate has interior mutability, so this holds as soon as
     /// the handle is an `Arc`. The assertion exists to stop a later `Rc` or
     /// `RefCell` taking it away silently — which is exactly how the renderer's
-    /// glyph cache came to block a spawnable future.
+    /// glyph cache came to block a spawnable future. [`FontCache`] is on the
+    /// list because one instance serves every worker of a parallel page walk.
     #[test]
     fn loaded_fonts_are_shareable_across_threads() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<Font>();
         assert_send_sync::<Arc<Font>>();
         assert_send_sync::<GState>();
+        assert_send_sync::<FontCache>();
+    }
+
+    /// `/F1` in a form's own resources and `/F1` in the page resources are
+    /// different fonts: the name→font binding is resource-scoped (ISO 32000
+    /// §7.8.3). The loaded-font cache is keyed by the font dictionary's
+    /// object reference, never by name — a cache keyed by name would hand
+    /// the form the page's font and fail this test.
+    #[test]
+    fn same_name_binds_a_different_font_per_resource_scope() {
+        use pdfboss_testkit::PdfBuilder;
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> /XObject << /Fx 6 0 R >> >> \
+             /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td (aa) Tj ET /Fx Do");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding /FirstChar 97 /LastChar 97 /Widths [500] >>",
+        );
+        b.stream(
+            6,
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] \
+             /Resources << /Font << /F1 7 0 R >> >>",
+            b"BT /F1 12 Tf 72 700 Td (aa) Tj ET",
+        );
+        b.object(
+            7,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding /FirstChar 97 /LastChar 97 /Widths [1000] >>",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = page_spans(&doc, &page);
+        assert_eq!(spans.len(), 2);
+        let advance = |s: &TextSpan| s.end_x - s.x;
+        assert!(
+            (advance(&spans[0]) - 12.0).abs() < 1e-3,
+            "page scope must use the 500-width font: {}",
+            advance(&spans[0])
+        );
+        assert!(
+            (advance(&spans[1]) - 24.0).abs() < 1e-3,
+            "form scope must use the 1000-width font: {}",
+            advance(&spans[1])
+        );
     }
 
     /// A stroked 2x2 grid: the `re` contributes its four border edges in

--- a/crates/pdfboss-text/src/lib.rs
+++ b/crates/pdfboss-text/src/lib.rs
@@ -8,7 +8,7 @@ mod sfnt;
 
 use pdfboss_core::{block_on, AsyncObjectSource, Document, Immediate, Page, Result};
 
-pub use extract::{ExtractReport, SkipCause, SkippedText, SkippedTextKind};
+pub use extract::{ExtractReport, FontCache, SkipCause, SkippedText, SkippedTextKind};
 pub use pdfboss_core::Point;
 
 /// A positioned run of extracted text.
@@ -78,7 +78,7 @@ pub async fn extract_spans_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
 ) -> Result<Vec<TextSpan>> {
-    let (spans, _, _) = extract::page_spans_and_rulings_with(src, page).await;
+    let (spans, _, _) = extract::page_spans_and_rulings_with(src, page, None).await;
     Ok(spans)
 }
 
@@ -100,7 +100,40 @@ pub async fn extract_spans_reporting_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
 ) -> Result<(Vec<TextSpan>, ExtractReport)> {
-    let (spans, _, report) = extract::page_spans_and_rulings_with(src, page).await;
+    let (spans, _, report) = extract::page_spans_and_rulings_with(src, page, None).await;
+    Ok((spans, report))
+}
+
+/// [`extract_spans_reporting`] with fonts cached across calls: a caller
+/// walking a whole document passes one [`FontCache`] to every page, and each
+/// font dictionary — descriptor, widths, encoding, ToUnicode and font-program
+/// parsing included — loads once for the document instead of once per page.
+/// The cache is `Send + Sync`, so a parallel page walk may share it.
+///
+/// The result is identical to calling [`extract_spans_reporting`] per page:
+/// the cache is keyed by each font dictionary's object reference, never by
+/// its resource name, and a reference resolves to the same dictionary on
+/// every page of a document.
+pub fn extract_spans_reporting_cached(
+    doc: &Document,
+    page: &Page,
+    fonts: &FontCache,
+) -> Result<(Vec<TextSpan>, ExtractReport)> {
+    block_on(extract_spans_reporting_cached_with(
+        Immediate(doc),
+        page,
+        fonts,
+    ))
+}
+
+/// [`extract_spans_reporting_cached`] against any object source. Signed like
+/// [`extract_spans_with`], for the same reasons.
+pub async fn extract_spans_reporting_cached_with<S: AsyncObjectSource>(
+    src: S,
+    page: &Page,
+    fonts: &FontCache,
+) -> Result<(Vec<TextSpan>, ExtractReport)> {
+    let (spans, _, report) = extract::page_spans_and_rulings_with(src, page, Some(fonts)).await;
     Ok((spans, report))
 }
 
@@ -124,7 +157,37 @@ pub async fn extract_spans_and_rulings_reporting_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
 ) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
-    let (spans, rulings, report) = extract::page_spans_and_rulings_with(src, page).await;
+    let (spans, rulings, report) = extract::page_spans_and_rulings_with(src, page, None).await;
+    Ok((spans, rulings, report))
+}
+
+/// [`extract_spans_and_rulings_reporting`] with fonts cached across calls —
+/// the rulings twin of [`extract_spans_reporting_cached`], for a caller
+/// walking a whole document page by page. Spans, rulings, and report are
+/// identical to the uncached call's, for the same reason: the cache is keyed
+/// by each font dictionary's object reference, never by its resource name,
+/// and rulings never touch fonts at all.
+pub fn extract_spans_and_rulings_reporting_cached(
+    doc: &Document,
+    page: &Page,
+    fonts: &FontCache,
+) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
+    block_on(extract_spans_and_rulings_reporting_cached_with(
+        Immediate(doc),
+        page,
+        fonts,
+    ))
+}
+
+/// [`extract_spans_and_rulings_reporting_cached`] against any object source.
+/// Signed like [`extract_spans_with`], for the same reasons.
+pub async fn extract_spans_and_rulings_reporting_cached_with<S: AsyncObjectSource>(
+    src: S,
+    page: &Page,
+    fonts: &FontCache,
+) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
+    let (spans, rulings, report) =
+        extract::page_spans_and_rulings_with(src, page, Some(fonts)).await;
     Ok((spans, rulings, report))
 }
 
@@ -319,6 +382,185 @@ mod tests {
         let page = doc.page(0).unwrap();
         let spans = extract_spans(&doc, &page).unwrap();
         assert!(spans[0].bold && spans[0].italic);
+    }
+
+    /// An asynchronous source that counts each reference resolution by
+    /// object number and delegates to the document. Loading a font resolves
+    /// its dictionary's reference exactly once, so the count makes cache
+    /// hits observable without any instrumentation in the production code.
+    struct Counting<'a> {
+        inner: Immediate<&'a Document>,
+        resolutions: std::cell::RefCell<std::collections::HashMap<u32, usize>>,
+    }
+
+    impl<'a> Counting<'a> {
+        fn new(doc: &'a Document) -> Counting<'a> {
+            Counting {
+                inner: Immediate(doc),
+                resolutions: std::cell::RefCell::new(std::collections::HashMap::new()),
+            }
+        }
+
+        fn resolutions(&self, num: u32) -> usize {
+            self.resolutions.borrow().get(&num).copied().unwrap_or(0)
+        }
+    }
+
+    impl AsyncObjectSource for Counting<'_> {
+        fn get(&self, r: ObjRef) -> BoxFuture<'_, Result<Object>> {
+            self.inner.get(r)
+        }
+
+        fn stream_data<'b>(&'b self, s: &'b Stream) -> BoxFuture<'b, Result<Vec<u8>>> {
+            self.inner.stream_data(s)
+        }
+
+        fn resolve<'b>(&'b self, o: &'b Object) -> BoxFuture<'b, Result<Object>> {
+            if let Object::Ref(r) = o {
+                *self.resolutions.borrow_mut().entry(r.num).or_insert(0) += 1;
+            }
+            self.inner.resolve(o)
+        }
+    }
+
+    /// Two invocations of the same form used to load the form's font twice:
+    /// every invocation started with an empty font map. The walk-level cache
+    /// (no [`FontCache`] involved) must fetch the font dictionary once.
+    #[test]
+    fn a_font_reached_from_repeated_forms_loads_once_per_page() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /XObject << /Fx 6 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"/Fx Do /Fx Do");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        b.stream(
+            6,
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >>",
+            b"BT /F1 12 Tf 72 700 Td (x) Tj ET",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let counting = Counting::new(&doc);
+        let (spans, report) = block_on(extract_spans_reporting_with(&counting, &page)).unwrap();
+        assert!(report.is_complete(), "unexpected skips: {report:?}");
+        assert_eq!(spans.len(), 2, "both form invocations must show text");
+        assert_eq!(
+            counting.resolutions(5),
+            1,
+            "one font dictionary resolution per page walk"
+        );
+    }
+
+    /// A two-page document whose pages bind the same font dictionary: with
+    /// one [`FontCache`] passed to both extractions the dictionary is
+    /// fetched once, and the spans are exactly the uncached call's.
+    #[test]
+    fn a_font_shared_across_pages_loads_once_per_document() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 7 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td (one) Tj ET");
+        b.object(
+            5,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 7 0 R >> >> /Contents 6 0 R >>",
+        );
+        b.stream(6, "", b"BT /F1 12 Tf 72 720 Td (two) Tj ET");
+        b.object(
+            7,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let fonts = FontCache::default();
+        let counting = Counting::new(&doc);
+        let mut cached = Vec::new();
+        for index in 0..2 {
+            let page = doc.page(index).unwrap();
+            let (spans, report) = block_on(extract_spans_reporting_cached_with(
+                &counting, &page, &fonts,
+            ))
+            .unwrap();
+            assert!(report.is_complete(), "unexpected skips: {report:?}");
+            cached.push(spans);
+        }
+        assert_eq!(
+            counting.resolutions(7),
+            1,
+            "one font dictionary resolution per document"
+        );
+        for (index, spans) in cached.iter().enumerate() {
+            let page = doc.page(index).unwrap();
+            let plain = extract_spans_reporting(&doc, &page).unwrap().0;
+            assert_eq!(spans, &plain, "page {index} must extract identically");
+        }
+    }
+
+    /// `/F1` on one page and `/F1` on the next may be different fonts: the
+    /// shared cache is keyed by the font dictionary's object reference, so
+    /// each page keeps its own binding. A cache keyed by resource name would
+    /// hand page two the font of page one and fail here.
+    #[test]
+    fn a_shared_cache_keeps_the_name_binding_per_page() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 7 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td (aa) Tj ET");
+        b.object(
+            5,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 8 0 R >> >> /Contents 6 0 R >>",
+        );
+        b.stream(6, "", b"BT /F1 12 Tf 72 720 Td (aa) Tj ET");
+        b.object(
+            7,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding /FirstChar 97 /LastChar 97 /Widths [500] >>",
+        );
+        b.object(
+            8,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding /FirstChar 97 /LastChar 97 /Widths [1000] >>",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let fonts = FontCache::default();
+        let mut advances = Vec::new();
+        for index in 0..2 {
+            let page = doc.page(index).unwrap();
+            let (spans, _) = extract_spans_reporting_cached(&doc, &page, &fonts).unwrap();
+            assert_eq!(spans.len(), 1);
+            advances.push(spans[0].end_x - spans[0].x);
+        }
+        assert!(
+            (advances[0] - 12.0).abs() < 1e-3,
+            "page one: {}",
+            advances[0]
+        );
+        assert!(
+            (advances[1] - 24.0).abs() < 1e-3,
+            "page two: {}",
+            advances[1]
+        );
     }
 
     /// An asynchronous source that answers everything with `null`.


### PR DESCRIPTION
Speeds up text and markdown extraction with provably unchanged output. Five commits, measured in three gated stages and adversarially reviewed under a zero-quality-loss gate: byte-identical output (stdout/stderr sha256 + exit code per document) across the 200-doc opendataloader corpus, `file.pdf`, and a multi-page ba-qa sample — verified against fresh origin/main builds at every stage, plus the full workspace suite (1609 tests, 36 suites).

**What changed:**

1. **Lexer numeric fast path** — numeric tokens skip the redundant UTF-8 validation and full `dec2flt` machinery when a u64-mantissa/small-exponent path is provably exact; anything else falls back to std. Guarded by an 829-case differential fuzz test against std parsing, compared at f64 *and* after the f32 cast (zero guard tightenings needed).
2. **ToUnicode on FxHash** — per-glyph SipHash lookups replaced with the project's `FastMap`; last-insert-wins on duplicate CMap keys preserved and tested.
3. **Inflate buffer pre-sizing** — output starts at 4× compressed (typical PDF expansion) instead of 2×; the 1024 floor and 4 MiB hostile-stream cap are unchanged.
4. **Font caching across pages and forms** — a walk-level cache kills per-form font re-parsing (zero API change), plus an opt-in document-level `FontCache` keyed by font-dict ObjRef (never by resource name — collision tests bind `/F1` to different fonts in page and form scopes), threaded through additive `*_cached` entry points into the doc-level CLI/Python/markdown paths.
5. **Content-parsing allocation churn** — keywords borrowed instead of owned, operand stacks consumed instead of cloned, one emit-driven parse pass instead of two, pre-sized op vectors, memchr-gated single-pass literal strings. Public `Token`/`Op` shapes unchanged.

**Measured** (in-process whole-corpus passes, prebuilt binaries interleaved in single sessions, noise floor quantified first; commit bodies carry the per-round tables). Commits 1–3 were one combined keep decision — individually they sit inside the noise floor:

| stage | text | markdown |
|---|---|---|
| lexer + hashing + inflate (combined) | −8.3% | −8.2% |
| font cache (multi-page ba-qa workloads) | +6–11% | +6–9% |
| allocation churn | −6.5% | −6.2% |

The two corpus-wide deltas were certified in separate sessions on this machine, where absolute times are not comparable across sessions; multiplied, they give **~−14% combined on the single-page corpus**, with the font-cache win coming on top for multi-page documents. A sixth candidate (`Document::get` clone sharing) was implemented, reviewed safe, measured at ≤1.4% with negative rounds — and dropped: no measurable win, no ship.

The allocation-churn commit initially failed the strict every-round-beats-max-floor rule on one 1.87% round despite winning 18/18 rounds; a diagnostic showed this machine's same-binary spread reaches 5.7% even at 95% idle. It was re-landed under a pre-registered paired-difference protocol (≥14/16 positive rounds and median > 3× the null median, both modes) and passed 32/32 with margins 4–5× the threshold.