### PR TITLE
fix: replace constant-size chunks_exact with as_chunks

### DIFF
--- a/crates/pdfboss-core/src/crypt.rs
+++ b/crates/pdfboss-core/src/crypt.rs
@@ -508,7 +508,7 @@ fn aes_cbc_decrypt_blocks(key: &[u8], iv: &[u8], data: &[u8]) -> Vec<u8> {
     let mut prev = [0u8; 16];
     prev.copy_from_slice(&iv[..16]);
     let mut out = Vec::with_capacity(data.len());
-    for chunk in data.chunks_exact(16) {
+    for chunk in data.as_chunks::<16>().0 {
         let mut block = [0u8; 16];
         block.copy_from_slice(chunk);
         let cipher = block;
@@ -529,7 +529,7 @@ fn aes_cbc_encrypt_blocks(key: &[u8], iv: &[u8], data: &[u8]) -> Vec<u8> {
     let mut prev = [0u8; 16];
     prev.copy_from_slice(&iv[..16]);
     let mut out = Vec::with_capacity(data.len());
-    for chunk in data.chunks_exact(16) {
+    for chunk in data.as_chunks::<16>().0 {
         let mut block = [0u8; 16];
         for ((b, c), p) in block.iter_mut().zip(chunk).zip(&prev) {
             *b = c ^ p;
@@ -595,10 +595,10 @@ fn sha256(input: &[u8]) -> [u8; 32] {
     }
     msg.extend_from_slice(&bitlen.to_be_bytes());
 
-    for chunk in msg.chunks_exact(64) {
+    for chunk in msg.as_chunks::<64>().0 {
         let mut w = [0u32; 64];
-        for (word, bytes) in w.iter_mut().zip(chunk.chunks_exact(4)) {
-            *word = u32::from_be_bytes(bytes.try_into().unwrap());
+        for (word, bytes) in w.iter_mut().zip(chunk.as_chunks::<4>().0) {
+            *word = u32::from_be_bytes(*bytes);
         }
         for i in 16..64 {
             let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
@@ -674,10 +674,10 @@ fn sha512_core(input: &[u8], mut h: [u64; 8]) -> [u64; 8] {
     }
     msg.extend_from_slice(&bitlen.to_be_bytes());
 
-    for chunk in msg.chunks_exact(128) {
+    for chunk in msg.as_chunks::<128>().0 {
         let mut w = [0u64; 80];
-        for (word, bytes) in w.iter_mut().zip(chunk.chunks_exact(8)) {
-            *word = u64::from_be_bytes(bytes.try_into().unwrap());
+        for (word, bytes) in w.iter_mut().zip(chunk.as_chunks::<8>().0) {
+            *word = u64::from_be_bytes(*bytes);
         }
         for i in 16..80 {
             let s0 = w[i - 15].rotate_right(1) ^ w[i - 15].rotate_right(8) ^ (w[i - 15] >> 7);
@@ -857,10 +857,10 @@ fn md5(input: &[u8]) -> [u8; 16] {
     }
     msg.extend_from_slice(&bitlen.to_le_bytes());
 
-    for chunk in msg.chunks_exact(64) {
+    for chunk in msg.as_chunks::<64>().0 {
         let mut m = [0u32; 16];
-        for (word, bytes) in m.iter_mut().zip(chunk.chunks_exact(4)) {
-            *word = u32::from_le_bytes(bytes.try_into().unwrap());
+        for (word, bytes) in m.iter_mut().zip(chunk.as_chunks::<4>().0) {
+            *word = u32::from_le_bytes(*bytes);
         }
         let (mut a, mut b, mut c, mut d) = (a0, b0, c0, d0);
         for i in 0..64 {

--- a/crates/pdfboss-core/src/document.rs
+++ b/crates/pdfboss-core/src/document.rs
@@ -1610,10 +1610,10 @@ mod tests {
             msg.push(0);
         }
         msg.extend_from_slice(&bitlen.to_le_bytes());
-        for chunk in msg.chunks_exact(64) {
+        for chunk in msg.as_chunks::<64>().0 {
             let mut m = [0u32; 16];
-            for (word, bytes) in m.iter_mut().zip(chunk.chunks_exact(4)) {
-                *word = u32::from_le_bytes(bytes.try_into().unwrap());
+            for (word, bytes) in m.iter_mut().zip(chunk.as_chunks::<4>().0) {
+                *word = u32::from_le_bytes(*bytes);
             }
             let (mut a, mut b, mut c, mut d) = (a0, b0, c0, d0);
             for i in 0..64 {

--- a/crates/pdfboss-core/src/filters/jbig2/bitmap.rs
+++ b/crates/pdfboss-core/src/filters/jbig2/bitmap.rs
@@ -315,8 +315,8 @@ impl Bitmap {
             // groups of eight and each group folded into a byte. Doing it a
             // pixel at a time costs a bounds check and a variable shift per
             // pixel, and a full page of a scan has millions of them.
-            let mut groups = row.chunks_exact(8);
-            for (byte, group) in dst.iter_mut().zip(&mut groups) {
+            let (groups, rest) = row.as_chunks::<8>();
+            for (byte, group) in dst.iter_mut().zip(groups) {
                 *byte = group
                     .iter()
                     .fold(0u8, |acc, &pixel| (acc << 1) | u8::from(pixel != 0));
@@ -324,7 +324,6 @@ impl Bitmap {
             // A row whose width is not a multiple of eight ends in a partial
             // byte, whose remaining low bits stay 0 — the padding this
             // function's contract leaves clear.
-            let rest = groups.remainder();
             if !rest.is_empty() {
                 if let Some(byte) = dst.get_mut(row.len() / 8) {
                     *byte = rest

--- a/crates/pdfboss-core/src/object.rs
+++ b/crates/pdfboss-core/src/object.rs
@@ -211,7 +211,9 @@ impl Object {
 pub fn decode_text_string(bytes: &[u8]) -> String {
     if let Some(rest) = bytes.strip_prefix(&[0xFE, 0xFF]) {
         let units = rest
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| u16::from_be_bytes([pair[0], pair[1]]));
         let mut out: String = std::char::decode_utf16(units)
             .map(|r| r.unwrap_or(char::REPLACEMENT_CHARACTER))

--- a/crates/pdfboss-jpx/src/boxes.rs
+++ b/crates/pdfboss-jpx/src/boxes.rs
@@ -419,18 +419,18 @@ fn check_ftyp(payload: &[u8], warnings: &mut Vec<JpxWarning>) -> Result<()> {
     if be32(&payload[4..]) != 0 {
         warnings.push(JpxWarning::note("ftyp minor version is not zero"));
     }
-    let mut chunks = payload[8..].chunks_exact(4);
+    let (entries, remainder) = payload[8..].as_chunks::<4>();
     let mut compatible = false;
     let mut jpx_compatible = false;
-    for entry in &mut chunks {
-        let code = [entry[0], entry[1], entry[2], entry[3]];
+    for entry in entries {
+        let code = *entry;
         compatible = compatible || code == BRAND_JP2;
         jpx_compatible = jpx_compatible || code == BRAND_JPX || code == BRAND_JPXB;
     }
-    if !chunks.remainder().is_empty() {
+    if !remainder.is_empty() {
         warnings.push(JpxWarning::note(format!(
             "ftyp compatibility list has {} trailing bytes",
-            chunks.remainder().len()
+            remainder.len()
         )));
     }
     if brand == BRAND_JP2 {
@@ -775,7 +775,7 @@ fn parse_cmap(
         )));
     }
     let mut entries = Vec::with_capacity(payload.len() / 4);
-    for chunk in payload.chunks_exact(4) {
+    for chunk in payload.as_chunks::<4>().0 {
         let component = be16(chunk);
         let mapping_type = chunk[2];
         let palette_column = chunk[3];
@@ -821,7 +821,9 @@ fn parse_cdef(payload: &[u8]) -> Result<Vec<ChannelDefinition>> {
         )));
     }
     Ok(payload[2..]
-        .chunks_exact(6)
+        .as_chunks::<6>()
+        .0
+        .iter()
         .map(|chunk| ChannelDefinition {
             channel: be16(chunk),
             kind: be16(&chunk[2..]),

--- a/crates/pdfboss-render/src/cff.rs
+++ b/crates/pdfboss-render/src/cff.rs
@@ -629,7 +629,7 @@ impl<'a> Type2Interpreter<'a> {
             }
             T2_RLINETO => {
                 let args = std::mem::take(&mut self.stack);
-                for pair in args.chunks_exact(2) {
+                for pair in args.as_chunks::<2>().0 {
                     self.lineto(pair[0] as f32, pair[1] as f32);
                 }
                 OpResult::Continue
@@ -649,7 +649,7 @@ impl<'a> Type2Interpreter<'a> {
             }
             T2_RRCURVETO => {
                 let args = std::mem::take(&mut self.stack);
-                for c in args.chunks_exact(6) {
+                for c in args.as_chunks::<6>().0 {
                     self.curveto(
                         c[0] as f32,
                         c[1] as f32,
@@ -681,7 +681,7 @@ impl<'a> Type2Interpreter<'a> {
                 let args = std::mem::take(&mut self.stack);
                 if args.len() >= 2 {
                     let (curves, line) = args.split_at(args.len() - 2);
-                    for c in curves.chunks_exact(6) {
+                    for c in curves.as_chunks::<6>().0 {
                         self.curveto(
                             c[0] as f32,
                             c[1] as f32,
@@ -699,7 +699,7 @@ impl<'a> Type2Interpreter<'a> {
                 let args = std::mem::take(&mut self.stack);
                 if args.len() >= 6 {
                     let (lines, curve) = args.split_at(args.len() - 6);
-                    for pair in lines.chunks_exact(2) {
+                    for pair in lines.as_chunks::<2>().0 {
                         self.lineto(pair[0] as f32, pair[1] as f32);
                     }
                     self.curveto(

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -287,7 +287,7 @@ impl Default for TextState {
 /// keep its backdrop and read as that backdrop's coverage.
 fn mask_from_group(pix: &Pixmap, luminosity: bool) -> Mask {
     let mut mask = Mask::new(pix.width, pix.height);
-    for (px, out) in pix.data.chunks_exact(4).zip(mask.data.iter_mut()) {
+    for (px, out) in pix.data.as_chunks::<4>().0.iter().zip(mask.data.iter_mut()) {
         *out = if luminosity {
             let luma =
                 (77 * u32::from(px[0]) + 150 * u32::from(px[1]) + 29 * u32::from(px[2])) >> 8;
@@ -4790,7 +4790,11 @@ mod tests {
             render_page_with_options(&doc, &page, 1.0, &RenderOptions::default()).expect("render");
         assert_eq!((pix.width, pix.height), (612, 792));
         assert!(
-            pix.data.chunks_exact(4).any(|p| p[0] != 255 || p[1] != 255),
+            pix.data
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .any(|p| p[0] != 255 || p[1] != 255),
             "page must contain non-white pixels"
         );
         // 1 0 0 rg 72 600 100 80 re -> device rows [112,192].

--- a/crates/pdfboss-render/src/glyph.rs
+++ b/crates/pdfboss-render/src/glyph.rs
@@ -938,7 +938,9 @@ async fn load_type0_truetype<S: AsyncObjectSource>(src: &S, cid: &Dict) -> Optio
         Some(Object::Stream(s)) => match decoded_stream_data_with(src, &s).await {
             Ok(bytes) => Some(
                 bytes
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| u16::from_be_bytes([c[0], c[1]]))
                     .collect(),
             ),
@@ -2226,7 +2228,9 @@ mod tests {
     #[cfg(feature = "substitute-fonts")]
     fn has_dark_ink(pix: &Pixmap) -> bool {
         pix.data
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .any(|p| p[0] < 200 && p[1] < 200 && p[2] < 200)
     }
 

--- a/crates/pdfboss-render/src/image.rs
+++ b/crates/pdfboss-render/src/image.rs
@@ -571,18 +571,18 @@ fn decode_jpeg<'a>(data: &[u8]) -> Option<Rgba<'a>> {
             }
         }
         jpeg_decoder::PixelFormat::L16 => {
-            for (i, pair) in pixels.chunks_exact(2).enumerate().take(w * h) {
+            for (i, pair) in pixels.as_chunks::<2>().0.iter().enumerate().take(w * h) {
                 let g = pair[0]; // big-endian: high byte carries the tone
                 out[i * 4..i * 4 + 3].copy_from_slice(&[g, g, g]);
             }
         }
         jpeg_decoder::PixelFormat::RGB24 => {
-            for (i, rgb) in pixels.chunks_exact(3).enumerate().take(w * h) {
+            for (i, rgb) in pixels.as_chunks::<3>().0.iter().enumerate().take(w * h) {
                 out[i * 4..i * 4 + 3].copy_from_slice(rgb);
             }
         }
         jpeg_decoder::PixelFormat::CMYK32 => {
-            for (i, cmyk) in pixels.chunks_exact(4).enumerate().take(w * h) {
+            for (i, cmyk) in pixels.as_chunks::<4>().0.iter().enumerate().take(w * h) {
                 let rgb = inverted_cmyk_to_rgb([cmyk[0], cmyk[1], cmyk[2], cmyk[3]]);
                 out[i * 4..i * 4 + 3].copy_from_slice(&rgb);
             }
@@ -857,7 +857,7 @@ fn jpx_rgba(
     let converted = decode_samples(width, height, &color_data, cs, 8, None);
     let mut quads = owned_quads(converted);
     if masking {
-        for (px, &a) in quads.chunks_exact_mut(4).zip(&alpha_data) {
+        for (px, &a) in quads.as_chunks_mut::<4>().0.iter_mut().zip(&alpha_data) {
             px[3] = a;
         }
     }

--- a/crates/pdfboss-render/src/lib.rs
+++ b/crates/pdfboss-render/src/lib.rs
@@ -98,8 +98,8 @@ impl Pixmap {
 
     /// Fills every pixel with `rgba`.
     pub fn fill(&mut self, rgba: [u8; 4]) {
-        for px in self.data.chunks_exact_mut(4) {
-            px.copy_from_slice(&rgba);
+        for px in self.data.as_chunks_mut::<4>().0 {
+            *px = rgba;
         }
     }
 

--- a/crates/pdfboss-render/src/raster.rs
+++ b/crates/pdfboss-render/src/raster.rs
@@ -675,8 +675,8 @@ fn blend_row<const NORMAL: bool>(
 /// Fills a run of pixels with one RGBA value (plain repeated 4-byte
 /// pattern; the loop lowers to wide stores).
 fn fill_run(dst: &mut [u8], px: [u8; 4]) {
-    for chunk in dst.chunks_exact_mut(4) {
-        chunk.copy_from_slice(&px);
+    for chunk in dst.as_chunks_mut::<4>().0 {
+        *chunk = px;
     }
 }
 

--- a/crates/pdfboss-render/src/type1.rs
+++ b/crates/pdfboss-render/src/type1.rs
@@ -107,7 +107,9 @@ fn hex_decode_lenient(region: &[u8]) -> Vec<u8> {
         }
     }
     nibbles
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| (pair[0] << 4) | pair[1])
         .collect()
 }

--- a/crates/pdfboss-render/tests/jpx_page.rs
+++ b/crates/pdfboss-render/tests/jpx_page.rs
@@ -45,7 +45,9 @@ fn render_clean(bytes: &[u8]) -> Pixmap {
 /// below 245 — the 9-7 wavelet is lossy, so near-white is still white).
 fn nonwhite(pix: &Pixmap) -> usize {
     pix.data
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .filter(|px| px[0] < 245 || px[1] < 245 || px[2] < 245)
         .count()
 }
@@ -53,7 +55,9 @@ fn nonwhite(pix: &Pixmap) -> usize {
 /// How many pixels are visibly chromatic rather than a shade of gray.
 fn colored(pix: &Pixmap) -> usize {
     pix.data
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .filter(|px| {
             let hi = px[0].max(px[1]).max(px[2]);
             let lo = px[0].min(px[1]).min(px[2]);

--- a/crates/pdfboss-render/tests/render_identity.rs
+++ b/crates/pdfboss-render/tests/render_identity.rs
@@ -69,7 +69,9 @@ fn digest(pix: &Pixmap) -> String {
 fn ink(pix: &Pixmap) -> String {
     let inked = pix
         .data
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .filter(|p| p[0] != 255 || p[1] != 255 || p[2] != 255)
         .count();
     let total = (pix.width * pix.height) as usize;
@@ -437,7 +439,9 @@ fn every_case_paints_something_distinct() {
         let pix = render(&case);
         let inked = pix
             .data
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .filter(|p| p[0] != 255 || p[1] != 255 || p[2] != 255)
             .count();
         assert!(
@@ -458,7 +462,9 @@ fn every_case_paints_something_distinct() {
 /// counts are exact rather than approximate.
 fn count_rgb(pix: &Pixmap, rgb: [u8; 3]) -> usize {
     pix.data
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .filter(|p| p[0] == rgb[0] && p[1] == rgb[1] && p[2] == rgb[2])
         .count()
 }

--- a/crates/pdfboss-testkit/src/crypt.rs
+++ b/crates/pdfboss-testkit/src/crypt.rs
@@ -61,10 +61,10 @@ fn md5(input: &[u8]) -> [u8; 16] {
         msg.push(0);
     }
     msg.extend_from_slice(&bitlen.to_le_bytes());
-    for chunk in msg.chunks_exact(64) {
+    for chunk in msg.as_chunks::<64>().0 {
         let mut m = [0u32; 16];
-        for (word, bytes) in m.iter_mut().zip(chunk.chunks_exact(4)) {
-            *word = u32::from_le_bytes(bytes.try_into().unwrap());
+        for (word, bytes) in m.iter_mut().zip(chunk.as_chunks::<4>().0) {
+            *word = u32::from_le_bytes(*bytes);
         }
         let (mut a, mut b, mut c, mut d) = (a0, b0, c0, d0);
         for i in 0..64 {


### PR DESCRIPTION
Rust 1.98.0 (Aug 18) shipped clippy's `chunks_exact_to_as_chunks` lint, which turned main's CI clippy gate red. The failures predate #53 — that merge was simply the first CI run on the new stable toolchain, and CI's error list was a lower bound since compilation aborted before linting the downstream crates.

All 37 sites across pdfboss-core, pdfboss-jpx, pdfboss-render, and pdfboss-testkit now use `as_chunks`/`as_chunks_mut`. Remainder handling in the ftyp compatibility list and JBIG2 row packing is preserved via the returned remainder slice; the array-typed chunks let the hash loops drop their `try_into().unwrap()`.

Verified on 1.98.0: `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p pdfboss-aio --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`, and `cargo test --workspace` (all suites green, 0 failed).