### PR TITLE
docs: close the README's benchmark and staleness gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Against other Python PDF libraries over 40 real-world PDFs (best-of-3 per file, 
   <img src="https://raw.githubusercontent.com/4thel00z/pdfboss/main/benchmarks/results.png" alt="pdfboss vs. Python PDF libraries" width="100%">
 </p>
 
-**pdfboss is the fastest library measured on both operations, including against the C-backed PyMuPDF.** On text extraction it reaches 9,000 pages/s. PyMuPDF reaches 449 (about 20×), and the pure-Python readers are 95× to 500× slower. Since 0.9.0, `doc.extract_text()` spreads pages across cores, which widened the gap over the sequential libraries from the 7× measured before that landed. On open + parse it reaches 357,000 pages/s against PyMuPDF's 99,000 (about 3.6×). Lazy page-tree loading means opening a document reads only its declared page count instead of parsing every page dictionary up front. Opening is close to free, so the ratio says more about what the others do eagerly than about pdfboss. Rendering is not compared on this corpus. A few faces still go unpainted (see Limitations), and timing pdfboss against full renderers would credit it for work it skipped. The scanned-document benchmark below is the render comparison, and it is fair because a scan has no glyphs in it.
+**pdfboss is the fastest library measured on both operations, including against the C-backed PyMuPDF.** On text extraction it reaches 9,000 pages/s. PyMuPDF reaches 449 (about 20×), and the pure-Python readers are 95× to 500× slower. Since 0.9.0, `doc.extract_text()` spreads pages across cores, which widened the gap over the sequential libraries from the 7× measured before that landed. On open + parse it reaches 357,000 pages/s against PyMuPDF's 99,000 (about 3.6×). Lazy page-tree loading means opening a document reads only its declared page count instead of parsing every page dictionary up front. Opening is close to free, so the ratio says more about what the others do eagerly than about pdfboss. Rendering is compared in its own section below, restricted to the files pdfboss provably rasterizes completely — timing it against full renderers on the rest would credit it for work it skips.
 
 Numbers are machine-dependent; reproduce with [`benchmarks/bench.py`](benchmarks/README.md).
 
@@ -143,6 +143,21 @@ Speed without fidelity is worthless, so extraction quality is measured too. The 
 pdfboss reads the whole corpus in about a seventh of a second in either mode. That is over 3× faster than the fastest competing Markdown engine measured on the same machine. Its reading-order score sits in the middle of the field: per document, the plain-text output beats pdf-inspector's NID on 105 of the 200 files, ties on 23 and loses on 72. The losses concentrate in table regions, where structured output matches the ground truth more closely than flowed text can. On the benchmark's combined metric the Markdown adapter scores 0.801 (reading order 0.877, headings and lists 0.667, table structure 0.532). It detects tables from column gaps and from drawn borders, so bordered grids and boxed lists without column gaps are found too. Two-column layouts are read column-major. Justified text keeps its word spacing. Ligatures and small-caps variants decode through the full Adobe Glyph List conventions.
 
 Quality rows come from the benchmark's own evaluator over all 200 documents. The two pdfboss timings were measured together in one session on an Apple M3 Pro under the benchmark's protocol: median of five single-process runs after a warm-up, wheel built from main. pdf-inspector was measured the same way on the same machine in an earlier session. The other engines' timings are the ones [published with the corpus](https://github.com/firecrawl/opendataloader-bench/tree/abi/pdf-parser-benchmark-results) from an Apple M4 Pro. Read them as order-of-magnitude context, not a same-machine race.
+
+### Rendering
+
+A renderer that skips work looks fast, and pdfboss does not paint everything yet. So the render benchmark certifies every file before the stopwatch starts: pdfboss rasterizes each page through `render_reporting` at the `full` fonts tier — substituting non-embedded fonts, which is what the other engines do by default — and a file where any page reports dropped or approximated content is excluded, with its reason printed and counted. A second gate renders each file's first page in every library and excludes files whose ink coverage disagrees, which catches work skipped without a report: a blank page renders instantly and means nothing. Of the 40-file sample above, 33 files (660 pages) certify. The exclusions were three files with annotation appearances, one with tiling patterns — both Limitations items, counted on a real corpus — and three whose fonts lack a glyph for a code the page draws.
+
+| Library | pages/sec |
+|---|--:|
+| pypdfium2 | 121.7 |
+| pdfplumber (via pdfium) | 103.3 |
+| pdfboss | 98.2 |
+| PyMuPDF | 89.5 |
+
+pdfboss rasterizes the mixed corpus inside the C-backed field: about 24% behind pdfium, 10% ahead of PyMuPDF, with no C in it. Compare the rows against each other, not against another machine's numbers. Across three back-to-back passes every library repeated within 1.3% and the ordering never moved.
+
+Reproduce with [`benchmarks/bench_render.py`](benchmarks/README.md).
 
 ### Scanned documents
 

--- a/README.md
+++ b/README.md
@@ -196,8 +196,6 @@ Not yet supported (they error or degrade gracefully, and are on the roadmap): pa
 
 Rendering is lenient: content pdfboss cannot read is skipped so the rest of the page still rasterizes. It says so rather than passing the result off as a faithful render. `pdfboss render` prints a warning line per dropped item on stderr and annotates its summary. The TUI preview raises a status-bar notice. The libraries expose the detail through `render_page_reporting` (Rust) and `Page.render_reporting()` (Python), which return the pixels plus a report of everything dropped or approximated.
 
-The sync and async APIs are not at parity on encryption. `Document`/`Page` (and the CLI's `info`/`text`/`md`/`render`/`obj`) decrypt empty-user-password RC4/AES files transparently, as above. `AsyncDocument` (`pdfboss tui`, any `http(s)://` target, and the Python `AsyncDocument`) currently rejects every encrypted document outright, real password or not. Async decryption parity is a tracked follow-up.
-
 ## Development
 
 ```bash

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,7 @@
 # Benchmarks
 
-Two scripts, because scanned PDFs and text PDFs are different workloads.
+Three scripts, because opening, rendering and scanned PDFs are different
+workloads.
 
 `bench.py` compares pdfboss against other Python PDF libraries on the two
 operations they all produce comparable output for:
@@ -8,26 +9,29 @@ operations they all produce comparable output for:
 - **Open + parse** — open the file and read its page count.
 - **Text extraction** — extract the text of every page.
 
-Rendering is **not** benchmarked there: pdfboss's rasterizer does not yet paint
-every glyph, so timing its incomplete output against full renderers would be
-misleading.
+`bench_render.py` compares rendering on the same corpus, but only on files it
+can prove fair. pdfboss does not yet paint everything (see the top-level
+README's Limitations), and timing a renderer that skipped work against full
+renderers would credit it for the skipping. So every sampled file is certified
+before the stopwatch starts, and the files that fail are excluded with their
+reasons printed — never silently.
 
-`bench_scans.py` benchmarks exactly what `bench.py` leaves out, on the one
-corpus where it is fair. A scanned page is a single full-page bilevel image —
-JBIG2 or CCITT G3/G4 — with no text operators, so there are no glyphs to paint
-and every library rasterizes the same picture.
+`bench_scans.py` benchmarks rendering where certification is unnecessary. A
+scanned page is a single full-page bilevel image — JBIG2 or CCITT G3/G4 — with
+no text operators, so there are no glyphs to paint and every library
+rasterizes the same picture.
 
 ## Libraries
 
-| Library | Open | Text | Scan | Notes |
-|---|:-:|:-:|:-:|---|
-| pdfboss | ✓ | ✓ | ✓ | this project (Rust) |
-| PyMuPDF | ✓ | ✓ | ✓ | C-backed |
-| pypdf | ✓ | ✓ | | pure Python; no rasterizer |
-| pdfplumber | ✓ | ✓ | ✓ | text via pdfminer.six, rasterizing via pdfium |
-| pypdfium2 | | | ✓ | pdfium bindings; no text API used here |
-| pdfminer.six | | ✓ | | pure Python |
-| pikepdf | ✓ | | | qpdf bindings; no text API |
+| Library | Open | Text | Render | Scan | Notes |
+|---|:-:|:-:|:-:|:-:|---|
+| pdfboss | ✓ | ✓ | ✓ | ✓ | this project (Rust) |
+| PyMuPDF | ✓ | ✓ | ✓ | ✓ | C-backed |
+| pypdf | ✓ | ✓ | | | pure Python; no rasterizer |
+| pdfplumber | ✓ | ✓ | ✓ | ✓ | text via pdfminer.six, rasterizing via pdfium |
+| pypdfium2 | | | ✓ | ✓ | pdfium bindings; no text API used here |
+| pdfminer.six | | ✓ | | | pure Python |
+| pikepdf | ✓ | | | | qpdf bindings; no text API |
 
 ## Method
 
@@ -38,6 +42,30 @@ and every library rasterizes the same picture.
   reported totals compare the exact same workload.
 - The headline metric is **pages per second** = (pages in the compared files) /
   (total time), which is independent of sample size.
+
+## Method — render
+
+- The same deterministic sample as `bench.py`.
+- **Certification** — pdfboss renders every page of every sampled file through
+  `render_reporting` at the `full` fonts tier, the tier that substitutes
+  non-embedded simple fonts the way the other engines do by default. Any page
+  reporting dropped or approximated content (an unpainted shading, a masked
+  image, an annotation appearance, a glyph a loaded font lacks) excludes the
+  file, and the exclusion reasons are printed and counted in the results.
+- **Ink agreement** — content a *refused or failed* font would have painted is
+  configured behavior, not a reported drop, so a second gate catches it: every
+  library renders each file's first page, and a file where any library's ink
+  coverage (percentage of dark pixels) falls outside a 2× band around the
+  cross-library median is excluded too. A blank page renders instantly and
+  means nothing. The band is wide because honest renders disagree: engines
+  differ on anti-aliasing weight, and where a non-embedded bold face is
+  substituted with a regular-weight one (a documented pdfboss approximation,
+  which the other engines also make with their own faces) the same text
+  carries visibly less ink.
+- What survives is timed like `bench.py`: every page to **PNG bytes** (PNG
+  encoding on every side), best-of-`--repeat` per file after one warm-up pass,
+  aggregated only over files every library handled, reported as **pages per
+  second**.
 
 ## Method — scans
 
@@ -56,13 +84,16 @@ and every library rasterizes the same picture.
 
 ```bash
 pip install pypdf pdfminer.six pdfplumber pikepdf pymupdf pypdfium2 pillow matplotlib
+pip install pdfboss-fonts               # substitute faces for bench_render.py's full tier
 maturin develop --release           # build pdfboss into the venv
-python benchmarks/bench.py       /path/to/pdfs --sample 40 --repeat 3
-python benchmarks/bench_scans.py /path/to/scan.pdf --pages 100 --repeat 3
+python benchmarks/bench.py        /path/to/pdfs --sample 40 --repeat 3
+python benchmarks/bench_render.py /path/to/pdfs --sample 40 --repeat 3
+python benchmarks/bench_scans.py  /path/to/scan.pdf --pages 100 --repeat 3
 ```
 
 `bench.py` writes `results.json` (raw numbers) and `results.png` (the chart
-shown in the top-level README); `bench_scans.py` writes `results-scans.json`.
+shown in the top-level README); `bench_render.py` writes
+`results-render.json`; `bench_scans.py` writes `results-scans.json`.
 Both datasets are local corpora of real-world PDFs and are not committed —
 `bench_scans.py` records the document's page count and geometry, never its
 name.

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -109,6 +109,8 @@ LIBS = {
 
 
 def sample_files(corpus, n):
+    if n <= 0:
+        raise SystemExit("--sample must be a positive number of files")
     files = sorted(glob.glob(os.path.join(corpus, "*.pdf")))
     if not files:
         raise SystemExit(f"no PDFs found in {corpus}")

--- a/benchmarks/bench_render.py
+++ b/benchmarks/bench_render.py
@@ -120,6 +120,8 @@ def sample_files(corpus, n):
     files = sorted(glob.glob(os.path.join(corpus, "*.pdf")))
     if not files:
         raise SystemExit(f"no PDFs found in {corpus}")
+    if n <= 0:
+        raise SystemExit("--sample must be >= 1")
     if n >= len(files):
         return files
     # Evenly spaced across the sorted corpus for a representative spread.

--- a/benchmarks/bench_render.py
+++ b/benchmarks/bench_render.py
@@ -115,6 +115,8 @@ INK_SLACK = 0.15
 
 
 def sample_files(corpus, n):
+    if n <= 0:
+        raise SystemExit("--sample must be a positive number of files")
     files = sorted(glob.glob(os.path.join(corpus, "*.pdf")))
     if not files:
         raise SystemExit(f"no PDFs found in {corpus}")
@@ -148,7 +150,7 @@ def certify(path, scale, fonts):
             # that do exist were all checked, so certify those.
             break
         try:
-            png, warnings = page.render_reporting(scale=scale, fonts=fonts)
+            warnings = page.render_reporting(scale=scale, fonts=fonts)[1]
         except Exception as exc:  # noqa: BLE001 - the message is the result
             return None, f"render failed: {type(exc).__name__}: {exc}"
         if warnings:

--- a/benchmarks/bench_render.py
+++ b/benchmarks/bench_render.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Benchmark pdfboss against other Python PDF libraries on page rendering.
+
+Timing a renderer is only fair when every side paints the same picture, and
+pdfboss does not paint everything yet (see the README's Limitations). So this
+script certifies each file before the stopwatch starts:
+
+- pdfboss renders every page through ``render_reporting`` at the ``full``
+  fonts tier — the tier that substitutes non-embedded simple fonts, which is
+  what the other engines do by default. A file where any page reports dropped
+  or approximated content (an unpainted shading, a masked image, an
+  annotation appearance, a glyph a loaded font lacks) is excluded, and the
+  exclusions are printed and counted. Nothing is dropped silently.
+- Content a *failed or refused* font would have painted is configured
+  behavior and not reported, so a second gate catches it: every library
+  renders the first page, and a file where the libraries' ink coverage
+  disagrees is excluded too. A blank page renders instantly and means
+  nothing.
+
+What survives is the corpus subset every engine rasterizes completely, and
+only that subset is timed: every page to PNG bytes, so PNG encoding is on
+every side of the comparison.
+
+Usage:
+    python benchmarks/bench_render.py /path/to/pdfs [--sample N] [--repeat K]
+                                      [--scale S] [--fonts TIER]
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import time
+import traceback
+
+
+# --- library adapters -------------------------------------------------------
+#
+# Each renders `indices` of `path` at `scale` and returns the PNG bytes of
+# every page. `fonts` is pdfboss's glyph-painting tier; the other libraries
+# have no such knob and ignore it.
+
+
+def pdfboss_render(path, indices, scale, fonts):
+    import pdfboss
+
+    doc = pdfboss.Document(path)
+    return [doc[i].render(scale=scale, fonts=fonts) for i in indices]
+
+
+def pymupdf_render(path, indices, scale, fonts):
+    import fitz
+
+    doc = fitz.open(path)
+    try:
+        matrix = fitz.Matrix(scale, scale)
+        return [doc[i].get_pixmap(matrix=matrix).tobytes("png") for i in indices]
+    finally:
+        doc.close()
+
+
+def pypdfium2_render(path, indices, scale, fonts):
+    import io
+
+    import pypdfium2
+
+    doc = pypdfium2.PdfDocument(path)
+    try:
+        out = []
+        for i in indices:
+            buf = io.BytesIO()
+            doc[i].render(scale=scale).to_pil().save(buf, format="PNG")
+            out.append(buf.getvalue())
+        return out
+    finally:
+        doc.close()
+
+
+def pdfplumber_render(path, indices, scale, fonts):
+    import io
+
+    import pdfplumber
+
+    # pdfplumber measures rasterization in DPI, not as a scale factor.
+    resolution = 72.0 * scale
+    with pdfplumber.open(path) as pdf:
+        out = []
+        for i in indices:
+            page = pdf.pages[i]
+            buf = io.BytesIO()
+            page.to_image(resolution=resolution).original.save(buf, format="PNG")
+            out.append(buf.getvalue())
+            page.close()
+        return out
+
+
+# Library display name -> renderer. Order controls report order.
+LIBS = {
+    "pdfboss": pdfboss_render,
+    "PyMuPDF": pymupdf_render,
+    "pypdfium2": pypdfium2_render,
+    "pdfplumber": pdfplumber_render,
+}
+
+# A file is excluded when any library's first-page ink coverage lands outside
+# [median / INK_BAND, median * INK_BAND] of the libraries' median — wide
+# enough for anti-aliasing and resampling differences, narrow enough to catch
+# a page that painted only part of its content. Deviations inside
+# INK_SLACK percentage points are ignored outright so near-blank pages do not
+# trip the ratio on noise.
+INK_BAND = 2.0
+INK_SLACK = 0.15
+
+
+def sample_files(corpus, n):
+    files = sorted(glob.glob(os.path.join(corpus, "*.pdf")))
+    if not files:
+        raise SystemExit(f"no PDFs found in {corpus}")
+    if n >= len(files):
+        return files
+    # Evenly spaced across the sorted corpus for a representative spread.
+    step = len(files) / n
+    return [files[int(i * step)] for i in range(n)]
+
+
+def certify(path, scale, fonts):
+    """The file's renderable page indices, or the reason it cannot be timed.
+
+    Returns ``(indices, None)`` when pdfboss rasterized every page with an
+    empty report, and ``(None, reason)`` otherwise. The reason keeps the
+    report's own wording, so the exclusion tally names what pdfboss cannot
+    paint rather than hiding it.
+    """
+    import pdfboss
+
+    try:
+        doc = pdfboss.Document(path)
+    except Exception as exc:  # noqa: BLE001 - the message is the result
+        return None, f"unreadable: {type(exc).__name__}: {exc}"
+    indices = []
+    for i in range(doc.page_count):
+        try:
+            page = doc[i]
+        except Exception:
+            # A damaged file can declare more pages than it holds; the pages
+            # that do exist were all checked, so certify those.
+            break
+        try:
+            png, warnings = page.render_reporting(scale=scale, fonts=fonts)
+        except Exception as exc:  # noqa: BLE001 - the message is the result
+            return None, f"render failed: {type(exc).__name__}: {exc}"
+        if warnings:
+            return None, warnings[0]
+        indices.append(i)
+    if not indices:
+        return None, "no pages"
+    return indices, None
+
+
+def ink(png):
+    """Percentage of dark pixels in a rendered page, or None without PIL."""
+    try:
+        import io
+
+        from PIL import Image
+    except ImportError:
+        return None
+    gray = Image.open(io.BytesIO(png)).convert("L").tobytes()
+    return 100.0 * sum(1 for v in gray if v < 128) / len(gray)
+
+
+def ink_agreement(path, scale, fonts):
+    """Whether every library's first-page render holds the same ink, roughly.
+
+    Returns ``None`` on agreement, else a one-line reason naming the odd one
+    out. A library that raises here is left for the timing pass to exclude
+    via the common-file intersection; this gate only compares the renders
+    that exist.
+    """
+    coverage = {}
+    for name, fn in LIBS.items():
+        try:
+            pages = fn(path, [0], scale, fonts)
+        except Exception:
+            continue
+        pct = ink(pages[0])
+        if pct is not None:
+            coverage[name] = pct
+    if len(coverage) < 2:
+        return None
+    values = sorted(coverage.values())
+    median = values[len(values) // 2]
+    for name, pct in coverage.items():
+        if abs(pct - median) <= INK_SLACK:
+            continue
+        if median > 0 and median / INK_BAND <= pct <= median * INK_BAND:
+            continue
+        return (
+            f"renders disagree: {name} ink {pct:.2f}% vs median {median:.2f}%"
+        )
+    return None
+
+
+def time_one(fn, path, indices, scale, fonts, repeat):
+    """Best-of-`repeat` wall time, or None if the library raised."""
+    best = None
+    for _ in range(repeat):
+        start = time.perf_counter()
+        try:
+            fn(path, indices, scale, fonts)
+        except Exception:
+            return None
+        elapsed = time.perf_counter() - start
+        if best is None or elapsed < best:
+            best = elapsed
+    return best
+
+
+def run(corpus, sample_n, repeat, scale, fonts):
+    files = sample_files(corpus, sample_n)
+
+    # Certification: only files every engine rasterizes completely are timed.
+    certified = {}
+    excluded = {}
+    for f in files:
+        indices, reason = certify(f, scale, fonts)
+        if reason is None:
+            reason = ink_agreement(f, scale, fonts)
+        if reason is not None:
+            excluded[f] = reason
+            continue
+        certified[f] = indices
+    print(
+        f"[certify] {len(certified)} of {len(files)} sampled files rasterize"
+        f" completely at fonts={fonts}; {len(excluded)} excluded:"
+    )
+    for f, reason in excluded.items():
+        print(f"    {os.path.basename(f):20} {reason}")
+    if not certified:
+        raise SystemExit("no file passed certification; nothing to time")
+
+    # Warm the OS file cache and every import before the timed passes.
+    for fn in LIBS.values():
+        for f, indices in certified.items():
+            try:
+                fn(f, indices, scale, fonts)
+            except Exception:
+                pass
+
+    # Time each file, then keep only files EVERY library handled, so the
+    # aggregate compares the same workload.
+    timings = {name: {} for name in LIBS}
+    for f, indices in certified.items():
+        for name, fn in LIBS.items():
+            t = time_one(fn, f, indices, scale, fonts, repeat)
+            if t is not None:
+                timings[name][f] = t
+    common = set(certified)
+    for name in LIBS:
+        common &= set(timings[name])
+
+    libraries = {}
+    for name in LIBS:
+        total = sum(timings[name][f] for f in common)
+        pages = sum(len(certified[f]) for f in common)
+        libraries[name] = {"time": total, "pages": pages, "ok": len(common)}
+
+    # Tally exclusions by their leading words only ("2 shadings skipped:
+    # ..." -> "shading skipped", depluralized so counts merge) and record no
+    # file names: the corpus is not public.
+    reasons = {}
+    for reason in excluded.values():
+        key = reason.split(":")[0].lstrip("0123456789 ")
+        if key.endswith("s skipped"):
+            key = key.removesuffix("s skipped") + " skipped"
+        reasons[key] = reasons.get(key, 0) + 1
+    results = {
+        "corpus": os.path.basename(corpus.rstrip("/")),
+        "files_sampled": len(files),
+        "files_certified": len(certified),
+        "files_compared": len(common),
+        "excluded": reasons,
+        "scale": scale,
+        "fonts": fonts,
+        "repeat": repeat,
+        "libraries": libraries,
+    }
+    print(f"[render] {len(common)} files at scale {scale}")
+    for name, r in sorted(libraries.items(), key=lambda kv: kv[1]["time"] or 1e9):
+        pps = r["pages"] / r["time"] if r["time"] else 0
+        print(f"    {name:14} {r['time']:8.3f}s   {pps:9.1f} pages/s")
+    return results
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("corpus", help="directory of .pdf files")
+    ap.add_argument("--sample", type=int, default=40, help="files to sample")
+    ap.add_argument("--repeat", type=int, default=3, help="best-of-N per file")
+    ap.add_argument("--scale", type=float, default=1.0, help="render scale factor")
+    ap.add_argument(
+        "--fonts",
+        default="full",
+        choices=("embedded-only", "all-embedded", "full"),
+        help="pdfboss glyph-painting tier (full = substitute like the others)",
+    )
+    args = ap.parse_args()
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    results = run(args.corpus, args.sample, args.repeat, args.scale, args.fonts)
+    out = os.path.join(here, "results-render.json")
+    with open(out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        traceback.print_exc()

--- a/benchmarks/quality/README.md
+++ b/benchmarks/quality/README.md
@@ -36,14 +36,14 @@ cp /path/to/pdfboss/benchmarks/quality/pdf_parser_pdfboss*.py src/
 ```
 
 Then register them in `src/engine_registry.py`: add both engines to
-`ENGINES` (the value is the version, `python -c "import pdfboss;
+`ENGINES` (the value is your installed version, `python -c "import pdfboss;
 print(pdfboss.__version__)"`), and their modules to `_ENGINE_MODULES`:
 
 ```python
 ENGINES: Dict[str, str] = {
     ...
-    "pdfboss": "0.15.0",
-    "pdfboss-text": "0.15.0",
+    "pdfboss": "X.Y.Z",
+    "pdfboss-text": "X.Y.Z",
 }
 
 _ENGINE_MODULES: Dict[str, str] = {

--- a/benchmarks/quality/README.md
+++ b/benchmarks/quality/README.md
@@ -1,0 +1,74 @@
+# Extraction quality
+
+The top-level README's quality table comes from
+[opendataloader-bench](https://github.com/opendataloader-project/opendataloader-bench),
+a 200-document corpus with ground-truth Markdown and an evaluator that scores
+reading order (NID), heading structure (MHS) and table structure (TEDS).
+The corpus and evaluator live in that repository; this directory holds the
+two pdfboss adapters and the recipe that reproduces the table's pdfboss rows.
+
+## Setup
+
+Clone the benchmark's results branch sparsely — the corpus, ground truth and
+evaluator, without the accumulated prediction history:
+
+```bash
+git clone --depth 1 --branch abi/pdf-parser-benchmark-results --filter=blob:none \
+    --sparse https://github.com/firecrawl/opendataloader-bench.git
+cd opendataloader-bench
+git sparse-checkout set src pdfs ground-truth
+```
+
+Create a venv with the evaluator's needs and a **release** pdfboss wheel.
+Skip the repo's own `uv sync` — it pulls the OCR engines' full ML stack:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install rapidfuzz lxml apted beautifulsoup4 py-cpuinfo pdfboss
+```
+
+## Register the engines
+
+Copy the two adapters next to the runner:
+
+```bash
+cp /path/to/pdfboss/benchmarks/quality/pdf_parser_pdfboss*.py src/
+```
+
+Then register them in `src/engine_registry.py`: add both engines to
+`ENGINES` (the value is the version, `python -c "import pdfboss;
+print(pdfboss.__version__)"`), and their modules to `_ENGINE_MODULES`:
+
+```python
+ENGINES: Dict[str, str] = {
+    ...
+    "pdfboss": "0.15.0",
+    "pdfboss-text": "0.15.0",
+}
+
+_ENGINE_MODULES: Dict[str, str] = {
+    ...
+    "pdfboss": "pdf_parser_pdfboss",
+    "pdfboss-text": "pdf_parser_pdfboss_text",
+}
+```
+
+## Run
+
+```bash
+cd src
+python pdf_parser.py --engine pdfboss        # writes prediction/pdfboss/markdown/
+python pdf_parser.py --engine pdfboss-text
+python evaluator.py  --engine pdfboss        # writes prediction/pdfboss/evaluation.json
+python evaluator.py  --engine pdfboss-text
+```
+
+`evaluation.json` carries the per-document and aggregate scores; the README
+table's NID column is its reading-order aggregate. `pdf_parser.py` also
+writes a `summary.json` with the wall-clock time per engine — the README's
+timing protocol is the median of five such runs after a warm-up, single
+process, on an otherwise idle machine.
+
+The plain-text engine is scored as if its output were Markdown, so it earns
+nothing on headings or tables; NID is the one number that means something
+for it, and that is how the README table presents it.

--- a/benchmarks/quality/pdf_parser_pdfboss.py
+++ b/benchmarks/quality/pdf_parser_pdfboss.py
@@ -1,0 +1,17 @@
+"""pdfboss Markdown adapter for the opendataloader-bench runner.
+
+Copy this file into the benchmark's ``src/`` directory and register the
+engine as described in this directory's README.
+"""
+
+from pathlib import Path
+
+import pdfboss
+
+
+def to_markdown(doc_paths, input_path, output_dir):
+    output_dir = Path(output_dir)
+    for doc_path in doc_paths:
+        markdown = pdfboss.Document(str(doc_path)).extract_markdown()
+        output_file = output_dir / f"{Path(doc_path).stem}.md"
+        output_file.write_text(markdown, encoding="utf-8")

--- a/benchmarks/quality/pdf_parser_pdfboss.py
+++ b/benchmarks/quality/pdf_parser_pdfboss.py
@@ -11,6 +11,7 @@ import pdfboss
 
 def to_markdown(doc_paths, input_path, output_dir):
     output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
     for doc_path in doc_paths:
         markdown = pdfboss.Document(str(doc_path)).extract_markdown()
         output_file = output_dir / f"{Path(doc_path).stem}.md"

--- a/benchmarks/quality/pdf_parser_pdfboss_text.py
+++ b/benchmarks/quality/pdf_parser_pdfboss_text.py
@@ -13,6 +13,7 @@ import pdfboss
 
 def to_markdown(doc_paths, input_path, output_dir):
     output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
     for doc_path in doc_paths:
         text = pdfboss.Document(str(doc_path)).extract_text()
         output_file = output_dir / f"{Path(doc_path).stem}.md"

--- a/benchmarks/quality/pdf_parser_pdfboss_text.py
+++ b/benchmarks/quality/pdf_parser_pdfboss_text.py
@@ -1,0 +1,19 @@
+"""pdfboss plain-text adapter for the opendataloader-bench runner.
+
+The default `extract_text` output scored as if it were Markdown: it earns
+nothing on headings or table structure, so its only competitive number is
+NID, the reading-order metric. That is the second pdfboss row of the
+top-level README's quality table.
+"""
+
+from pathlib import Path
+
+import pdfboss
+
+
+def to_markdown(doc_paths, input_path, output_dir):
+    output_dir = Path(output_dir)
+    for doc_path in doc_paths:
+        text = pdfboss.Document(str(doc_path)).extract_text()
+        output_file = output_dir / f"{Path(doc_path).stem}.md"
+        output_file.write_text(text, encoding="utf-8")

--- a/benchmarks/results-render.json
+++ b/benchmarks/results-render.json
@@ -1,0 +1,36 @@
+{
+  "corpus": "pdfs",
+  "files_sampled": 40,
+  "files_certified": 33,
+  "files_compared": 33,
+  "excluded": {
+    "annotation skipped": 3,
+    "glyph skipped": 3,
+    "pattern skipped": 1
+  },
+  "scale": 1.0,
+  "fonts": "full",
+  "repeat": 3,
+  "libraries": {
+    "pdfboss": {
+      "time": 6.72020858500764,
+      "pages": 660,
+      "ok": 33
+    },
+    "PyMuPDF": {
+      "time": 7.372506789979525,
+      "pages": 660,
+      "ok": 33
+    },
+    "pypdfium2": {
+      "time": 5.42418058799376,
+      "pages": 660,
+      "ok": 33
+    },
+    "pdfplumber": {
+      "time": 6.388550789000874,
+      "pages": 660,
+      "ok": 33
+    }
+  }
+}


### PR DESCRIPTION
Three gaps the README itself declares, closed:

- **The missing render benchmark.** `benchmarks/bench_render.py` times rendering on the mixed corpus, but only after certifying each file: `render_reporting` at the `full` fonts tier must come back empty on every page, and every library's first-page ink coverage must agree (the backstop for drops the report is silent about — both gates verified in the fire direction). 33 of 40 sampled files certify; exclusions are printed and counted, never silent. Result over three back-to-back passes (each within 1.3%, ordering fixed): pdfium 121.7 / pdfplumber 103.3 / **pdfboss 98.2** / PyMuPDF 89.5 pages/s — inside the C-backed field with no C in it.
- **The quality table had no in-repo reproduction path.** `benchmarks/quality/` commits the two opendataloader-bench adapters plus the recipe. Verified end-to-end against the published wheel: markdown NID 0.877 / overall 0.801, plain-text NID 0.868 — the table's numbers exactly.
- **The async-encryption paragraph was stale.** Parity shipped in 0.14.0 (46bfbca); re-verified with RC4-R3/AES128-R4/AES256-R6 fixtures through both `Document` and `AsyncDocument` before deleting it.

The exclusion tally doubles as a roadmap signal: annotation appearances (3 files) and tiling patterns (1 file) are the next Limitations items worth closing — each grows the certified set.