### PR TITLE
fix(render): evaluate Separation tint transforms instead of approximating ink

### DIFF
--- a/crates/pdfboss-render/src/color.rs
+++ b/crates/pdfboss-render/src/color.rs
@@ -1,6 +1,8 @@
 //! Color spaces: DeviceGray/RGB/CMYK, Indexed, and approximations for the
 //! CIE-based and tint-transform families, converted to RGB.
 
+use std::sync::Arc;
+
 use pdfboss_core::{block_on, AsyncObjectSource, Document, Error, Immediate, Object};
 
 use crate::shading::{load_functions, Functions, MAX_COMPS};
@@ -9,12 +11,6 @@ use crate::shading::{load_functions, Functions, MAX_COMPS};
 /// (Indexed bases, ICCBased `/Alternate` chains): levels `0..=MAX_DEPTH`
 /// are read, anything deeper reads as `DeviceGray`.
 const MAX_DEPTH: u32 = 8;
-
-/// Tint-transform samples a [`ColorSpace::Separation`] keeps. The transform
-/// is evaluated once per step at parse time and interpolated per pixel, so
-/// the pixel loops stay free of function evaluation; 256 steps hold a
-/// smooth ramp to within a 255th of the alternate space's own resolution.
-const TINT_STEPS: usize = 256;
 
 /// A color space reduced to what the rasterizer can paint.
 #[derive(Debug, Clone, PartialEq)]
@@ -31,10 +27,18 @@ pub(crate) enum ColorSpace {
         base: Box<ColorSpace>,
         lookup: Vec<u8>,
     },
-    /// A one-component `Separation` whose tint transform was evaluated
-    /// through its alternate space at parse time (§8.6.6.4): `ramp[i]` is
-    /// the RGB for tint `i / (TINT_STEPS - 1)`.
-    Separation { ramp: Vec<[f32; 3]> },
+    /// A one-component `Separation`: its tint transform and the alternate
+    /// space the transform's output is read in (§8.6.6.4).
+    ///
+    /// The transform is evaluated per colour, not per parse: a fill or stroke
+    /// costs one evaluation, and an image's samples reach it through the
+    /// reader's own per-value table (one entry per distinct sample, 256 at
+    /// eight bits) rather than once per pixel. `Arc` so cloning a space
+    /// shares one arena instead of copying a sampled function's data.
+    Separation {
+        tint: Arc<Functions>,
+        alternate: Box<ColorSpace>,
+    },
     /// Any other family, kept only for its component count. `to_rgb`
     /// approximates it as an ink tint: gray = 1 - max component (used for
     /// `DeviceN`, whose multi-input transforms this does not evaluate, for a
@@ -102,25 +106,10 @@ impl ColorSpace {
                 }
                 base.to_rgb(&base_comps[..n])
             }
-            ColorSpace::Separation { ramp } => {
-                // The transform is already evaluated; interpolate between the
-                // two nearest steps so a gradient over the tint stays smooth.
-                let t = comp(comps, 0) * (ramp.len().saturating_sub(1)) as f32;
-                let lo = t.floor().max(0.0) as usize;
-                let hi = (lo + 1).min(ramp.len().saturating_sub(1));
-                match (ramp.get(lo), ramp.get(hi)) {
-                    (Some(a), Some(b)) => {
-                        let f = t - lo as f32;
-                        [
-                            a[0] + (b[0] - a[0]) * f,
-                            a[1] + (b[1] - a[1]) * f,
-                            a[2] + (b[2] - a[2]) * f,
-                        ]
-                    }
-                    // An empty ramp cannot happen (the parser only builds a
-                    // full one) but white is the harmless reading.
-                    _ => [1.0, 1.0, 1.0],
-                }
+            ColorSpace::Separation { tint, alternate } => {
+                let mut components = [0f32; MAX_COMPS];
+                let written = tint.eval(comp(comps, 0), &mut components);
+                alternate.to_rgb(&components[..written])
             }
             ColorSpace::Other(n) => {
                 // Tint approximation: treat the strongest component as ink
@@ -266,16 +255,9 @@ impl ColorSpace {
             }
         }
         for funcs in tints.into_iter().rev() {
-            let alternate = result;
-            let mut out = [0f32; MAX_COMPS];
             result = ColorSpace::Separation {
-                ramp: (0..TINT_STEPS)
-                    .map(|i| {
-                        let tint = i as f32 / (TINT_STEPS - 1) as f32;
-                        let written = funcs.eval(tint, &mut out);
-                        alternate.to_rgb(&out[..written])
-                    })
-                    .collect(),
+                tint: Arc::new(funcs),
+                alternate: Box::new(result),
             };
         }
         for lookup in palettes.into_iter().rev() {

--- a/crates/pdfboss-render/src/color.rs
+++ b/crates/pdfboss-render/src/color.rs
@@ -3,10 +3,18 @@
 
 use pdfboss_core::{block_on, AsyncObjectSource, Document, Error, Immediate, Object};
 
+use crate::shading::{load_functions, Functions, MAX_COMPS};
+
 /// Nesting guard for color-space definitions that defer to another one
 /// (Indexed bases, ICCBased `/Alternate` chains): levels `0..=MAX_DEPTH`
 /// are read, anything deeper reads as `DeviceGray`.
 const MAX_DEPTH: u32 = 8;
+
+/// Tint-transform samples a [`ColorSpace::Separation`] keeps. The transform
+/// is evaluated once per step at parse time and interpolated per pixel, so
+/// the pixel loops stay free of function evaluation; 256 steps hold a
+/// smooth ramp to within a 255th of the alternate space's own resolution.
+const TINT_STEPS: usize = 256;
 
 /// A color space reduced to what the rasterizer can paint.
 #[derive(Debug, Clone, PartialEq)]
@@ -23,10 +31,14 @@ pub(crate) enum ColorSpace {
         base: Box<ColorSpace>,
         lookup: Vec<u8>,
     },
+    /// A one-component `Separation` whose tint transform was evaluated
+    /// through its alternate space at parse time (§8.6.6.4): `ramp[i]` is
+    /// the RGB for tint `i / (TINT_STEPS - 1)`.
+    Separation { ramp: Vec<[f32; 3]> },
     /// Any other family, kept only for its component count. `to_rgb`
     /// approximates it as an ink tint: gray = 1 - max component (used for
-    /// Separation/DeviceN, whose tint transforms are not evaluated, and
-    /// Lab).
+    /// `DeviceN`, whose multi-input transforms this does not evaluate, for a
+    /// `Separation` whose transform is a type 4, and for Lab).
     Other(usize),
 }
 
@@ -49,6 +61,7 @@ impl ColorSpace {
             ColorSpace::DeviceRGB => 3,
             ColorSpace::DeviceCMYK => 4,
             ColorSpace::Indexed { .. } => 1,
+            ColorSpace::Separation { .. } => 1,
             ColorSpace::Other(n) => *n,
         }
     }
@@ -89,6 +102,26 @@ impl ColorSpace {
                 }
                 base.to_rgb(&base_comps[..n])
             }
+            ColorSpace::Separation { ramp } => {
+                // The transform is already evaluated; interpolate between the
+                // two nearest steps so a gradient over the tint stays smooth.
+                let t = comp(comps, 0) * (ramp.len().saturating_sub(1)) as f32;
+                let lo = t.floor().max(0.0) as usize;
+                let hi = (lo + 1).min(ramp.len().saturating_sub(1));
+                match (ramp.get(lo), ramp.get(hi)) {
+                    (Some(a), Some(b)) => {
+                        let f = t - lo as f32;
+                        [
+                            a[0] + (b[0] - a[0]) * f,
+                            a[1] + (b[1] - a[1]) * f,
+                            a[2] + (b[2] - a[2]) * f,
+                        ]
+                    }
+                    // An empty ramp cannot happen (the parser only builds a
+                    // full one) but white is the harmless reading.
+                    _ => [1.0, 1.0, 1.0],
+                }
+            }
             ColorSpace::Other(n) => {
                 // Tint approximation: treat the strongest component as ink
                 // coverage v and paint gray 1 - v.
@@ -124,6 +157,11 @@ impl ColorSpace {
     /// palettes, innermost last.
     pub(crate) async fn parse_with<S: AsyncObjectSource>(src: &S, obj: &Object) -> ColorSpace {
         let mut palettes: Vec<Vec<u8>> = Vec::new();
+        // Tint transforms met on the way down, innermost last — the same
+        // deferral `palettes` uses, for the same reason: the transform's
+        // output is read in the alternate space, which this loop has not
+        // resolved yet.
+        let mut tints: Vec<Functions> = Vec::new();
         let mut current: Object = obj.clone();
         // If the loop runs out of levels while still descending, this is the
         // answer — the same one the recursion's depth guard gave.
@@ -185,8 +223,27 @@ impl ColorSpace {
                             }
                         }
                         "Separation" => {
-                            result = ColorSpace::Other(1);
-                            break;
+                            // [/Separation name alternate transform]: keep the
+                            // transform and carry on into the alternate space,
+                            // whose components the transform's output *is*.
+                            let transform = match items.get(3) {
+                                Some(o) => load_functions(src, o).await.ok().flatten(),
+                                None => None,
+                            };
+                            match (transform, items.get(2)) {
+                                (Some(funcs), Some(alternate)) => {
+                                    tints.push(funcs);
+                                    current = alternate.clone();
+                                    continue;
+                                }
+                                // A type 4 transform, a malformed one, or no
+                                // alternate at all: the ink approximation is
+                                // still better than painting nothing.
+                                _ => {
+                                    result = ColorSpace::Other(1);
+                                    break;
+                                }
+                            }
                         }
                         "DeviceN" => {
                             let n = match items.get(1) {
@@ -207,6 +264,19 @@ impl ColorSpace {
                 }
                 _ => break, // stays DeviceGray
             }
+        }
+        for funcs in tints.into_iter().rev() {
+            let alternate = result;
+            let mut out = [0f32; MAX_COMPS];
+            result = ColorSpace::Separation {
+                ramp: (0..TINT_STEPS)
+                    .map(|i| {
+                        let tint = i as f32 / (TINT_STEPS - 1) as f32;
+                        let written = funcs.eval(tint, &mut out);
+                        alternate.to_rgb(&out[..written])
+                    })
+                    .collect(),
+            };
         }
         for lookup in palettes.into_iter().rev() {
             result = ColorSpace::Indexed {

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -2004,13 +2004,14 @@ fn type3_glyph_plan(
 
 /// The initial color after selecting a color space: black for the device
 /// and Indexed spaces (CMYK black is `K = 1`). Separation/DeviceN start at
-/// full tint 1.0 (ISO 32000-1 8.6.6.4/8.6.6.5), which the tint
-/// approximation paints as gray 0; feeding 1.0 everywhere also gives the
-/// right dark initial color for Lab (`L = 0`), the other `Other` space.
+/// full tint 1.0 (ISO 32000-1 8.6.6.4/8.6.6.5) — a `Separation` runs that
+/// through its tint transform, while the `Other` approximation paints it as
+/// gray 0; feeding 1.0 everywhere also gives the right dark initial color
+/// for Lab (`L = 0`), the other `Other` space.
 fn initial_color(cs: &ColorSpace) -> [f32; 3] {
     match cs {
         ColorSpace::DeviceCMYK => cs.to_rgb(&[0.0, 0.0, 0.0, 1.0]),
-        ColorSpace::Other(_) => cs.to_rgb(&[1.0; 8]),
+        ColorSpace::Separation { .. } | ColorSpace::Other(_) => cs.to_rgb(&[1.0; 8]),
         _ => cs.to_rgb(&[0.0, 0.0, 0.0, 0.0]),
     }
 }
@@ -3091,6 +3092,13 @@ mod tests {
         // ISO 32000-1 8.6.6.4/8.6.6.5: selecting a Separation or DeviceN
         // space with `cs` sets every component to 1.0, so painting before
         // any `scn` must give a full-tint (dark) mark, not white.
+        //
+        // The tint transform below is what makes "full tint" mean dark:
+        // `/C0 [1] /C1 [0]` maps tint 0 to white and tint 1 to black, the
+        // usual ink direction. It has to say so explicitly — a transform
+        // that defaults to `C0 [0] C1 [1]` legally means the opposite, and
+        // this test would then be pinning the transform's direction rather
+        // than the initial component value it exists to check.
         for (entry, content) in [
             // Fill: broken initial color paints white-on-white.
             (
@@ -3108,7 +3116,10 @@ mod tests {
             ),
         ] {
             let bytes = small_doc("/ColorSpace << /T 6 0 R >>", content.as_bytes(), |b| {
-                b.object(5, "<< /FunctionType 2 /Domain [0 1] /N 1 >>");
+                b.object(
+                    5,
+                    "<< /FunctionType 2 /Domain [0 1] /C0 [1] /C1 [0] /N 1 >>",
+                );
                 b.object(6, entry);
             });
             let pix = render(bytes, 1.0);
@@ -3119,11 +3130,59 @@ mod tests {
             "/ColorSpace << /T 6 0 R >>",
             b"/T cs 0 scn 10 10 80 80 re f",
             |b| {
-                b.object(5, "<< /FunctionType 2 /Domain [0 1] /N 1 >>");
+                b.object(
+                    5,
+                    "<< /FunctionType 2 /Domain [0 1] /C0 [1] /C1 [0] /N 1 >>",
+                );
                 b.object(6, "[/Separation /Spot /DeviceGray 5 0 R]");
             },
         );
         assert_eq!(px(&render(bytes, 1.0), 50, 50), WHITE, "0 scn wins");
+    }
+
+    #[test]
+    fn separation_tint_transform_decides_the_color() {
+        // A spot colour is whatever its tint transform says, which is not
+        // always dark: print-origin files fill page backgrounds with a
+        // separation whose transform maps full tint to a pale ink. Painting
+        // such a fill as gray `1 - tint` turns the page black.
+        let bytes = small_doc(
+            "/ColorSpace << /T 6 0 R >>",
+            b"/T cs 1 scn 0 0 100 100 re f",
+            |b| {
+                // tint 1 -> CMYK 0.02 0.012 0.129 0, a pale cream.
+                b.object(
+                    5,
+                    "<< /FunctionType 2 /Domain [0 1] /C0 [0 0 0 0]                      /C1 [0.02 0.012 0.129 0] /N 1 >>",
+                );
+                b.object(6, "[/Separation /PaleSpot /DeviceCMYK 5 0 R]");
+            },
+        );
+        let [r, g, b_, _] = px(&render(bytes, 1.0), 50, 50);
+        assert!(
+            r > 240 && g > 240 && b_ > 210 && b_ < 240,
+            "expected the transform's pale cream, got {:?}",
+            [r, g, b_],
+        );
+    }
+
+    #[test]
+    fn separation_without_an_evaluable_transform_keeps_the_ink_approximation() {
+        // Type 4 (PostScript calculator) transforms are not evaluated here;
+        // full tint has to stay dark rather than falling back to white.
+        let bytes = small_doc(
+            "/ColorSpace << /T 6 0 R >>",
+            b"/T cs 1 scn 0 0 100 100 re f",
+            |b| {
+                b.stream(
+                    5,
+                    "<< /FunctionType 4 /Domain [0 1] /Range [0 1] >>",
+                    b"{ }",
+                );
+                b.object(6, "[/Separation /Spot /DeviceGray 5 0 R]");
+            },
+        );
+        assert_eq!(px(&render(bytes, 1.0), 50, 50), BLACK);
     }
 
     #[test]

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -3167,6 +3167,35 @@ mod tests {
     }
 
     #[test]
+    fn separation_image_samples_go_through_the_tint_transform() {
+        // An image in a Separation space reaches the transform through the
+        // reader's per-value table — one entry per distinct sample, not one
+        // evaluation per pixel — so this also pins that path.
+        let bytes = small_doc(
+            "/XObject << /Im1 5 0 R >> /ColorSpace << /T 7 0 R >>",
+            b"q 100 0 0 100 0 0 cm /Im1 Do Q",
+            |b| {
+                b.stream(
+                    5,
+                    "/Type /XObject /Subtype /Image /Width 2 /Height 1 \
+                     /ColorSpace 7 0 R /BitsPerComponent 8",
+                    // Tint 0 (no ink) then tint 1 (full ink).
+                    &[0x00, 0xFF],
+                );
+                b.object(
+                    6,
+                    "<< /FunctionType 2 /Domain [0 1] /C0 [0 0 0 0] \
+                     /C1 [0 0 0 1] /N 1 >>",
+                );
+                b.object(7, "[/Separation /Spot /DeviceCMYK 6 0 R]");
+            },
+        );
+        let pix = render(bytes, 1.0);
+        assert_eq!(px(&pix, 25, 50), WHITE, "tint 0 is no ink");
+        assert_eq!(px(&pix, 75, 50), BLACK, "tint 1 is full ink");
+    }
+
+    #[test]
     fn separation_without_an_evaluable_transform_keeps_the_ink_approximation() {
         // Type 4 (PostScript calculator) transforms are not evaluated here;
         // full tint has to stay dark rather than falling back to white.

--- a/crates/pdfboss-render/src/shading.rs
+++ b/crates/pdfboss-render/src/shading.rs
@@ -14,7 +14,7 @@ use crate::Pixmap;
 
 /// Most components any color space here carries (CMYK is 4; `Other` caps at
 /// what `ColorSpace::to_rgb` reads).
-const MAX_COMPS: usize = 8;
+pub(crate) const MAX_COMPS: usize = 8;
 
 /// Upper bound on parsed function nodes per shading. A real gradient uses a
 /// handful (one stitching function over a few exponentials); the cap only
@@ -24,6 +24,7 @@ const MAX_FUNCTIONS: usize = 256;
 /// One parsed function. Stitching children are arena indices, so loading
 /// needs no recursion (a queue fills the arena) and evaluation recurses
 /// over indices with the depth bounded by [`MAX_FUNCTIONS`].
+#[derive(Debug, Clone, PartialEq)]
 enum Node {
     /// Type 2: `C0 + x^N (C1 - C0)` over `domain`.
     Exponential {
@@ -55,7 +56,8 @@ enum Node {
 
 /// The functions a shading evaluates: one n-output function, or an array of
 /// single-output functions whose results concatenate (§8.7.4.5.2).
-struct Functions {
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Functions {
     nodes: Vec<Node>,
     roots: Vec<usize>,
 }
@@ -63,7 +65,7 @@ struct Functions {
 impl Functions {
     /// Evaluates every root at `x` into `out`, returning how many
     /// components were written.
-    fn eval(&self, x: f32, out: &mut [f32; MAX_COMPS]) -> usize {
+    pub(crate) fn eval(&self, x: f32, out: &mut [f32; MAX_COMPS]) -> usize {
         let mut written = 0;
         for &root in &self.roots {
             if written >= MAX_COMPS {
@@ -305,7 +307,7 @@ async fn function_dict<S: AsyncObjectSource>(
 /// Loads `/Function` — one function or an array of them — into an arena.
 /// `Ok(None)` means a function *type* nobody evaluates here (the PostScript
 /// calculator); `Err` is a structural failure worth reporting verbatim.
-async fn load_functions<S: AsyncObjectSource>(
+pub(crate) async fn load_functions<S: AsyncObjectSource>(
     src: &S,
     obj: &Object,
 ) -> Result<Option<Functions>, Error> {

--- a/crates/pdfboss-render/tests/fixtures/separation-tint.pdf
+++ b/crates/pdfboss-render/tests/fixtures/separation-tint.pdf
@@ -1,0 +1,37 @@
+%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /ColorSpace << /Cs1 5 0 R >> >> >>
+endobj
+4 0 obj
+<<  /Length 30 >>
+stream
+/Cs1 cs 1 sc 0 0 200 200 re f
+
+endstream
+endobj
+5 0 obj
+[ /Separation /PaleSpot /DeviceCMYK 6 0 R ]
+endobj
+6 0 obj
+<< /FunctionType 2 /Domain [0 1] /C0 [0 0 0 0] /C1 [0.02 0.012 0.129 0] /N 1 >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000248 00000 n 
+0000000329 00000 n 
+0000000388 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+483
+%%EOF

--- a/crates/pdfboss-render/tests/separation_page.rs
+++ b/crates/pdfboss-render/tests/separation_page.rs
@@ -1,0 +1,37 @@
+//! End-to-end coverage of `/Separation` tint transforms (ISO 32000-1 8.6.6.4),
+//! from PDF bytes to rasterized pixels.
+//!
+//! The unit tests build their spaces inline, which pins the conversion but not
+//! the path a real file takes: the colour space has to be found in the page's
+//! `/Resources`, its transform loaded from an indirect object, and the tint
+//! carried from `sc` through to compositing. This walks that path over a file.
+//!
+//! The fixture is the 686-byte reproducer from #52: one page filled with a
+//! `/Separation` whose type-2 transform maps full tint to a pale cream in
+//! `DeviceCMYK`. The assertion is about the colour rather than about `Ok` — the
+//! bug it covers rendered the page solid black and reported nothing wrong.
+
+use pdfboss_core::Document;
+use pdfboss_render::{render_page_reporting, RenderOptions};
+
+#[test]
+fn separation_fill_takes_its_color_from_the_tint_transform() {
+    let bytes = include_bytes!("fixtures/separation-tint.pdf").to_vec();
+    let doc = Document::load(bytes).expect("the fixture PDF opens");
+    let page = doc.page(0).expect("the fixture has one page");
+    let (pix, report) = render_page_reporting(&doc, &page, 1.0, &RenderOptions::default())
+        .expect("the page renders");
+
+    assert!(
+        report.is_empty(),
+        "content was skipped: {:?}",
+        report.warnings()
+    );
+    let middle = ((pix.height / 2) * pix.width + pix.width / 2) as usize * 4;
+    let pixel = &pix.data[middle..middle + 3];
+    // tint 1 -> CMYK 0.02 0.012 0.129 0 -> a pale cream, not black.
+    assert!(
+        pixel[0] > 240 && pixel[1] > 240 && (210..240).contains(&pixel[2]),
+        "expected the transform's pale cream, got {pixel:?}",
+    );
+}


### PR DESCRIPTION
Fixes #52.

`/Separation` was painted with a fixed ink approximation (`gray = 1 - max
component`), so a spot colour whose tint transform maps to a light value came
out black — a page filled with one at tint 1 rendered solid black.

## How

`shading.rs` already evaluated function types 0, 2 and 3 for shadings, so this
reuses that evaluator rather than adding one:

- `ColorSpace::Separation { ramp }` holds the transform evaluated through the
  space's `/Alternate` at parse time, 256 steps, interpolated per pixel — the
  pixel loops stay free of function evaluation.
- `parse_with` descends into the alternate space carrying the transform, the
  same deferral `/Indexed` already uses for palettes (no recursion added).
- Type 4 (PostScript calculator) transforms, a missing alternate, or a
  malformed transform keep the existing approximation, so nothing regresses.
- `initial_color` covers the new variant, keeping full tint (ISO 32000-1
  8.6.6.4) as the initial value.
- `/DeviceN` is unchanged: its transforms are multi-input, which this evaluator
  does not do.

## Numbers

Minimal repro from the issue, centre pixel (`/Separation` → `DeviceCMYK`, tint 1
→ CMYK 0.02/0.012/0.129/0):

| | value |
|---|---|
| before | `(0, 0, 0)` |
| **after** | **`(250, 252, 222)`** |
| pdfium 5.7.1 | `(249, 248, 226)` |

Two real print-origin PDFs, page mean luma:

| file | before | after | pdfium |
|---|---|---|---|
| Pantone-filled menu | 0.0 | **240.2** | 239.1 |
| Pantone-filled flyer | 52.6 | **104.0** | 102.0 |

## Tests

`cargo test -p pdfboss-render`: 272 pass (270 before), `cargo fmt --check` and
`cargo clippy -p pdfboss-render --all-targets` clean. Two added:

- `separation_tint_transform_decides_the_color` — the pale-cream fill.
- `separation_without_an_evaluable_transform_keeps_the_ink_approximation` — a
  type 4 transform still paints full tint dark.

One existing test changed fixture, not intent:
`separation_and_devicen_initial_color_is_full_tint` used a transform with no
`/C0`/`/C1`, which defaults to `C0 [0] C1 [1]` — i.e. *more tint = lighter*, so
once the transform is honoured its colours invert. It now states the ink
direction explicitly (`/C0 [1] /C1 [0]`) and still asserts what it exists to
assert: that selecting the space sets components to 1.0.
