### PR TITLE
feat(render): configurable PNG encode compression

### DIFF
--- a/crates/pdfboss-cli/src/main.rs
+++ b/crates/pdfboss-cli/src/main.rs
@@ -117,6 +117,9 @@ enum Command {
         /// `pdfboss-fonts` package). Overrides the compiled-in OFL set.
         #[arg(long)]
         font_dir: Option<PathBuf>,
+        /// PNG compression: encode time against file size, same pixels.
+        #[arg(long, value_enum, default_value_t = PngCompressionArg::Default)]
+        png_compression: PngCompressionArg,
     },
     /// Pretty-print a single object.
     Obj {
@@ -242,6 +245,33 @@ impl FontsArg {
     }
 }
 
+/// `--png-compression` choices for `render`, mapping to
+/// `pdfboss_render::PngCompression`.
+#[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
+enum PngCompressionArg {
+    /// Uncompressed: fastest, largest files.
+    None,
+    /// Very fast with a decent ratio.
+    Fast,
+    /// Balances encode speed and file size (default).
+    #[default]
+    Default,
+    /// Smallest files, much slower.
+    Best,
+}
+
+impl PngCompressionArg {
+    fn to_compression(self) -> pdfboss_render::PngCompression {
+        use pdfboss_render::PngCompression;
+        match self {
+            PngCompressionArg::None => PngCompression::None,
+            PngCompressionArg::Fast => PngCompression::Fast,
+            PngCompressionArg::Default => PngCompression::Balanced,
+            PngCompressionArg::Best => PngCompression::Best,
+        }
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
     let result: Result<(), Failure> = match cli.command {
@@ -264,7 +294,18 @@ fn main() {
             fonts,
             font_dir,
             password,
-        } => cmd_render(&file, page, out, scale, fonts, font_dir, &password).map_err(Failure::from),
+            png_compression,
+        } => cmd_render(
+            &file,
+            page,
+            out,
+            scale,
+            fonts,
+            font_dir,
+            &password,
+            png_compression,
+        )
+        .map_err(Failure::from),
         Command::Obj {
             file,
             num,
@@ -540,6 +581,7 @@ fn substitute_source(
 }
 
 /// `pdfboss render`: rasterizes one page to a PNG file.
+#[allow(clippy::too_many_arguments)]
 fn cmd_render(
     file: &Path,
     page: usize,
@@ -548,6 +590,7 @@ fn cmd_render(
     fonts: FontsArg,
     font_dir: Option<PathBuf>,
     password: &str,
+    png_compression: PngCompressionArg,
 ) -> Result<(), String> {
     if !scale.is_finite() || scale <= 0.0 {
         return Err(format!("invalid scale {scale}: must be a positive number"));
@@ -563,7 +606,10 @@ fn cmd_render(
     let (pixmap, report) =
         pdfboss_render::render_page_reporting(&doc, &p, scale, &opts).map_err(|e| e.to_string())?;
     let out = out.unwrap_or_else(|| default_out(page));
-    pixmap.save_png(&out).map_err(|e| e.to_string())?;
+    let png = pixmap
+        .encode_png_with(png_compression.to_compression())
+        .map_err(|e| e.to_string())?;
+    std::fs::write(&out, png).map_err(|e| e.to_string())?;
     // Rendering is lenient, so a page whose content pdfboss could not read
     // still writes a PNG and still exits 0. Say what was lost, on stderr and
     // in the summary line, rather than reporting a clean render.
@@ -728,6 +774,59 @@ mod tests {
 
         let source = substitute_source(fonts, font_dir).expect("--font-dir given, always Ok");
         assert!(matches!(source, pdfboss_render::SubstituteSource::Dir(p) if p == Path::new("X")));
+    }
+
+    #[test]
+    fn png_compression_flag_defaults_to_default_level() {
+        let cli = Cli::parse_from(["pdfboss", "render", "in.pdf", "--page", "1"]);
+        let Command::Render {
+            png_compression, ..
+        } = cli.command
+        else {
+            panic!("expected render command");
+        };
+        assert!(matches!(png_compression, PngCompressionArg::Default));
+    }
+
+    #[test]
+    fn png_compression_flag_parses_every_level() {
+        for (value, expected) in [
+            ("none", pdfboss_render::PngCompression::None),
+            ("fast", pdfboss_render::PngCompression::Fast),
+            ("default", pdfboss_render::PngCompression::Balanced),
+            ("best", pdfboss_render::PngCompression::Best),
+        ] {
+            let cli = Cli::parse_from([
+                "pdfboss",
+                "render",
+                "in.pdf",
+                "--page",
+                "1",
+                "--png-compression",
+                value,
+            ]);
+            let Command::Render {
+                png_compression, ..
+            } = cli.command
+            else {
+                panic!("expected render command");
+            };
+            assert_eq!(png_compression.to_compression(), expected, "{value}");
+        }
+    }
+
+    #[test]
+    fn png_compression_flag_rejects_unknown_levels() {
+        let outcome = Cli::try_parse_from([
+            "pdfboss",
+            "render",
+            "in.pdf",
+            "--page",
+            "1",
+            "--png-compression",
+            "bogus",
+        ]);
+        assert!(outcome.is_err());
     }
 
     #[test]

--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -182,6 +182,21 @@ fn glyph_painting_from_str(s: &str) -> PyResult<pdfboss_render::GlyphPainting> {
     }
 }
 
+/// Maps the Python `compression=` string to a
+/// [`pdfboss_render::PngCompression`] level.
+fn png_compression_from_str(s: &str) -> PyResult<pdfboss_render::PngCompression> {
+    use pdfboss_render::PngCompression;
+    match s {
+        "none" => Ok(PngCompression::None),
+        "fast" => Ok(PngCompression::Fast),
+        "default" => Ok(PngCompression::Balanced),
+        "best" => Ok(PngCompression::Best),
+        other => Err(PyValueError::new_err(format!(
+            "unknown compression {other:?}: expected 'none', 'fast', 'default' or 'best'"
+        ))),
+    }
+}
+
 /// The core document behind a lock, shareable across threads.
 ///
 /// [`CoreDocument`] itself is neither `Send` nor `Sync`: its interior
@@ -389,7 +404,7 @@ impl Document {
     /// document this is the convenient fast path: one call renders them all
     /// at once, where per-page `render` calls only parallelize if you run
     /// them from your own threads.
-    #[pyo3(signature = (pages=None, scale=1.0, fonts="all-embedded", font_dir=None))]
+    #[pyo3(signature = (pages=None, scale=1.0, fonts="all-embedded", font_dir=None, compression="default"))]
     fn render_pages<'py>(
         &self,
         py: Python<'py>,
@@ -397,8 +412,10 @@ impl Document {
         scale: f32,
         fonts: &str,
         font_dir: Option<String>,
+        compression: &str,
     ) -> PyResult<Vec<Bound<'py, PyBytes>>> {
         let opts = resolve_render_options(py, scale, fonts, font_dir)?;
+        let compression = png_compression_from_str(compression)?;
         let inner = &self.inner;
         let pngs = py.allow_threads(move || {
             // The lock is held only long enough to seed; the fan-out runs
@@ -407,7 +424,7 @@ impl Document {
             let outcomes = match &pages {
                 None => pdfboss_core::map_pages(&doc, |doc, page| {
                     let (pix, _) = pdfboss_render::render_page_reporting(doc, page, scale, &opts)?;
-                    pix.encode_png()
+                    pix.encode_png_with(compression)
                 }),
                 Some(wanted) => {
                     // An explicit list renders exactly those pages, in the
@@ -439,7 +456,7 @@ impl Document {
                                         let (pix, _) = pdfboss_render::render_page_reporting(
                                             &worker, &page, scale, opts,
                                         )?;
-                                        pix.encode_png()
+                                        pix.encode_png_with(compression)
                                     });
                                     slots[s].set(outcome).ok();
                                 }
@@ -563,17 +580,22 @@ impl Page {
     /// message rather than silently degrading or leaking a raw import
     /// error.
     ///
+    /// `compression` trades PNG encode time against file size: `"none"`,
+    /// `"fast"`, `"default"` or `"best"`. Every level produces the same
+    /// pixels.
+    ///
     /// Content pdfboss cannot read is skipped, so a page can come out blank
     /// without raising. Use `render_reporting` to see what was dropped.
-    #[pyo3(signature = (scale=1.0, fonts="all-embedded", font_dir=None))]
+    #[pyo3(signature = (scale=1.0, fonts="all-embedded", font_dir=None, compression="default"))]
     fn render<'py>(
         &self,
         py: Python<'py>,
         scale: f32,
         fonts: &str,
         font_dir: Option<String>,
+        compression: &str,
     ) -> PyResult<Bound<'py, PyBytes>> {
-        let rendered = self.render_reporting(py, scale, fonts, font_dir)?;
+        let rendered = self.render_reporting(py, scale, fonts, font_dir, compression)?;
         Ok(rendered.0)
     }
 
@@ -584,21 +606,26 @@ impl Page {
     /// unsupported filter /Crypt"`. It is empty when the page
     /// rasterized exactly as it describes itself, so a blank page is never
     /// mistaken for a clean render.
-    #[pyo3(signature = (scale=1.0, fonts="all-embedded", font_dir=None))]
+    #[pyo3(signature = (scale=1.0, fonts="all-embedded", font_dir=None, compression="default"))]
     fn render_reporting<'py>(
         &self,
         py: Python<'py>,
         scale: f32,
         fonts: &str,
         font_dir: Option<String>,
+        compression: &str,
     ) -> PyResult<(Bound<'py, PyBytes>, Vec<String>)> {
         let opts = resolve_render_options(py, scale, fonts, font_dir)?;
+        let compression = png_compression_from_str(compression)?;
         let (png, warnings) = py.allow_threads(|| {
             let doc = CoreDocument::from_seed(self.seed.clone());
             let (pixmap, report) =
                 pdfboss_render::render_page_reporting(&doc, &self.page, scale, &opts)
                     .map_err(pdf_err)?;
-            Ok::<_, PyErr>((pixmap.encode_png().map_err(pdf_err)?, report.warnings()))
+            Ok::<_, PyErr>((
+                pixmap.encode_png_with(compression).map_err(pdf_err)?,
+                report.warnings(),
+            ))
         })?;
         Ok((PyBytes::new(py, &png), warnings))
     }
@@ -959,7 +986,7 @@ impl AsyncDocument {
     /// never idles the others — except the workers are tokio tasks, so the
     /// asyncio loop stays free and it works over any source, including
     /// `open_url` documents (each worker range-fetches what its page needs).
-    #[pyo3(signature = (pages=None, scale=1.0, fonts="all-embedded", font_dir=None))]
+    #[pyo3(signature = (pages=None, scale=1.0, fonts="all-embedded", font_dir=None, compression="default"))]
     fn render_pages<'py>(
         &self,
         py: Python<'py>,
@@ -967,8 +994,10 @@ impl AsyncDocument {
         scale: f32,
         fonts: &str,
         font_dir: Option<String>,
+        compression: &str,
     ) -> PyResult<Bound<'py, PyAny>> {
         let opts = resolve_render_options(py, scale, fonts, font_dir)?;
+        let compression = png_compression_from_str(compression)?;
         let inner = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let selection: Arc<Vec<usize>> = Arc::new(match pages {
@@ -1005,7 +1034,7 @@ impl AsyncDocument {
                                 &opts,
                             )
                             .await
-                            .and_then(|(pix, _)| pix.encode_png())
+                            .and_then(|(pix, _)| pix.encode_png_with(compression))
                             .map_err(pdf_err),
                         };
                         done.push((s, outcome));
@@ -1146,22 +1175,24 @@ impl AsyncPage {
 
     /// Renders the page and resolves to PNG bytes; same arguments and
     /// leniency as the sync `Page.render`. Coroutine.
-    #[pyo3(signature = (scale=1.0, fonts="all-embedded", font_dir=None))]
+    #[pyo3(signature = (scale=1.0, fonts="all-embedded", font_dir=None, compression="default"))]
     fn render<'py>(
         &self,
         py: Python<'py>,
         scale: f32,
         fonts: &str,
         font_dir: Option<String>,
+        compression: &str,
     ) -> PyResult<Bound<'py, PyAny>> {
         let opts = resolve_render_options(py, scale, fonts, font_dir)?;
+        let compression = png_compression_from_str(compression)?;
         let doc = self.doc.clone();
         let page = self.page.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let (pixmap, _) = pdfboss_render::render_page_reporting_with(doc, &page, scale, &opts)
                 .await
                 .map_err(pdf_err)?;
-            let png = pixmap.encode_png().map_err(pdf_err)?;
+            let png = pixmap.encode_png_with(compression).map_err(pdf_err)?;
             Python::with_gil(|py| {
                 Ok::<Py<PyAny>, PyErr>(PyBytes::new(py, &png).into_any().unbind())
             })
@@ -1171,15 +1202,17 @@ impl AsyncPage {
     /// Renders the page like `render`, resolving to `(png_bytes, warnings)`;
     /// same reporting semantics as the sync `Page.render_reporting`.
     /// Coroutine.
-    #[pyo3(signature = (scale=1.0, fonts="all-embedded", font_dir=None))]
+    #[pyo3(signature = (scale=1.0, fonts="all-embedded", font_dir=None, compression="default"))]
     fn render_reporting<'py>(
         &self,
         py: Python<'py>,
         scale: f32,
         fonts: &str,
         font_dir: Option<String>,
+        compression: &str,
     ) -> PyResult<Bound<'py, PyAny>> {
         let opts = resolve_render_options(py, scale, fonts, font_dir)?;
+        let compression = png_compression_from_str(compression)?;
         let doc = self.doc.clone();
         let page = self.page.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
@@ -1187,7 +1220,7 @@ impl AsyncPage {
                 pdfboss_render::render_page_reporting_with(doc, &page, scale, &opts)
                     .await
                     .map_err(pdf_err)?;
-            let png = pixmap.encode_png().map_err(pdf_err)?;
+            let png = pixmap.encode_png_with(compression).map_err(pdf_err)?;
             let warnings = report.warnings();
             Python::with_gil(|py| {
                 let bytes = PyBytes::new(py, &png).into_any().unbind();

--- a/crates/pdfboss-render/src/lib.rs
+++ b/crates/pdfboss-render/src/lib.rs
@@ -59,6 +59,33 @@ pub struct Pixmap {
     pub data: Vec<u8>,
 }
 
+/// How much CPU the PNG encoder spends shrinking the file. Every level
+/// round-trips the exact same pixels; only encode time and file size move.
+/// `Balanced` is what [`Pixmap::encode_png`] has always used.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PngCompression {
+    /// Uncompressed: fastest, largest files.
+    None,
+    /// Very fast with a decent ratio.
+    Fast,
+    /// Balances encode speed and file size.
+    #[default]
+    Balanced,
+    /// Smallest files, much slower.
+    Best,
+}
+
+impl PngCompression {
+    fn to_encoding(self) -> png::Compression {
+        match self {
+            PngCompression::None => png::Compression::NoCompression,
+            PngCompression::Fast => png::Compression::Fast,
+            PngCompression::Balanced => png::Compression::Balanced,
+            PngCompression::Best => png::Compression::High,
+        }
+    }
+}
+
 impl Pixmap {
     /// Creates a fully transparent pixmap.
     pub fn new(w: u32, h: u32) -> Pixmap {
@@ -76,8 +103,13 @@ impl Pixmap {
         }
     }
 
-    /// Encodes the pixmap as a PNG image.
+    /// Encodes the pixmap as a PNG image, at the default compression level.
     pub fn encode_png(&self) -> Result<Vec<u8>> {
+        self.encode_png_with(PngCompression::default())
+    }
+
+    /// Encodes the pixmap as a PNG image at the given compression level.
+    pub fn encode_png_with(&self, compression: PngCompression) -> Result<Vec<u8>> {
         fn err(e: png::EncodingError) -> Error {
             Error::Other(format!("png encode: {e}"))
         }
@@ -85,6 +117,7 @@ impl Pixmap {
         let mut enc = png::Encoder::new(&mut out, self.width, self.height);
         enc.set_color(png::ColorType::Rgba);
         enc.set_depth(png::BitDepth::Eight);
+        enc.set_compression(compression.to_encoding());
         let mut writer = enc.write_header().map_err(err)?;
         writer.write_image_data(&self.data).map_err(err)?;
         writer.finish().map_err(err)?;
@@ -486,6 +519,32 @@ mod tests {
         let mut pix = Pixmap::new(2, 2);
         pix.fill([1, 2, 3, 4]);
         assert_eq!(pix.data, [1, 2, 3, 4].repeat(4));
+    }
+
+    #[test]
+    fn compression_levels_map_to_their_encoder_settings() {
+        // png::Compression derives no PartialEq, hence matches!.
+        assert!(matches!(
+            PngCompression::None.to_encoding(),
+            png::Compression::NoCompression
+        ));
+        assert!(matches!(
+            PngCompression::Fast.to_encoding(),
+            png::Compression::Fast
+        ));
+        assert!(matches!(
+            PngCompression::Balanced.to_encoding(),
+            png::Compression::Balanced
+        ));
+        assert!(matches!(
+            PngCompression::Best.to_encoding(),
+            png::Compression::High
+        ));
+    }
+
+    #[test]
+    fn balanced_is_the_default_compression() {
+        assert_eq!(PngCompression::default(), PngCompression::Balanced);
     }
 
     #[test]

--- a/crates/pdfboss-render/tests/png_compression.rs
+++ b/crates/pdfboss-render/tests/png_compression.rs
@@ -1,0 +1,78 @@
+//! PNG encode compression levels: every level must round-trip the exact
+//! pixels — compression only trades encode time against file size, never
+//! image content — and the default-compression path must stay byte-identical
+//! to what `encode_png` always produced, so callers that never asked for a
+//! level see no change.
+
+use pdfboss_render::{Pixmap, PngCompression};
+
+/// A pixmap with enough structure to compress well: a two-axis gradient
+/// with an opaque square stamped on it. Compressible content is what makes
+/// the size ordering between `None` and `Best` observable.
+fn gradient_pixmap() -> Pixmap {
+    let mut pix = Pixmap::new(128, 96);
+    for y in 0..96u32 {
+        for x in 0..128u32 {
+            let i = ((y * 128 + x) * 4) as usize;
+            pix.data[i] = (x * 2) as u8;
+            pix.data[i + 1] = (y * 2) as u8;
+            pix.data[i + 2] = 128;
+            pix.data[i + 3] = 255;
+        }
+    }
+    for y in 20..60u32 {
+        for x in 30..90u32 {
+            let i = ((y * 128 + x) * 4) as usize;
+            pix.data[i..i + 4].copy_from_slice(&[10, 200, 40, 255]);
+        }
+    }
+    pix
+}
+
+fn decode(bytes: &[u8]) -> (u32, u32, Vec<u8>) {
+    let decoder = png::Decoder::new(std::io::Cursor::new(bytes));
+    let mut reader = decoder.read_info().expect("png header");
+    let mut buf = vec![0; reader.output_buffer_size().expect("output size")];
+    let info = reader.next_frame(&mut buf).expect("png frame");
+    buf.truncate(info.buffer_size());
+    (info.width, info.height, buf)
+}
+
+#[test]
+fn every_level_round_trips_the_exact_pixels() {
+    let pix = gradient_pixmap();
+    for level in [
+        PngCompression::None,
+        PngCompression::Fast,
+        PngCompression::Balanced,
+        PngCompression::Best,
+    ] {
+        let png = pix.encode_png_with(level).expect("encode");
+        let (w, h, data) = decode(&png);
+        assert_eq!((w, h), (pix.width, pix.height), "{level:?} dimensions");
+        assert_eq!(data, pix.data, "{level:?} pixels");
+    }
+}
+
+#[test]
+fn uncompressed_output_is_larger_than_best() {
+    let pix = gradient_pixmap();
+    let none = pix.encode_png_with(PngCompression::None).expect("encode");
+    let best = pix.encode_png_with(PngCompression::Best).expect("encode");
+    assert!(
+        none.len() > best.len(),
+        "expected None ({}) > Best ({})",
+        none.len(),
+        best.len()
+    );
+}
+
+#[test]
+fn encode_png_is_byte_identical_to_the_default_level() {
+    let pix = gradient_pixmap();
+    let plain = pix.encode_png().expect("encode");
+    let with_default = pix
+        .encode_png_with(PngCompression::default())
+        .expect("encode");
+    assert_eq!(plain, with_default);
+}

--- a/python/pdfboss/_pdfboss.pyi
+++ b/python/pdfboss/_pdfboss.pyi
@@ -95,6 +95,7 @@ class Document:
         scale: float = 1.0,
         fonts: str = "all-embedded",
         font_dir: str | None = None,
+        compression: str = "default",
     ) -> list[bytes]:
         """Renders every page (or the 0-based ``pages`` given, in the order
         given) to PNG bytes, fanned out across the machine's cores."""
@@ -156,6 +157,7 @@ class Page:
         scale: float = 1.0,
         fonts: str = "all-embedded",
         font_dir: str | None = None,
+        compression: str = "default",
     ) -> bytes:
         """Renders the page at ``scale`` and returns PNG bytes.
 
@@ -170,6 +172,10 @@ class Page:
         raises ``ValueError`` (install with ``pip install pdfboss[full]``,
         or pass ``font_dir=...``).
 
+        ``compression`` trades PNG encode time against file size:
+        ``"none"``, ``"fast"``, ``"default"`` or ``"best"``. Every level
+        produces the same pixels.
+
         Content pdfboss cannot read is skipped rather than raising, so a
         page can come out blank; ``render_reporting`` says what was lost.
         """
@@ -179,6 +185,7 @@ class Page:
         scale: float = 1.0,
         fonts: str = "all-embedded",
         font_dir: str | None = None,
+        compression: str = "default",
     ) -> tuple[bytes, list[str]]:
         """Renders the page like ``render``, returning ``(png, warnings)``.
 
@@ -220,6 +227,7 @@ class AsyncDocument:
         scale: float = 1.0,
         fonts: str = "all-embedded",
         font_dir: str | None = None,
+        compression: str = "default",
     ) -> list[bytes]:
         """Renders every page (or the 0-based ``pages`` given, in the order
         given) to PNG bytes — the async twin of ``Document.render_pages``,
@@ -264,10 +272,12 @@ class AsyncPage:
         scale: float = 1.0,
         fonts: str = "all-embedded",
         font_dir: str | None = None,
+        compression: str = "default",
     ) -> bytes: ...
     async def render_reporting(
         self,
         scale: float = 1.0,
         fonts: str = "all-embedded",
         font_dir: str | None = None,
+        compression: str = "default",
     ) -> tuple[bytes, list[str]]: ...

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -428,3 +428,35 @@ class TestAsyncPageParity:
         sync_doc = Document(str(pdf_path))
         doc = await AsyncDocument.open_url(url)
         assert await doc.render_pages() == sync_doc.render_pages()
+
+
+class TestAsyncRenderCompression:
+    @pytest.mark.asyncio
+    async def test_every_level_matches_the_sync_bytes(self, hello_pdf: Path) -> None:
+        sync_page = Document(str(hello_pdf))[0]
+        doc = await AsyncDocument.open(str(hello_pdf))
+        for level in ("none", "fast", "default", "best"):
+            png = await doc[0].render(compression=level)
+            assert png == sync_page.render(compression=level), level
+
+    @pytest.mark.asyncio
+    async def test_omitted_compression_is_byte_identical_to_the_default_level(
+        self, hello_pdf: Path
+    ) -> None:
+        doc = await AsyncDocument.open(str(hello_pdf))
+        page = doc[0]
+        assert await page.render() == await page.render(compression="default")
+        reporting = await page.render_reporting()
+        explicit = await page.render_reporting(compression="default")
+        assert reporting[0] == explicit[0]
+        assert await doc.render_pages() == await doc.render_pages(compression="default")
+
+    @pytest.mark.asyncio
+    async def test_unknown_compression_raises_value_error_naming_the_choices(
+        self, hello_pdf: Path
+    ) -> None:
+        doc = await AsyncDocument.open(str(hello_pdf))
+        page = doc[0]
+        for call in (page.render, page.render_reporting, doc.render_pages):
+            with pytest.raises(ValueError, match="'none', 'fast', 'default' or 'best'"):
+                await call(compression="bogus")

--- a/tests/test_pdfboss.py
+++ b/tests/test_pdfboss.py
@@ -8,6 +8,7 @@ import gc
 import sys
 import threading
 import time
+import zlib
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -17,6 +18,57 @@ import pdfboss
 from pdfboss import Document, Page, PdfError
 
 PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def decode_png(png: bytes) -> tuple[int, int, bytes]:
+    """Stdlib-only RGBA8 PNG decode: chunk walk, zlib, row unfilter.
+
+    Deliberately not an imaging dependency, so the pixel-identity tests
+    below always run. The ``none`` compression level writes unfiltered
+    rows, so comparing it against the filtered levels also cross-checks
+    this unfilter implementation.
+    """
+    if png[:8] != PNG_MAGIC:
+        raise ValueError("not a PNG")
+    pos, idat, width, height = 8, b"", 0, 0
+    while pos < len(png):
+        length = int.from_bytes(png[pos : pos + 4], "big")
+        kind = png[pos + 4 : pos + 8]
+        data = png[pos + 8 : pos + 8 + length]
+        if kind == b"IHDR":
+            width = int.from_bytes(data[0:4], "big")
+            height = int.from_bytes(data[4:8], "big")
+            if (data[8], data[9], data[12]) != (8, 6, 0):
+                raise ValueError("expected non-interlaced RGBA8")
+        elif kind == b"IDAT":
+            idat += data
+        pos += 12 + length
+    raw = zlib.decompress(idat)
+    stride = width * 4
+    out = bytearray()
+    prev = bytearray(stride)
+    for y in range(height):
+        start = y * (stride + 1)
+        filter_type = raw[start]
+        row = bytearray(raw[start + 1 : start + 1 + stride])
+        for i in range(stride):
+            a = row[i - 4] if i >= 4 else 0
+            b = prev[i]
+            c = prev[i - 4] if i >= 4 else 0
+            if filter_type == 1:
+                row[i] = (row[i] + a) & 0xFF
+            elif filter_type == 2:
+                row[i] = (row[i] + b) & 0xFF
+            elif filter_type == 3:
+                row[i] = (row[i] + (a + b) // 2) & 0xFF
+            elif filter_type == 4:
+                p = a + b - c
+                pa, pb, pc = abs(p - a), abs(p - b), abs(p - c)
+                nearest = a if pa <= pb and pa <= pc else b if pb <= pc else c
+                row[i] = (row[i] + nearest) & 0xFF
+        out += row
+        prev = row
+    return width, height, bytes(out)
 
 
 class TestOpen:
@@ -225,6 +277,47 @@ class TestRender:
         # all-embedded / embedded-only must not attempt discovery -> no raise.
         assert page.render(fonts="all-embedded")[:8] == PNG_MAGIC
         assert page.render(fonts="embedded-only")[:8] == PNG_MAGIC
+
+
+class TestRenderCompression:
+    def test_every_level_round_trips_the_same_pixels(self, hello_pdf: Path) -> None:
+        page = Document(str(hello_pdf))[0]
+        reference = decode_png(page.render())
+        for level in ("none", "fast", "default", "best"):
+            assert decode_png(page.render(compression=level)) == reference, level
+
+    def test_no_compression_is_larger_than_best(self, hello_pdf: Path) -> None:
+        page = Document(str(hello_pdf))[0]
+        none = page.render(compression="none")
+        best = page.render(compression="best")
+        assert len(none) > len(best)
+
+    def test_omitted_compression_is_byte_identical_to_the_default_level(
+        self, hello_pdf: Path
+    ) -> None:
+        doc = Document(str(hello_pdf))
+        page = doc[0]
+        assert page.render() == page.render(compression="default")
+        assert (
+            page.render_reporting()[0] == page.render_reporting(compression="default")[0]
+        )
+        assert doc.render_pages() == doc.render_pages(compression="default")
+
+    def test_render_pages_honors_the_level(self, three_pages_pdf: Path) -> None:
+        doc = Document(str(three_pages_pdf))
+        none = doc.render_pages(compression="none")
+        best = doc.render_pages(compression="best")
+        assert all(png.startswith(PNG_MAGIC) for png in none + best)
+        assert all(len(n) > len(b) for n, b in zip(none, best))
+
+    def test_unknown_compression_raises_value_error_naming_the_choices(
+        self, hello_pdf: Path
+    ) -> None:
+        doc = Document(str(hello_pdf))
+        page = doc[0]
+        for call in (page.render, page.render_reporting, doc.render_pages):
+            with pytest.raises(ValueError, match="'none', 'fast', 'default' or 'best'"):
+                call(compression="bogus")
 
 
 def pdf_with_undecodable_image() -> bytes:


### PR DESCRIPTION
PNG encoding is 20-37% of render time on the benchmark's gap files, at the png crate's default deflate. This makes the level a knob instead: `PngCompression { None, Fast, Balanced (default), Best }` on `Pixmap::encode_png_with`, a `compression=` kwarg ("none"/"fast"/"default"/"best") on all six Python render entry points (sync + async, stubs updated), and `--png-compression` on `pdfboss render`.

The default is unchanged and proven byte-identical two ways: source-level (the encoder's `Options::default()` equals what `set_compression(Balanced)` sets, pinned by a test) and empirically (all seven entry points reproduce their pre-change PNGs sha-for-sha). Pixels are identical at every level by decode-and-compare in both Rust and pytest; an unknown Python value raises ValueError before any coroutine runs.

Verification: TDD at every layer (each test watched failing first), full workspace suite 1652 green, clippy clean.