### PR TITLE
fix(render): stroke pen geometry, bilevel minification, and Tr modes

### DIFF
--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -317,18 +317,6 @@ fn rgba8(rgb: [f32; 3]) -> [u8; 4] {
     [q(rgb[0]), q(rgb[1]), q(rgb[2]), 255]
 }
 
-/// Approximate device scale of `m`: the square root of the absolute
-/// determinant (exact for uniform scaling), used to size stroke widths and
-/// dash lengths in device space.
-fn ctm_scale(m: Matrix) -> f32 {
-    let det = (m.a * m.d - m.b * m.c).abs();
-    if det.is_finite() && det > 0.0 {
-        det.sqrt()
-    } else {
-        1.0
-    }
-}
-
 /// True when every value is finite (NaN/Inf operands skip the op).
 fn all_finite(vals: &[f32]) -> bool {
     vals.iter().all(|v| v.is_finite())
@@ -1095,9 +1083,7 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             }
         }
         if how.stroke {
-            let s = ctm_scale(gs.ctm);
-            let dash: Vec<f32> = gs.dash.iter().map(|d| d * s).collect();
-            let quads = stroke_path(&polys, gs.line_width * s, &dash, gs.dash_phase * s);
+            let quads = stroke_path(&polys, gs.line_width, gs.ctm, &gs.dash, gs.dash_phase);
             match &stroke_pattern {
                 Some(PatternPaint::Shading(shading, to_device)) => self.paint_shading_through(
                     &quads,

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -120,6 +120,13 @@ struct GState {
     fill_alpha: f32,
     /// Constant stroke alpha (`CA`).
     stroke_alpha: f32,
+    /// Text rendering mode (`Tr`, ISO 32000-1 §9.3.6) — graphics state
+    /// (Table 104), so `Q` restores it; producers bracket their hidden OCR
+    /// layer with `q 3 Tr … Q` and never issue `0 Tr`. Modes 3 and 7 paint
+    /// nothing — painting a hidden OCR layer double-prints every searchable
+    /// scan. The other modes all paint as fills here: stroking and clipping
+    /// text are approximated by the shape they share.
+    text_render: i32,
     /// Active group soft mask (`/SMask` in `/ExtGState`), a device-space
     /// coverage mask multiplied into every paint alongside the clip. Its
     /// own field, never folded into `clip`: `/SMask /None` must reset it
@@ -145,6 +152,7 @@ impl GState {
             fill_pattern_name: None,
             stroke_pattern_name: None,
             line_width: 1.0,
+            text_render: 0,
             line_cap: 0,
             line_join: 0,
             miter_limit: 10.0,
@@ -858,6 +866,7 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                     Op::SetHorizScaling(v) if v.is_finite() => frame.ts.horiz = v / 100.0,
                     Op::SetLeading(v) if v.is_finite() => frame.ts.leading = *v,
                     Op::SetTextRise(v) if v.is_finite() => frame.ts.rise = *v,
+                    Op::SetTextRender(mode) => frame.gs.text_render = *mode,
                     Op::SetFont(name, size) => {
                         frame.ts.size = if size.is_finite() { *size } else { 0.0 };
                         frame.ts.font = self
@@ -1629,11 +1638,14 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
     /// CharProc frames are pushed by the driver, one at a time, before the
     /// frame's next operator.
     fn show_text(&mut self, frame: &mut Frame, bytes: &[u8]) {
+        // Modes 3 and 7 show nothing (ISO 32000-1 §9.3.6); the advances
+        // below still happen, so a visible run that follows stays placed.
+        let visible = !matches!(frame.gs.text_render, 3 | 7);
         if let Some(t3) = frame.ts.type3.clone() {
             // The depth guard bounds a self-referential glyph: each CharProc
             // frame is pushed at `depth + 1`, so painting stops at
             // `MAX_FORM_DEPTH` while the advances still happen.
-            let paint = frame.depth < MAX_FORM_DEPTH;
+            let paint = visible && frame.depth < MAX_FORM_DEPTH;
             let planned = type3_glyph_plan(&mut frame.ts, &t3, bytes, frame.gs.ctm, paint);
             frame.pending_glyphs.extend(planned);
             frame.pending_t3 = Some(t3);
@@ -1671,10 +1683,11 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                 .concat(params)
                 .concat(ts.tm)
                 .concat(gs.ctm);
-            if !font.paints() {
-                // A metrics-only font: the advance below is the whole point,
-                // and its unpainted codes are configured tier behavior, so
-                // neither the paint attempt nor the no-glyph report applies.
+            if !font.paints() || !visible {
+                // A metrics-only font or an invisible rendering mode: the
+                // advance below is the whole point, and nothing was going to
+                // paint, so neither the paint attempt nor the no-glyph
+                // report applies.
             } else if gid != 0 && finite_matrix(&to_device) {
                 // Flatten under the linear part only (memoized per glyph +
                 // linear map); the per-glyph translation is applied when the
@@ -2966,6 +2979,59 @@ mod tests {
         b.stream(4, "", content);
         extra(&mut b);
         b.build(1)
+    }
+
+    /// `3 Tr` is how a searchable scan hides its OCR text layer
+    /// (ISO 32000-1 §9.3.6): the glyphs position but never paint. Painting
+    /// them double-prints every such page — the scan and the recognized
+    /// text over it. The advance must survive, though, so a later visible
+    /// run lands where the invisible one left off.
+    #[test]
+    fn invisible_text_mode_advances_without_painting() {
+        let bytes = small_doc(
+            "/Font << /T3 5 0 R >>",
+            b"BT /T3 100 Tf 3 Tr 0 20 Td <41> Tj 0 Tr <41> Tj ET",
+            |b| {
+                b.object(
+                    5,
+                    "<< /Type /Font /Subtype /Type3 /FontBBox [0 0 1000 1000] \
+                     /FontMatrix [0.001 0 0 0.001 0 0] \
+                     /Encoding << /Differences [65 /box] >> \
+                     /CharProcs << /box 6 0 R >> /FirstChar 65 /Widths [500] >>",
+                );
+                b.stream(6, "", b"500 0 d0 0 0 500 500 re f");
+            },
+        );
+        let pix = render(bytes, 1.0);
+        // Each glyph is a 50x50 box on the baseline at y 20; the invisible
+        // first one spans device x 0..50, the visible second x 50..100.
+        assert_eq!(px(&pix, 25, 50), WHITE, "invisible glyph painted");
+        assert_eq!(px(&pix, 75, 50), BLACK, "visible glyph after the advance");
+    }
+
+    /// The rendering mode is graphics state (ISO 32000-1 §9.3.1, Table 104),
+    /// so `Q` must restore it: producers write `q … 3 Tr … Q` and rely on
+    /// the restore instead of issuing `0 Tr`. A mode that leaked past `Q`
+    /// would blank every glyph after the OCR block — worse than the
+    /// double-print it was hiding.
+    #[test]
+    fn text_render_mode_is_restored_by_q() {
+        let bytes = small_doc(
+            "/Font << /T3 5 0 R >>",
+            b"q BT /T3 100 Tf 3 Tr ET Q BT /T3 100 Tf 0 20 Td <41> Tj ET",
+            |b| {
+                b.object(
+                    5,
+                    "<< /Type /Font /Subtype /Type3 /FontBBox [0 0 1000 1000] \
+                     /FontMatrix [0.001 0 0 0.001 0 0] \
+                     /Encoding << /Differences [65 /box] >> \
+                     /CharProcs << /box 6 0 R >> /FirstChar 65 /Widths [500] >>",
+                );
+                b.stream(6, "", b"500 0 d0 0 0 500 500 re f");
+            },
+        );
+        let pix = render(bytes, 1.0);
+        assert_eq!(px(&pix, 25, 50), BLACK, "text after Q must paint");
     }
 
     #[test]

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -1641,6 +1641,12 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         // Modes 3 and 7 show nothing (ISO 32000-1 §9.3.6); the advances
         // below still happen, so a visible run that follows stays placed.
         let visible = !matches!(frame.gs.text_render, 3 | 7);
+        // Modes 4-7 also ask the glyph outlines to join the clipping path,
+        // which this renderer does not do: whatever the author clipped to
+        // the text paints unclipped, and that approximation is reported.
+        if matches!(frame.gs.text_render, 4..=7) && !bytes.is_empty() {
+            self.skip(SkippedKind::TextClip, SkipReason::Unsupported);
+        }
         if let Some(t3) = frame.ts.type3.clone() {
             // The depth guard bounds a self-referential glyph: each CharProc
             // frame is pushed at `depth + 1`, so painting stops at
@@ -3007,6 +3013,42 @@ mod tests {
         // first one spans device x 0..50, the visible second x 50..100.
         assert_eq!(px(&pix, 25, 50), WHITE, "invisible glyph painted");
         assert_eq!(px(&pix, 75, 50), BLACK, "visible glyph after the advance");
+    }
+
+    /// The clipping half of modes 4-7 is not implemented — the glyph
+    /// outlines never join the clipping path, so content the author clipped
+    /// to text paints unclipped — and an approximation is never silent:
+    /// showing text in those modes must land in the report. Mode 0 must not.
+    #[test]
+    fn text_clip_modes_are_reported() {
+        let font = |b: &mut PdfBuilder| {
+            b.object(
+                5,
+                "<< /Type /Font /Subtype /Type3 /FontBBox [0 0 1000 1000] \
+                 /FontMatrix [0.001 0 0 0.001 0 0] \
+                 /Encoding << /Differences [65 /box] >> \
+                 /CharProcs << /box 6 0 R >> /FirstChar 65 /Widths [500] >>",
+            );
+            b.stream(6, "", b"500 0 d0 0 0 500 500 re f");
+        };
+        let clipping = small_doc(
+            "/Font << /T3 5 0 R >>",
+            b"BT /T3 100 Tf 7 Tr 0 20 Td <41> Tj ET",
+            font,
+        );
+        let (pix, report) = render_reporting(clipping);
+        assert_eq!(
+            drops(&report),
+            vec![(SkippedKind::TextClip, SkipReason::Unsupported, 1)],
+        );
+        assert_eq!(px(&pix, 25, 50), WHITE, "mode 7 shows nothing");
+        let plain = small_doc(
+            "/Font << /T3 5 0 R >>",
+            b"BT /T3 100 Tf 0 20 Td <41> Tj ET",
+            font,
+        );
+        let (_, report) = render_reporting(plain);
+        assert_eq!(drops(&report), vec![], "mode 0 reports nothing");
     }
 
     /// The rendering mode is graphics state (ISO 32000-1 §9.3.1, Table 104),

--- a/crates/pdfboss-render/src/image.rs
+++ b/crates/pdfboss-render/src/image.rs
@@ -239,6 +239,9 @@ impl Rgba<'_> {
         let jstep = (j1 - j0).div_ceil(FOOTPRINT_SAMPLES).max(1);
         // Packed 1-bit samples — every CCITT and JBIG2 scan — average by
         // counting set bits per row instead of converting pixel by pixel.
+        // The count walks the row in full, so past FOOTPRINT_SAMPLES bytes
+        // of width the strided read below keeps the per-device-pixel bound
+        // instead.
         if let Pixels::Packed {
             data,
             bpc: 1,
@@ -247,17 +250,19 @@ impl Rgba<'_> {
         } = &self.pixels
         {
             if let [zero, one] = lut[..] {
-                let mut ones = 0u32;
-                let mut n = 0u32;
-                for j in (j0..j1).step_by(jstep) {
-                    ones += ones_in_row(data, j * row_bytes, i0, i1);
-                    n += (i1 - i0) as u32;
+                if i1 - i0 <= FOOTPRINT_SAMPLES * 8 {
+                    let mut ones = 0u32;
+                    let mut n = 0u32;
+                    for j in (j0..j1).step_by(jstep) {
+                        ones += ones_in_row(data, j * row_bytes, i0, i1);
+                        n += (i1 - i0) as u32;
+                    }
+                    let zeros = n - ones;
+                    let mix = |c: usize| {
+                        ((ones * u32::from(one[c]) + zeros * u32::from(zero[c]) + n / 2) / n) as u8
+                    };
+                    return [mix(0), mix(1), mix(2), mix(3)];
                 }
-                let zeros = n - ones;
-                let mix = |c: usize| {
-                    ((ones * u32::from(one[c]) + zeros * u32::from(zero[c]) + n / 2) / n) as u8
-                };
-                return [mix(0), mix(1), mix(2), mix(3)];
             }
         }
         let istep = (i1 - i0).div_ceil(FOOTPRINT_SAMPLES).max(1);
@@ -1193,8 +1198,9 @@ fn draw_rgba(pix: &mut Pixmap, img: &Rgba<'_>, p: &DrawParams) {
     if minified {
         rx = (fx as usize).max(1);
         ry = (fy as usize).max(1);
-        let visible = (x1.saturating_sub(x0) as usize) * (y1.saturating_sub(y0) as usize);
-        if visible * 4 < img.width.div_ceil(rx) * img.height.div_ceil(ry) {
+        let visible = u64::from(x1.saturating_sub(x0)) * u64::from(y1.saturating_sub(y0));
+        let texels = (img.width.div_ceil(rx) as u64) * (img.height.div_ceil(ry) as u64);
+        if visible * 4 < texels {
             rx = 1;
             ry = 1;
         }

--- a/crates/pdfboss-render/src/image.rs
+++ b/crates/pdfboss-render/src/image.rs
@@ -107,7 +107,208 @@ impl Rgba<'_> {
             }
         }
     }
+
+    /// A copy shrunk by integer factors: each output pixel averages an
+    /// `rx` by `ry` block of this image (smaller blocks at the right and
+    /// bottom edges). One sequential pass over the source; drawing then
+    /// samples the copy the way it samples any image, so the per-device-
+    /// pixel cost of a minified draw stays what point sampling costs.
+    fn reduced(&self, rx: usize, ry: usize) -> Rgba<'static> {
+        if let Pixels::Packed {
+            data,
+            bpc: 1,
+            row_bytes,
+            lut,
+        } = &self.pixels
+        {
+            if let [zero, one] = lut[..] {
+                return self.reduced_bilevel(rx, ry, data, *row_bytes, zero, one);
+            }
+        }
+        let rw = self.width.div_ceil(rx);
+        let rh = self.height.div_ceil(ry);
+        let mut quads = vec![0u8; rw * rh * 4];
+        let mut sums = vec![[0u32; 4]; rw];
+        for jr in 0..rh {
+            sums.fill([0; 4]);
+            let j1 = ((jr + 1) * ry).min(self.height);
+            for j in jr * ry..j1 {
+                for i in 0..self.width {
+                    let s = self.at(i, j);
+                    for (acc, v) in sums[i / rx].iter_mut().zip(s) {
+                        *acc += u32::from(v);
+                    }
+                }
+            }
+            let rows = (j1 - jr * ry) as u32;
+            let out = quads[jr * rw * 4..(jr + 1) * rw * 4].as_chunks_mut::<4>().0;
+            for (ir, (texel, sum)) in out.iter_mut().zip(&sums).enumerate() {
+                let n = rows * rx.min(self.width - ir * rx) as u32;
+                for (t, acc) in texel.iter_mut().zip(sum) {
+                    *t = ((acc + n / 2) / n) as u8;
+                }
+            }
+        }
+        Rgba {
+            width: rw,
+            height: rh,
+            pixels: Pixels::Quads(quads),
+            truncated: self.truncated,
+        }
+    }
+
+    /// [`Rgba::reduced`] for packed 1-bit samples — every CCITT and JBIG2
+    /// scan — counting set bits per block instead of converting pixel by
+    /// pixel.
+    fn reduced_bilevel(
+        &self,
+        rx: usize,
+        ry: usize,
+        data: &[u8],
+        row_bytes: usize,
+        zero: [u8; 4],
+        one: [u8; 4],
+    ) -> Rgba<'static> {
+        let rw = self.width.div_ceil(rx);
+        let rh = self.height.div_ceil(ry);
+        let mut quads = vec![0u8; rw * rh * 4];
+        let mut ones = vec![0u32; rw];
+        for jr in 0..rh {
+            ones.fill(0);
+            let j1 = ((jr + 1) * ry).min(self.height);
+            for j in jr * ry..j1 {
+                let row = data.get(j * row_bytes..).unwrap_or(&[]);
+                let row = &row[..row.len().min(row_bytes)];
+                // One walk over the row's bytes: a byte whose bits all land
+                // in one block adds its popcount; one that straddles blocks
+                // (and the padded last byte) splits bit by bit.
+                for (b, &byte) in row.iter().enumerate() {
+                    if byte == 0 {
+                        continue;
+                    }
+                    let bit0 = b * 8;
+                    if bit0 + 8 <= self.width && bit0 / rx == (bit0 + 7) / rx {
+                        ones[bit0 / rx] += byte.count_ones();
+                        continue;
+                    }
+                    for k in 0..8.min(self.width - bit0) {
+                        ones[(bit0 + k) / rx] += u32::from((byte >> (7 - k)) & 1);
+                    }
+                }
+            }
+            let rows = (j1 - jr * ry) as u32;
+            let out = quads[jr * rw * 4..(jr + 1) * rw * 4].as_chunks_mut::<4>().0;
+            for (ir, (texel, k)) in out.iter_mut().zip(&ones).enumerate() {
+                let n = rows * rx.min(self.width - ir * rx) as u32;
+                for c in 0..4 {
+                    texel[c] =
+                        ((k * u32::from(one[c]) + (n - k) * u32::from(zero[c]) + n / 2) / n) as u8;
+                }
+            }
+        }
+        Rgba {
+            width: rw,
+            height: rh,
+            pixels: Pixels::Quads(quads),
+            truncated: self.truncated,
+        }
+    }
+
+    /// The average pixel over the box of half-extents `hx`, `hy` around
+    /// (`ic`, `jc`), all in image pixels — the source footprint of one
+    /// device pixel when the image is drawn smaller than itself. Every
+    /// channel is averaged, alpha included, which is what turns a halftone
+    /// pattern back into its gray and a stencil's dropped-or-kept pixels
+    /// into fractional coverage.
+    ///
+    /// A footprint wider than [`FOOTPRINT_SAMPLES`] pixels on an axis is
+    /// read at a stride instead of in full, which bounds the cost of a
+    /// device pixel to a constant however extreme the shrink.
+    fn averaged(&self, ic: f32, jc: f32, hx: f32, hy: f32) -> [u8; 4] {
+        // Rounded box edges rather than floor/ceil ones: adjacent device
+        // pixels then split the boundary source pixel instead of both
+        // reading it, which keeps the total work one read per source pixel.
+        // The caller clamps the center into the image, so each range below
+        // holds at least one pixel.
+        let i0 = ((ic - hx).round().max(0.0) as usize).min(self.width - 1);
+        let i1 = (((ic + hx).round()).max(0.0) as usize).clamp(i0 + 1, self.width);
+        // `jc` reaches exactly `height` when `v = 0` maps onto a pixel
+        // center, and rounding `height - 0.5` would step past the last row.
+        let j0 = ((jc - hy).round().max(0.0) as usize).min(self.height - 1);
+        let j1 = (((jc + hy).round()).max(0.0) as usize).clamp(j0 + 1, self.height);
+        let jstep = (j1 - j0).div_ceil(FOOTPRINT_SAMPLES).max(1);
+        // Packed 1-bit samples — every CCITT and JBIG2 scan — average by
+        // counting set bits per row instead of converting pixel by pixel.
+        if let Pixels::Packed {
+            data,
+            bpc: 1,
+            row_bytes,
+            lut,
+        } = &self.pixels
+        {
+            if let [zero, one] = lut[..] {
+                let mut ones = 0u32;
+                let mut n = 0u32;
+                for j in (j0..j1).step_by(jstep) {
+                    ones += ones_in_row(data, j * row_bytes, i0, i1);
+                    n += (i1 - i0) as u32;
+                }
+                let zeros = n - ones;
+                let mix = |c: usize| {
+                    ((ones * u32::from(one[c]) + zeros * u32::from(zero[c]) + n / 2) / n) as u8
+                };
+                return [mix(0), mix(1), mix(2), mix(3)];
+            }
+        }
+        let istep = (i1 - i0).div_ceil(FOOTPRINT_SAMPLES).max(1);
+        let mut sum = [0u32; 4];
+        let mut n = 0u32;
+        for j in (j0..j1).step_by(jstep) {
+            for i in (i0..i1).step_by(istep) {
+                let s = self.at(i, j);
+                for (acc, v) in sum.iter_mut().zip(s) {
+                    *acc += u32::from(v);
+                }
+                n += 1;
+            }
+        }
+        [
+            ((sum[0] + n / 2) / n) as u8,
+            ((sum[1] + n / 2) / n) as u8,
+            ((sum[2] + n / 2) / n) as u8,
+            ((sum[3] + n / 2) / n) as u8,
+        ]
+    }
 }
+
+/// Set bits of the row starting at byte `row`, sample columns `i0..i1`
+/// (1-bit samples, MSB first). Bytes past the end of the data count as
+/// zero, matching [`Rgba::at`]'s leniency toward short data.
+fn ones_in_row(data: &[u8], row: usize, i0: usize, i1: usize) -> u32 {
+    let first = i0 / 8;
+    let last = (i1 - 1) / 8;
+    let mut ones = 0u32;
+    for b in first..=last {
+        let mut byte = data.get(row + b).copied().unwrap_or(0);
+        if b == first {
+            byte &= 0xFF >> (i0 % 8);
+        }
+        if b == last {
+            byte &= 0xFF << (7 - (i1 - 1) % 8);
+        }
+        ones += byte.count_ones();
+    }
+    ones
+}
+
+/// Point sampling holds until a device pixel spans more than this many
+/// source pixels on either image axis; past it the footprint is averaged.
+/// Slightly above one so that 1:1 placements with rounding jitter keep the
+/// exact-copy path.
+const MINIFICATION_THRESHOLD: f32 = 1.25;
+
+/// Cap on averaged samples per image axis of one device pixel's footprint.
+const FOOTPRINT_SAMPLES: usize = 64;
 
 /// How much of an image [`draw`] managed to paint.
 pub(crate) enum Drawn {
@@ -950,6 +1151,13 @@ fn composite_over(dst: &mut [u8], rgb: [u8; 3], a: f32) {
 /// unit square through `p.ctm`, sampling nearest-neighbor (image row 0 at
 /// the `v = 1` edge), and compositing source-over with the constant alpha
 /// and clip mask.
+///
+/// Nearest is right at 1:1 and under magnification, where it keeps bilevel
+/// edges crisp. Under minification a device pixel spans several source
+/// pixels and point sampling keeps one of them, which reads a halftoned
+/// scan as moiré stripes and drops the thin strokes of scanned text; there
+/// the sample is the average of the device pixel's source footprint
+/// instead ([`Rgba::averaged`]).
 fn draw_rgba(pix: &mut Pixmap, img: &Rgba<'_>, p: &DrawParams) {
     let Some(inv) = p.ctm.invert() else {
         return;
@@ -967,15 +1175,49 @@ fn draw_rgba(pix: &mut Pixmap, img: &Rgba<'_>, p: &DrawParams) {
     let y0 = bbox.y0.floor().max(0.0) as u32;
     let x1 = (bbox.x1.ceil().max(0.0) as u32).min(pix.width);
     let y1 = (bbox.y1.ceil().max(0.0) as u32).min(pix.height);
+    // Source pixels one device-pixel step spans, per image axis: the sum of
+    // the two inverse-mapped device steps, so rotations and shears count
+    // their full reach.
+    let fx = (inv.a.abs() + inv.c.abs()) * img.width as f32;
+    let fy = (inv.b.abs() + inv.d.abs()) * img.height as f32;
+    let minified = fx.is_finite()
+        && fy.is_finite()
+        && (fx > MINIFICATION_THRESHOLD || fy > MINIFICATION_THRESHOLD);
+    // Shrink whole axes of the image first — one sequential pass — and keep
+    // per-pixel footprint averaging only for what a pass cannot serve: the
+    // sub-2x fraction the integer factors leave, and a draw whose visible
+    // part is so small that reducing the whole image would out-cost it
+    // (the box cost there is bounded by the same factors being under 2).
+    let mut rx = 1;
+    let mut ry = 1;
+    if minified {
+        rx = (fx as usize).max(1);
+        ry = (fy as usize).max(1);
+        let visible = (x1.saturating_sub(x0) as usize) * (y1.saturating_sub(y0) as usize);
+        if visible * 4 < img.width.div_ceil(rx) * img.height.div_ceil(ry) {
+            rx = 1;
+            ry = 1;
+        }
+    }
+    let reduced = (rx > 1 || ry > 1).then(|| img.reduced(rx, ry));
+    let img = reduced.as_ref().unwrap_or(img);
+    let (fx, fy) = (fx / rx as f32, fy / ry as f32);
+    let footprint = (minified && (fx > MINIFICATION_THRESHOLD || fy > MINIFICATION_THRESHOLD))
+        .then_some((fx.max(1.0) / 2.0, fy.max(1.0) / 2.0));
     for py in y0..y1 {
         for px in x0..x1 {
             let u = inv.apply(Point::new(px as f32 + 0.5, py as f32 + 0.5));
             if !(0.0..1.0).contains(&u.x) || !(0.0..1.0).contains(&u.y) {
                 continue;
             }
-            let i = ((u.x * img.width as f32) as usize).min(img.width - 1);
-            let j = (((1.0 - u.y) * img.height as f32) as usize).min(img.height - 1);
-            let s = img.at(i, j);
+            let ic = u.x * img.width as f32;
+            let jc = (1.0 - u.y) * img.height as f32;
+            let i = (ic as usize).min(img.width - 1);
+            let j = (jc as usize).min(img.height - 1);
+            let s = match footprint {
+                None => img.at(i, j),
+                Some((hx, hy)) => img.averaged(ic, jc, hx, hy),
+            };
             let mut a = f32::from(s[3]) / 255.0 * alpha;
             if let Some(m) = p.smask {
                 a *= f32::from(m.sample(u.x, u.y)) / 255.0;
@@ -1700,6 +1942,178 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// An 8x8 one-pixel checkerboard squeezed into 2x2 device pixels. Point
+    /// sampling lands on one source pixel per device pixel — solid black or
+    /// solid white, and which one is an accident of rounding; that is the
+    /// moiré that turns a halftoned scan into stripes. Averaging the device
+    /// pixel's source footprint reads all sixteen and lands on the gray the
+    /// halftone encodes.
+    #[test]
+    fn minified_halftone_averages_to_its_gray() {
+        let mut quads = Vec::with_capacity(8 * 8 * 4);
+        for j in 0..8u8 {
+            for i in 0..8u8 {
+                let v = if (i + j) % 2 == 0 { 0 } else { 255 };
+                quads.extend_from_slice(&[v, v, v, 255]);
+            }
+        }
+        let img = Rgba {
+            width: 8,
+            height: 8,
+            pixels: Pixels::Quads(quads),
+            truncated: false,
+        };
+        let mut pix = Pixmap::new(2, 2);
+        let p = DrawParams {
+            ctm: Matrix::scale(2.0, 2.0),
+            alpha: 1.0,
+            fill_rgb: [0; 3],
+            clip: None,
+            blend: BlendMode::Normal,
+            smask: None,
+        };
+        draw_rgba(&mut pix, &img, &p);
+        for y in 0..2 {
+            for x in 0..2 {
+                let [r, _, _, a] = pix_at(&pix, x, y);
+                assert!((112..=144).contains(&r), "({x},{y}) gray {r}, want ~128");
+                assert_eq!(a, 255, "({x},{y}) opaque");
+            }
+        }
+    }
+
+    fn checkerboard(side: u8) -> Rgba<'static> {
+        let mut quads = Vec::with_capacity(usize::from(side) * usize::from(side) * 4);
+        for j in 0..side {
+            for i in 0..side {
+                let v = if (i + j) % 2 == 0 { 0 } else { 255 };
+                quads.extend_from_slice(&[v, v, v, 255]);
+            }
+        }
+        Rgba {
+            width: usize::from(side),
+            height: usize::from(side),
+            pixels: Pixels::Quads(quads),
+            truncated: false,
+        }
+    }
+
+    /// A shrink factor between the integer reductions (11 source pixels per
+    /// 2.75 device steps: reduce by 2, then a 1.375 residual) exercises the
+    /// per-pixel footprint average over the reduced copy.
+    #[test]
+    fn fractional_minification_still_averages() {
+        let mut pix = Pixmap::new(4, 4);
+        let p = DrawParams {
+            ctm: Matrix::scale(4.0, 4.0),
+            alpha: 1.0,
+            fill_rgb: [0; 3],
+            clip: None,
+            blend: BlendMode::Normal,
+            smask: None,
+        };
+        draw_rgba(&mut pix, &checkerboard(11), &p);
+        // Interior pixels only: at the image's edges the residual box can
+        // degenerate to a single one-source-pixel block, which is not gray.
+        for y in 1..3 {
+            for x in 1..3 {
+                let [r, _, _, _] = pix_at(&pix, x, y);
+                assert!((100..=156).contains(&r), "({x},{y}) gray {r}, want ~128");
+            }
+        }
+    }
+
+    /// A draw whose visible part is a sliver of the image skips the
+    /// whole-image reduction pass and still averages per device pixel.
+    #[test]
+    fn minified_sliver_averages_without_a_reduction_pass() {
+        let mut pix = Pixmap::new(2, 2);
+        let p = DrawParams {
+            ctm: Matrix::scale(8.0, 8.0),
+            alpha: 1.0,
+            fill_rgb: [0; 3],
+            clip: None,
+            blend: BlendMode::Normal,
+            smask: None,
+        };
+        draw_rgba(&mut pix, &checkerboard(32), &p);
+        for y in 0..2 {
+            for x in 0..2 {
+                let [r, _, _, _] = pix_at(&pix, x, y);
+                assert!((112..=144).contains(&r), "({x},{y}) gray {r}, want ~128");
+            }
+        }
+    }
+
+    /// The packed 1-bit layout every CCITT and JBIG2 scan decodes into has
+    /// its own counting path through [`Rgba::averaged`]; it must land on
+    /// the same gray the generic path finds.
+    #[test]
+    fn minified_packed_bilevel_averages_to_its_gray() {
+        // 8x8 one-pixel checkerboard, one byte per row, MSB first.
+        let data: &[u8] = &[0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA];
+        let img = Rgba {
+            width: 8,
+            height: 8,
+            pixels: Pixels::Packed {
+                data,
+                bpc: 1,
+                row_bytes: 1,
+                lut: vec![[0, 0, 0, 255], [255, 255, 255, 255]],
+            },
+            truncated: false,
+        };
+        let mut pix = Pixmap::new(2, 2);
+        let p = DrawParams {
+            ctm: Matrix::scale(2.0, 2.0),
+            alpha: 1.0,
+            fill_rgb: [0; 3],
+            clip: None,
+            blend: BlendMode::Normal,
+            smask: None,
+        };
+        draw_rgba(&mut pix, &img, &p);
+        for y in 0..2 {
+            for x in 0..2 {
+                let [r, _, _, _] = pix_at(&pix, x, y);
+                assert!((112..=144).contains(&r), "({x},{y}) gray {r}, want ~128");
+            }
+        }
+    }
+
+    /// The stencil analogue: a mask whose alpha alternates opaque/clear per
+    /// pixel paints half-coverage when minified, not the all-or-nothing a
+    /// point sample gives. Black at 50% over white must land mid-gray.
+    #[test]
+    fn minified_stencil_paints_fractional_coverage() {
+        let mut quads = Vec::with_capacity(8 * 8 * 4);
+        for j in 0..8u8 {
+            for i in 0..8u8 {
+                let a = if (i + j) % 2 == 0 { 255 } else { 0 };
+                quads.extend_from_slice(&[0, 0, 0, a]);
+            }
+        }
+        let img = Rgba {
+            width: 8,
+            height: 8,
+            pixels: Pixels::Quads(quads),
+            truncated: false,
+        };
+        let mut pix = Pixmap::new(2, 2);
+        pix.fill([255, 255, 255, 255]);
+        let p = DrawParams {
+            ctm: Matrix::scale(2.0, 2.0),
+            alpha: 1.0,
+            fill_rgb: [0; 3],
+            clip: None,
+            blend: BlendMode::Normal,
+            smask: None,
+        };
+        draw_rgba(&mut pix, &img, &p);
+        let [r, _, _, _] = pix_at(&pix, 1, 1);
+        assert!((112..=144).contains(&r), "coverage gray {r}, want ~128");
     }
 
     #[test]

--- a/crates/pdfboss-render/src/lib.rs
+++ b/crates/pdfboss-render/src/lib.rs
@@ -294,6 +294,11 @@ pub enum SkippedKind {
     /// failure) is configured behavior and stays unreported; such a font
     /// still loads its metrics so the text advances.
     Glyph,
+    /// Text shown in a clipping rendering mode (`Tr` 4-7, ISO 32000-1
+    /// §9.3.6). The painting half of the mode is honored, but the glyph
+    /// outlines never join the clipping path, so content the author
+    /// clipped to the text paints unclipped.
+    TextClip,
 }
 
 impl SkippedKind {
@@ -322,6 +327,8 @@ impl SkippedKind {
             SkippedKind::Annotation => "annotations",
             SkippedKind::Glyph if one => "glyph",
             SkippedKind::Glyph => "glyphs",
+            SkippedKind::TextClip if one => "text clip",
+            SkippedKind::TextClip => "text clips",
         }
     }
 }

--- a/crates/pdfboss-render/src/stroke.rs
+++ b/crates/pdfboss-render/src/stroke.rs
@@ -1,11 +1,22 @@
 //! Stroking: flattened segments expanded to offset quads with approximated
 //! round joins/caps, and dash patterns applied at the flatten level.
+//!
+//! The pen is a circle in *user* space (ISO 32000-1 §8.4.3.2), so in device
+//! space it is that circle carried through the current transformation — an
+//! ellipse under anisotropic scaling. Reducing the matrix to one scalar
+//! (say the square root of its determinant) mis-sizes every stroke the
+//! moment the two axes scale differently: a matrix like
+//! `0 2.0629 0.4848 0 0 0 cm` has determinant ~1, and scalar-width strokes
+//! under it come out at half their true thickness, turning the stroked-line
+//! gradients some producers emit into stripes. Everything here therefore
+//! takes the matrix itself and offsets each segment by the device image of
+//! the user-space pen radius.
 
-use pdfboss_core::geom::Point;
+use pdfboss_core::geom::{Matrix, Point};
 
 use crate::path::Subpath;
 
-/// Minimum stroke width in device pixels; thinner pens still leave a
+/// Minimum stroke thickness in device pixels; thinner pens still leave a
 /// visible hairline.
 const MIN_WIDTH: f32 = 0.75;
 /// Vertex count of the small fan approximating round joins and caps.
@@ -14,17 +25,23 @@ const FAN_SEGMENTS: usize = 12;
 /// patterns (e.g. many near-zero entries).
 const MAX_DASH_PIECES: usize = 65_536;
 
-fn dist(a: Point, b: Point) -> f32 {
-    (b.x - a.x).hypot(b.y - a.y)
-}
-
 fn lerp(a: Point, b: Point, t: f32) -> Point {
     Point::new(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t)
 }
 
-/// Splits a polyline into its painted ("on") runs according to a dash
-/// pattern. An empty or degenerate pattern yields the whole polyline.
-fn dash_split(points: &[Point], dash: &[f32], phase: f32) -> Vec<Vec<Point>> {
+/// The linear part of `m` applied to a vector — a direction or offset,
+/// which a translation never touches.
+fn linear(m: Matrix, v: Point) -> Point {
+    Point::new(m.a * v.x + m.c * v.y, m.b * v.x + m.d * v.y)
+}
+
+/// Splits a polyline of device-space points into its painted ("on") runs
+/// according to a dash pattern. The pattern and phase are user-space
+/// quantities (ISO 32000-1 §8.4.3.6), so each segment is measured through
+/// `inv`, the device-to-user matrix; the cut positions themselves are
+/// fractions along the segment, which a linear map preserves. An empty or
+/// degenerate pattern yields the whole polyline.
+fn dash_split(points: &[Point], dash: &[f32], phase: f32, inv: Matrix) -> Vec<Vec<Point>> {
     let pattern: Vec<f32> = dash
         .iter()
         .copied()
@@ -58,7 +75,10 @@ fn dash_split(points: &[Point], dash: &[f32], phase: f32) -> Vec<Vec<Point>> {
     let mut pieces = 0usize;
     for seg in points.windows(2) {
         let (a, b) = (seg[0], seg[1]);
-        let seglen = dist(a, b);
+        let seglen = {
+            let u = linear(inv, Point::new(b.x - a.x, b.y - a.y));
+            u.x.hypot(u.y)
+        };
         let mut done = 0.0f32;
         while seglen - done > rem && pieces < MAX_DASH_PIECES {
             done += rem;
@@ -89,36 +109,101 @@ fn dash_split(points: &[Point], dash: &[f32], phase: f32) -> Vec<Vec<Point>> {
     runs
 }
 
-/// The offset quad covering one stroked segment. All quads share one
-/// intrinsic orientation, so overlapping pieces union under the nonzero
-/// rule. Returns `None` for zero-length segments.
-fn segment_quad(p: Point, q: Point, r: f32) -> Option<Subpath> {
+/// The pen carried into device space: the user-to-device matrix, its
+/// inverse, and the sign of its determinant, which is the one orientation
+/// every quad and fan must share for their union to survive the nonzero
+/// rule (a negative determinant flips them all together).
+#[derive(Clone, Copy)]
+struct Pen {
+    to_device: Matrix,
+    to_user: Matrix,
+    /// User-space pen radius (half the `/LineWidth`).
+    r: f32,
+    /// +1.0 or -1.0, the handedness of `to_device`.
+    winding: f32,
+    /// The device pen radius when `to_device` maps circles to circles —
+    /// every scale/rotation/flip matrix, which is nearly every matrix a
+    /// document sets. There the offset is the plain device perpendicular
+    /// and the per-segment inverse mapping below is skipped.
+    uniform_r: Option<f32>,
+}
+
+/// The offset quad covering one stroked segment of device points. The
+/// offset is the device image of the user-space pen radius perpendicular
+/// to the segment *in user space* — generally not perpendicular to the
+/// device segment; the parallelogram it spans is the transformed pen band.
+/// All quads share the orientation [`Pen::winding`] names, so overlapping
+/// pieces union under the nonzero rule. Returns `None` for zero-length
+/// segments.
+fn segment_quad(p: Point, q: Point, pen: Pen) -> Option<Subpath> {
     let dx = q.x - p.x;
     let dy = q.y - p.y;
     let len = dx.hypot(dy);
     if len <= 1e-6 || !len.is_finite() {
         return None;
     }
-    let nx = -dy / len * r;
-    let ny = dx / len * r;
+    let mut o = if let Some(r) = pen.uniform_r {
+        Point::new(-dy / len * r * pen.winding, dx / len * r * pen.winding)
+    } else {
+        let u = linear(pen.to_user, Point::new(dx, dy));
+        let ulen = u.x.hypot(u.y);
+        if ulen > 0.0 && ulen.is_finite() {
+            linear(
+                pen.to_device,
+                Point::new(-u.y / ulen * pen.r, u.x / ulen * pen.r),
+            )
+        } else {
+            Point::new(0.0, 0.0)
+        }
+    };
+    // The band's half-thickness across the device segment (the tangential
+    // part of the offset skews the quad without thickening it). Clamping
+    // it here rather than clamping the width keeps hairlines visible in
+    // exactly the direction they are thin.
+    let across = ((o.x * -dy + o.y * dx) / len).abs();
+    if !across.is_finite() || across <= 0.0 {
+        let h = MIN_WIDTH / 2.0 * pen.winding;
+        o = Point::new(-dy / len * h, dx / len * h);
+    } else if across < MIN_WIDTH / 2.0 {
+        let k = MIN_WIDTH / 2.0 / across;
+        o = Point::new(o.x * k, o.y * k);
+    }
     Some(Subpath {
         points: vec![
-            Point::new(p.x + nx, p.y + ny),
-            Point::new(q.x + nx, q.y + ny),
-            Point::new(q.x - nx, q.y - ny),
-            Point::new(p.x - nx, p.y - ny),
+            Point::new(p.x + o.x, p.y + o.y),
+            Point::new(q.x + o.x, q.y + o.y),
+            Point::new(q.x - o.x, q.y - o.y),
+            Point::new(p.x - o.x, p.y - o.y),
         ],
         closed: true,
     })
 }
 
-/// A small fan (regular polygon) of radius `r` around `c`, wound to match
-/// [`segment_quad`]'s orientation; approximates round joins and caps.
-fn disc(c: Point, r: f32) -> Subpath {
+/// A small fan around `c` approximating the pen's own shape — the device
+/// image of the user-space circle of radius `pen.r`, an ellipse — used for
+/// round joins and caps. Wound to match [`segment_quad`]'s orientation.
+/// A vertex that would land inside the minimum hairline disc is pushed out
+/// to it radially, which keeps sub-hairline caps visible and preserves the
+/// winding.
+fn disc(c: Point, pen: Pen) -> Subpath {
     let mut points = Vec::with_capacity(FAN_SEGMENTS);
     for i in 0..FAN_SEGMENTS {
         let theta = -(i as f32) * std::f32::consts::TAU / FAN_SEGMENTS as f32;
-        points.push(Point::new(c.x + r * theta.cos(), c.y + r * theta.sin()));
+        let (sin, cos) = theta.sin_cos();
+        // Mapping through the matrix flips the fan's orientation exactly
+        // when it flips the quads', so no correction is needed here; only
+        // the unmapped fallback below must be reflected to match.
+        let v = linear(pen.to_device, Point::new(pen.r * cos, pen.r * sin));
+        let vlen = v.x.hypot(v.y);
+        let v = if !vlen.is_finite() || vlen <= 0.0 {
+            Point::new(MIN_WIDTH / 2.0 * cos, MIN_WIDTH / 2.0 * sin * pen.winding)
+        } else if vlen < MIN_WIDTH / 2.0 {
+            let k = MIN_WIDTH / 2.0 / vlen;
+            Point::new(v.x * k, v.y * k)
+        } else {
+            v
+        };
+        points.push(Point::new(c.x + v.x, c.y + v.y));
     }
     Subpath {
         points,
@@ -129,17 +214,47 @@ fn disc(c: Point, r: f32) -> Subpath {
 /// Expands flattened device-space subpaths into closed polygons that,
 /// filled with the nonzero rule, paint the stroke: one offset quad per
 /// segment plus a fan at every vertex (round joins at interior vertices,
-/// round caps at run ends). `width` is the device-space pen width (clamped
-/// up to [`MIN_WIDTH`]); `dash`/`phase` split each subpath into painted
-/// runs first (empty `dash` = solid).
+/// round caps at run ends). `width`, `dash` and `phase` are user-space
+/// quantities carried into device space through `ctm` (only its linear
+/// part matters to a pen); a stroke thinner than [`MIN_WIDTH`] device
+/// pixels is widened to a visible hairline. A matrix that cannot be
+/// inverted cannot carry the pen either way and is treated as the
+/// identity, which keeps the stroke visible.
 pub(crate) fn stroke_path(
     subpaths: &[Subpath],
     width: f32,
+    ctm: Matrix,
     dash: &[f32],
     phase: f32,
 ) -> Vec<Subpath> {
-    let width = if width.is_finite() { width } else { MIN_WIDTH };
-    let r = width.max(MIN_WIDTH) / 2.0;
+    let width = if width.is_finite() {
+        width.max(0.0)
+    } else {
+        0.0
+    };
+    let (to_device, to_user) = match ctm.invert() {
+        Some(inv) => (ctm, inv),
+        None => (Matrix::identity(), Matrix::identity()),
+    };
+    // Circle-preserving means orthogonal columns of equal length; the
+    // tolerance forgives the drift a chain of concatenations leaves.
+    let c1 = to_device.a * to_device.a + to_device.b * to_device.b;
+    let c2 = to_device.c * to_device.c + to_device.d * to_device.d;
+    let dot = to_device.a * to_device.c + to_device.b * to_device.d;
+    let scale = c1.max(c2);
+    let uniform_r = ((c1 - c2).abs() <= scale * 1e-3 && dot.abs() <= scale * 1e-3)
+        .then(|| width / 2.0 * c1.sqrt());
+    let pen = Pen {
+        to_device,
+        to_user,
+        r: width / 2.0,
+        winding: if to_device.a * to_device.d - to_device.b * to_device.c < 0.0 {
+            -1.0
+        } else {
+            1.0
+        },
+        uniform_r,
+    };
     let mut out = Vec::new();
     for sub in subpaths {
         if sub.points.is_empty() {
@@ -152,14 +267,14 @@ pub(crate) fn stroke_path(
         if pts.len() < 2 {
             continue;
         }
-        for run in dash_split(&pts, dash, phase) {
+        for run in dash_split(&pts, dash, phase, to_user) {
             for seg in run.windows(2) {
-                if let Some(quad) = segment_quad(seg[0], seg[1], r) {
+                if let Some(quad) = segment_quad(seg[0], seg[1], pen) {
                     out.push(quad);
                 }
             }
             for &v in &run {
-                out.push(disc(v, r));
+                out.push(disc(v, pen));
             }
         }
     }
@@ -201,7 +316,13 @@ mod tests {
     #[test]
     fn horizontal_line_paints_band_of_expected_thickness() {
         let mut pix = Pixmap::new(20, 10);
-        let polys = stroke_path(&[line(&[(2.0, 5.0), (18.0, 5.0)])], 4.0, &[], 0.0);
+        let polys = stroke_path(
+            &[line(&[(2.0, 5.0), (18.0, 5.0)])],
+            4.0,
+            Matrix::identity(),
+            &[],
+            0.0,
+        );
         paint(&mut pix, &polys);
         let thick = (0..10).filter(|&y| alpha_at(&pix, 10, y) > 127).count();
         assert!((3..=5).contains(&thick), "band thickness {thick}");
@@ -213,7 +334,13 @@ mod tests {
     #[test]
     fn round_caps_extend_past_endpoints() {
         let mut pix = Pixmap::new(20, 10);
-        let polys = stroke_path(&[line(&[(4.0, 5.0), (16.0, 5.0)])], 4.0, &[], 0.0);
+        let polys = stroke_path(
+            &[line(&[(4.0, 5.0), (16.0, 5.0)])],
+            4.0,
+            Matrix::identity(),
+            &[],
+            0.0,
+        );
         paint(&mut pix, &polys);
         // The cap fan reaches ~2px left of x=4.
         assert!(alpha_at(&pix, 2, 5) > 127, "left cap");
@@ -224,7 +351,13 @@ mod tests {
     #[test]
     fn minimum_device_width_keeps_hairlines_visible() {
         let mut pix = Pixmap::new(20, 10);
-        let polys = stroke_path(&[line(&[(2.0, 5.5), (18.0, 5.5)])], 0.05, &[], 0.0);
+        let polys = stroke_path(
+            &[line(&[(2.0, 5.5), (18.0, 5.5)])],
+            0.05,
+            Matrix::identity(),
+            &[],
+            0.0,
+        );
         paint(&mut pix, &polys);
         let total: u32 = (0..10).map(|y| alpha_at(&pix, 10, y) as u32).sum();
         // Coverage ~0.75px of ink; an unclamped 0.05px pen would leave ~13.
@@ -234,7 +367,13 @@ mod tests {
     #[test]
     fn dash_pattern_splits_into_runs() {
         let mut pix = Pixmap::new(21, 10);
-        let polys = stroke_path(&[line(&[(1.0, 5.0), (19.0, 5.0)])], 2.0, &[4.0, 4.0], 0.0);
+        let polys = stroke_path(
+            &[line(&[(1.0, 5.0), (19.0, 5.0)])],
+            2.0,
+            Matrix::identity(),
+            &[4.0, 4.0],
+            0.0,
+        );
         paint(&mut pix, &polys);
         let mut runs = 0;
         let mut prev_on = false;
@@ -251,13 +390,28 @@ mod tests {
     #[test]
     fn dash_split_counts_and_phase() {
         let pts = [Point::new(0.0, 0.0), Point::new(20.0, 0.0)];
-        assert_eq!(dash_split(&pts, &[2.0, 2.0], 0.0).len(), 5);
-        assert_eq!(dash_split(&pts, &[2.0, 2.0], 2.0).len(), 5);
-        assert_eq!(dash_split(&pts, &[2.0, 2.0], 1.0).len(), 6);
+        assert_eq!(
+            dash_split(&pts, &[2.0, 2.0], 0.0, Matrix::identity()).len(),
+            5
+        );
+        assert_eq!(
+            dash_split(&pts, &[2.0, 2.0], 2.0, Matrix::identity()).len(),
+            5
+        );
+        assert_eq!(
+            dash_split(&pts, &[2.0, 2.0], 1.0, Matrix::identity()).len(),
+            6
+        );
         // Empty or degenerate patterns are solid.
-        assert_eq!(dash_split(&pts, &[], 0.0).len(), 1);
-        assert_eq!(dash_split(&pts, &[0.0, 0.0], 0.0).len(), 1);
-        assert_eq!(dash_split(&pts, &[-1.0, 2.0], 0.0).len(), 1);
+        assert_eq!(dash_split(&pts, &[], 0.0, Matrix::identity()).len(), 1);
+        assert_eq!(
+            dash_split(&pts, &[0.0, 0.0], 0.0, Matrix::identity()).len(),
+            1
+        );
+        assert_eq!(
+            dash_split(&pts, &[-1.0, 2.0], 0.0, Matrix::identity()).len(),
+            1
+        );
     }
 
     #[test]
@@ -272,7 +426,7 @@ mod tests {
             ],
             closed: true,
         };
-        let polys = stroke_path(&[square], 2.0, &[], 0.0);
+        let polys = stroke_path(&[square], 2.0, Matrix::identity(), &[], 0.0);
         paint(&mut pix, &polys);
         // The closing (left) edge is painted, the interior is not.
         assert_eq!(alpha_at(&pix, 2, 6), 255, "left edge");
@@ -281,6 +435,77 @@ mod tests {
 
     #[test]
     fn zero_length_segments_are_skipped() {
-        assert!(segment_quad(Point::new(1.0, 1.0), Point::new(1.0, 1.0), 2.0).is_none());
+        let pen = Pen {
+            to_device: Matrix::identity(),
+            to_user: Matrix::identity(),
+            r: 2.0,
+            winding: 1.0,
+            uniform_r: Some(2.0),
+        };
+        assert!(segment_quad(Point::new(1.0, 1.0), Point::new(1.0, 1.0), pen).is_none());
+    }
+
+    /// The hand-made gradient in the corpus's 049466.pdf: vertical user-space
+    /// lines under `0 2.0629 0.4848 0 0 0 cm`, stroked `4.26 w`. The pen is a
+    /// user-space circle, so under this matrix the device band across these
+    /// (device-horizontal) lines is 4.26 * 2.0629 ~ 8.8 pixels — not the
+    /// 4.26 * sqrt(|det|) ~ 4.26 a scalar width yields, which leaves gaps
+    /// between strokes spaced 8.1 apart and stripes every such gradient.
+    #[test]
+    fn anisotropic_ctm_widens_the_pen_across_the_stroke() {
+        let ctm = Matrix {
+            a: 0.0,
+            b: 2.0629,
+            c: 0.4848,
+            d: 0.0,
+            e: 0.0,
+            f: 0.0,
+        };
+        let mut pix = Pixmap::new(40, 20);
+        let polys = stroke_path(&[line(&[(2.0, 10.0), (38.0, 10.0)])], 4.26, ctm, &[], 0.0);
+        paint(&mut pix, &polys);
+        let thick = (0..20).filter(|&y| alpha_at(&pix, 20, y) > 127).count();
+        assert!(
+            (8..=10).contains(&thick),
+            "band thickness {thick}, want ~8.8"
+        );
+    }
+
+    /// Dash lengths are user-space quantities (ISO 32000-1 §8.4.3.6). Under
+    /// the same anisotropic matrix, a device-horizontal line maps back to a
+    /// user-space length 1/0.4848 times its device length, so a [4 4] pattern
+    /// cuts runs every 8 * 0.4848 ~ 3.9 device pixels — not every 8.
+    #[test]
+    fn dash_pattern_is_measured_in_user_space() {
+        let ctm = Matrix {
+            a: 0.0,
+            b: 2.0629,
+            c: 0.4848,
+            d: 0.0,
+            e: 0.0,
+            f: 0.0,
+        };
+        let mut pix = Pixmap::new(40, 20);
+        let polys = stroke_path(
+            &[line(&[(1.0, 10.0), (39.0, 10.0)])],
+            1.5,
+            ctm,
+            &[4.0, 4.0],
+            0.0,
+        );
+        paint(&mut pix, &polys);
+        let mut runs = 0;
+        let mut prev_on = false;
+        for x in 0..40 {
+            let on = alpha_at(&pix, x, 10) > 127;
+            if on && !prev_on {
+                runs += 1;
+            }
+            prev_on = on;
+        }
+        // 38 device px = ~78 user units = ~9.8 pattern periods, so 10 painted
+        // runs (9 whole plus the partial each end); a device-measured pattern
+        // would paint only 5.
+        assert!((9..=11).contains(&runs), "painted runs {runs}, want ~10");
     }
 }


### PR DESCRIPTION
Scanned (CCITT/JBIG2) pages rendered with stripe patterns, moiré, and doubled text. The decoder was not at fault — all 968 CCITT streams in the 259-file corpus (including ASCII85-chained ones with array `/DecodeParms`) decode bit-identical to PyMuPDF. The artifacts were three renderer bugs, one commit each:

1. **Stroke pen geometry** — stroke width came from `sqrt(|det CTM|)`, which halves strokes under anisotropic matrices (`0 2.0629 0.4848 0 0 0 cm`, det ≈ 1). Producers' stroked-line gradients developed gaps that striped every scan behind them. The pen is now the CTM-transformed user-space circle; circle-preserving matrices keep a scalar fast path.
2. **Bilevel minification** — images drawn smaller than their pixel count were point-sampled, aliasing halftones into moiré and dropping text strokes. They are now reduced once by the integer factors (popcount byte walk for packed 1-bit samples) with the sub-2× residual box-averaged; magnified and 1:1 draws are untouched, and all `render_identity` digests are unchanged.
3. **Text rendering mode** — `Op::SetTextRender` was parsed but dropped, so the invisible OCR layer (`3 Tr`) of every searchable scan painted as doubled text. The mode is graphics state (Table 104), restored by `Q`; modes 3/7 advance without painting.

### Verification

Page MAD vs pdfium (scale 1.5, `--fonts full`), worst corpus offenders:

| page | symptom | before | after |
|---|---|---|---|
| 049466-p12 | striped sidebar | 19.3 | 8.8 |
| 049364-p5 | halftone → speckle | 17.4 | 7.3 |
| 049653-p3 | map dither → checkering | 12.1 | 7.0 |
| 049962-p1 | doubled OCR text | 12.4 | 7.7 |

Remaining top diffs are substitute-font glyph deltas, verified by diff map.

Full workspace suite: 1673 passed (7 new tests: transformed pen, user-space dashes, halftone/stencil/packed averaging, invisible-text advance, q/Q restore). Clippy `-D warnings` clean.

### Cost (M3 Pro, release, best of 4, vs pre-fix HEAD)

| workload | delta |
|---|---|
| full-page scan, scale 1.0 | +11% |
| full-page scan, scale 2.0 | +23% |
| anisotropic stroke-gradient page | +18% (≈2× more ink is now correctly painted) |
| ordinary text page | ±2% (noise) |

Only pages that shrink a scan or stroke under an anisotropic matrix pay anything; those are exactly the pages that rendered wrong before.
