### PR TITLE
docs: refresh the render benchmark after the paint gaps closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,16 +146,16 @@ Quality rows come from the benchmark's own evaluator over all 200 documents. The
 
 ### Rendering
 
-A renderer that skips work looks fast, and pdfboss does not paint everything yet. So the render benchmark certifies every file before the stopwatch starts: pdfboss rasterizes each page through `render_reporting` at the `full` fonts tier — substituting non-embedded fonts, which is what the other engines do by default — and a file where any page reports dropped or approximated content is excluded, with its reason printed and counted. A second gate renders each file's first page in every library and excludes files whose ink coverage disagrees, which catches work skipped without a report: a blank page renders instantly and means nothing. Of the 40-file sample above, 33 files (660 pages) certify. The exclusions were three files with annotation appearances, one with tiling patterns — both Limitations items, counted on a real corpus — and three whose fonts lack a glyph for a code the page draws.
+A renderer that skips work looks fast, and pdfboss does not paint everything yet. So the render benchmark certifies every file before the stopwatch starts: pdfboss rasterizes each page through `render_reporting` at the `full` fonts tier — substituting non-embedded fonts, which is what the other engines do by default — and a file where any page reports dropped or approximated content is excluded, with its reason printed and counted. A second gate renders each file's first page in every library and excludes files whose ink coverage disagrees, which catches work skipped without a report: a blank page renders instantly and means nothing. Of the 40-file sample above, 37 files (864 pages) certify. The three annotation-appearance files and the tiling-pattern file the earlier sample excluded now certify, leaving only three files whose fonts lack a glyph for a code the page draws.
 
 | Library | pages/sec |
 |---|--:|
-| pypdfium2 | 121.7 |
-| pdfplumber (via pdfium) | 103.3 |
-| pdfboss | 98.2 |
-| PyMuPDF | 89.5 |
+| pypdfium2 | 123.8 |
+| pdfplumber (via pdfium) | 103.1 |
+| pdfboss | 95.5 |
+| PyMuPDF | 91.9 |
 
-pdfboss rasterizes the mixed corpus inside the C-backed field: about 24% behind pdfium, 10% ahead of PyMuPDF, with no C in it. Compare the rows against each other, not against another machine's numbers. Across three back-to-back passes every library repeated within 1.3% and the ordering never moved.
+pdfboss rasterizes the mixed corpus inside the C-backed field: about 23% behind pdfium, 4% ahead of PyMuPDF, with no C in it — while painting the annotation and pattern pages the earlier sample had to exclude. Compare the rows against each other, not against another machine's numbers. Across three back-to-back passes every library repeated within 3.1% as ambient load shifted, the pdfboss-to-pdfium ratio held within 0.3%, and the ordering never moved.
 
 Reproduce with [`benchmarks/bench_render.py`](benchmarks/README.md).
 

--- a/benchmarks/results-render.json
+++ b/benchmarks/results-render.json
@@ -1,36 +1,34 @@
 {
   "corpus": "pdfs",
   "files_sampled": 40,
-  "files_certified": 33,
-  "files_compared": 33,
+  "files_certified": 37,
+  "files_compared": 37,
   "excluded": {
-    "annotation skipped": 3,
-    "glyph skipped": 3,
-    "pattern skipped": 1
+    "glyph skipped": 3
   },
   "scale": 1.0,
   "fonts": "full",
   "repeat": 3,
   "libraries": {
     "pdfboss": {
-      "time": 6.72020858500764,
-      "pages": 660,
-      "ok": 33
+      "time": 9.051422876960714,
+      "pages": 864,
+      "ok": 37
     },
     "PyMuPDF": {
-      "time": 7.372506789979525,
-      "pages": 660,
-      "ok": 33
+      "time": 9.402542333031306,
+      "pages": 864,
+      "ok": 37
     },
     "pypdfium2": {
-      "time": 5.42418058799376,
-      "pages": 660,
-      "ok": 33
+      "time": 6.981005289941095,
+      "pages": 864,
+      "ok": 37
     },
     "pdfplumber": {
-      "time": 6.388550789000874,
-      "pages": 660,
-      "ok": 33
+      "time": 8.376984704038478,
+      "pages": 864,
+      "ok": 37
     }
   }
 }


### PR DESCRIPTION
The one README refresh promised once the paint gaps landed. Re-run on the same 40-file sample, wheel built from main at 11313d3 (all of #35-#44 merged).

- Certification 33/40 → 37/40 (864 pages): the three annotation-appearance files and the tiling-pattern file now certify; the only exclusions left are the three glyph-gap files (Melior-Bold, DJOKGH+Carta, WPMathA).
- Table and results-render.json are the same pass. Across three back-to-back passes each library repeated within 3.1% under shifting ambient load, the pdfboss:pdfium ratio held within 0.3%, and the ordering (pdfium > pdfplumber > pdfboss > PyMuPDF) never moved.
- Scan and extraction sections untouched: the scan path was verified byte-identical during the mask PRs, and extraction is unaffected by render-only merges.