### PR TITLE
bench: wire pdfboss into olmOCR-bench and publish first scores

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -97,3 +97,15 @@ shown in the top-level README); `bench_render.py` writes
 Both datasets are local corpora of real-world PDFs and are not committed —
 `bench_scans.py` records the document's page count and geometry, never its
 name.
+
+## olmOCR-bench
+
+[olmocr/](olmocr/) wires pdfboss into
+[olmOCR-bench](https://huggingface.co/datasets/allenai/olmOCR-bench), a
+public suite of 7,010 machine-checkable tests (text presence, reading order,
+table structure, math rendering) over 1,403 single-page PDFs.
+`olmocr/generate_candidates.py` writes the markdown candidate tree the
+suite's scorer reads; results land in `results-olmocr.json`. pdfboss is a
+non-OCR engine, so the honest headline is the born-digital buckets — the
+scan and LaTeX-math buckets score near zero by construction. The recipe and
+the full interpretation notes are in [olmocr/README.md](olmocr/README.md).

--- a/benchmarks/olmocr/README.md
+++ b/benchmarks/olmocr/README.md
@@ -1,0 +1,95 @@
+# olmOCR-bench
+
+[olmOCR-bench](https://huggingface.co/datasets/allenai/olmOCR-bench) scores
+PDF-to-markdown conversion with 7,010 machine-checkable unit tests over 1,403
+single-page PDFs: is this text present (or absent), does this text come
+before that text, does this table cell carry that heading, does this equation
+render to the same symbols. The scorer is the `olmocr` package's bench
+module; this directory holds the candidate generator and the recipe that
+produced pdfboss's scores in `../results-olmocr.json`.
+
+## Reading the numbers honestly
+
+pdfboss extracts the text a PDF carries; it does not OCR pixels. The
+benchmark mixes both worlds, and the per-bucket table only means something
+with the text-layer census next to it (the generator prints it — `empty` is
+the count of PDFs whose extraction produced zero characters):
+
+- **Born-digital buckets** — `table_tests`, `multi_column`,
+  `headers_footers`, and the auto-added per-PDF `baseline` — are the honest
+  headline for a non-OCR engine. Nearly every PDF there has a text layer.
+- **Scan buckets** — `old_scans` is 98/98 image-only, `old_scans_math` 21/36,
+  `long_tiny_text` 23/62. Scores there measure the OCR pdfboss does not do
+  (plus, for the two partial buckets, whatever embedded text the scans carry).
+- **`arxiv_math` is ~0 by construction**: its 2,927 tests require LaTeX
+  inside `$…$`-family delimiters and are checked by rendering both sides with
+  KaTeX. The PDFs have text layers, but a rendered PDF's text layer holds
+  glyphs, not LaTeX source — no text extractor scores here.
+- **`headers_footers` is all absence tests** — the engine is rewarded for
+  *stripping* page headers, footers and page numbers. An empty output would
+  pass them all, so the number only means something next to `baseline`
+  (which requires real content per PDF). pdfboss keeps page headers and
+  footers in its markdown today, and the low score reflects that choice.
+- **Markdown tables cap the table score**: tests that hinge on rowspan or
+  colspan structure only pass with HTML `<table>` output (stated in the
+  benchmark's README). pdfboss emits pipe tables.
+- The overall score is a macro-average of the 8 buckets, each weighted
+  equally — the scan and math buckets pull a non-OCR engine's overall down
+  by construction. The leaderboard's engines OCR a rasterized page, which is
+  a different (strictly harder) task on the scan buckets.
+
+## Setup
+
+```bash
+python3.12 -m venv olmbench && source olmbench/bin/activate
+git clone --depth 1 https://github.com/allenai/olmocr.git
+pip install -e './olmocr[bench]' numpy pdfboss
+playwright install chromium   # math references render in Chromium at jsonl load time
+
+huggingface-cli download --repo-type dataset allenai/olmOCR-bench --local-dir ./olmOCR-bench
+```
+
+## Generate the candidate
+
+The scorer treats every subdirectory of `bench_data/` except `pdfs/` as a
+candidate and hard-fails one that is missing the markdown for *any* PDF, so
+the generator writes a file per PDF unconditionally — empty on failure, which
+merely fails that PDF's own tests:
+
+```bash
+python benchmarks/olmocr/generate_candidates.py ./olmOCR-bench/bench_data
+```
+
+It prints the per-category text-layer census and refuses to finish with
+fewer outputs than PDFs.
+
+## Score
+
+```bash
+# All 8 buckets (the numbers in ../results-olmocr.json):
+python -m olmocr.bench.benchmark --dir ./olmOCR-bench/bench_data --candidate pdfboss
+
+# A single bucket — pass its jsonl as --dir; baseline is then restricted to
+# that bucket's PDFs, so single-bucket numbers do not mix into the full table:
+python -m olmocr.bench.benchmark --dir ./olmOCR-bench/bench_data/table_tests.jsonl --candidate pdfboss
+```
+
+The first full run renders every reference equation in headless Chromium
+(cached in sqlite under `~/.cache/olmocr/bench/equations/`), so it is slow
+once and fast after.
+
+## Results
+
+pdfboss 0.17.1, one repeat (extraction is deterministic), full 8-bucket run:
+
+| Bucket | Pass rate | Tests |
+|---|--:|--:|
+| baseline | PENDING | 1403 |
+| table_tests | PENDING | 1020 |
+| multi_column | PENDING | 884 |
+| headers_footers | PENDING | 753 |
+| long_tiny_text | PENDING | 442 |
+| old_scans | PENDING | 526 |
+| old_scans_math | PENDING | 458 |
+| arxiv_math | PENDING | 2927 |
+| **overall (macro)** | **PENDING** | 8413 |

--- a/benchmarks/olmocr/README.md
+++ b/benchmarks/olmocr/README.md
@@ -80,16 +80,25 @@ once and fast after.
 
 ## Results
 
-pdfboss 0.17.1, one repeat (extraction is deterministic), full 8-bucket run:
+pdfboss 0.17.1, one repeat (extraction is deterministic), full 8-bucket run.
+Pass rates are load-insensitive and reported as measured; raw numbers in
+[`../results-olmocr.json`](../results-olmocr.json).
 
 | Bucket | Pass rate | Tests |
 |---|--:|--:|
-| baseline | PENDING | 1403 |
-| table_tests | PENDING | 1020 |
-| multi_column | PENDING | 884 |
-| headers_footers | PENDING | 753 |
-| long_tiny_text | PENDING | 442 |
-| old_scans | PENDING | 526 |
-| old_scans_math | PENDING | 458 |
-| arxiv_math | PENDING | 2927 |
-| **overall (macro)** | **PENDING** | 8413 |
+| baseline | 87.3% | 1394 |
+| headers_footers | 35.0% | 760 |
+| table_tests | 30.0% | 1022 |
+| long_tiny_text | 22.2% | 442 |
+| multi_column | 18.9% | 884 |
+| old_scans | 13.3% | 526 |
+| old_scans_math | 0.0% | 458 |
+| arxiv_math | 0.0% | 2927 |
+| **overall (macro over 8 buckets)** | **25.8% ± 0.9%** | 8413 |
+| **born-digital subset (baseline, tables, multi_column, headers_footers)** | **42.8%** | 4060 |
+
+(A few jsonls carry baseline-type tests of their own, which is why the test
+counts differ slightly from the bucket sizes; the born-digital subset number
+is the macro over those four rows of this same run, not a separate run.
+old_scans' 13.3% is exactly its 70 absence tests, passing trivially on
+empty output — the fully image-only bucket contributes nothing real.)

--- a/benchmarks/olmocr/generate_candidates.py
+++ b/benchmarks/olmocr/generate_candidates.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Generate the pdfboss candidate tree for olmOCR-bench.
+
+olmOCR-bench (HuggingFace dataset ``allenai/olmOCR-bench``) scores an engine
+by the markdown it wrote for each single-page PDF under ``bench_data/pdfs/``.
+The scorer treats every subdirectory of ``bench_data/`` except ``pdfs/`` as a
+candidate, and hard-fails a candidate missing the file for *any* PDF — so
+this script writes a file for every PDF no matter what: markdown when
+extraction succeeds, an empty file when it does not (an empty file merely
+fails its own tests). Markdown mode is required, not plain text: the table
+tests only read pipe or HTML tables.
+
+Filename convention (the PDF basename keeps its own suffix, so a double
+``_pgN_pg1`` is correct):
+
+    pdfs/arxiv_math/2502.15977_pg21.pdf
+      -> pdfboss/arxiv_math/2502.15977_pg21_pg1_repeat1.md
+
+One repeat is written — pdfboss is deterministic. The per-category summary
+printed at the end doubles as a text-layer census: a category whose outputs
+are almost all empty is image-only scans, which a non-OCR engine cannot read.
+
+Usage:
+    python benchmarks/olmocr/generate_candidates.py /path/to/bench_data
+                                                    [--candidate NAME]
+                                                    [--workers N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+
+def extract_one(pdf_path: str, pdf_root: str, out_root: str) -> tuple[str, int, str]:
+    """Writes every page's markdown repeat for one PDF.
+
+    Returns ``(category, chars_written, failure)`` where ``failure`` is empty
+    when every page extracted, else the reason the output is empty. A PDF
+    that cannot even open still gets an empty ``_pg1_repeat1.md`` — a missing
+    file fails the whole candidate, an empty one only its own tests.
+    """
+    import pdfboss
+
+    rel = Path(pdf_path).relative_to(pdf_root)
+    category = rel.parts[0] if len(rel.parts) > 1 else "."
+    out_dir = Path(out_root) / rel.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = rel.stem
+
+    failure = ""
+    page_count = 0
+    try:
+        doc = pdfboss.Document(pdf_path)
+        page_count = doc.page_count
+    except Exception as exc:  # noqa: BLE001 - the message is the result
+        failure = f"{type(exc).__name__}: {exc}"
+    if not page_count:
+        (out_dir / f"{stem}_pg1_repeat1.md").write_text("", encoding="utf-8")
+        return category, 0, failure or "no pages"
+
+    chars = 0
+    for index in range(page_count):
+        try:
+            markdown = doc[index].extract_markdown()
+        except Exception as exc:  # noqa: BLE001 - the message is the result
+            markdown = ""
+            failure = f"{type(exc).__name__}: {exc}"
+        out = out_dir / f"{stem}_pg{index + 1}_repeat1.md"
+        out.write_text(markdown, encoding="utf-8")
+        chars += len(markdown)
+    return category, chars, failure
+
+
+def run(bench_data: str, candidate: str, workers: int) -> None:
+    pdf_root = os.path.join(bench_data, "pdfs")
+    out_root = os.path.join(bench_data, candidate)
+    pdfs = sorted(str(p) for p in Path(pdf_root).rglob("*.pdf"))
+    if not pdfs:
+        raise SystemExit(f"no PDFs found under {pdf_root}")
+
+    stats: dict[str, dict[str, int]] = {}
+    with ProcessPoolExecutor(max_workers=workers) as pool:
+        results = pool.map(
+            extract_one, pdfs, [pdf_root] * len(pdfs), [out_root] * len(pdfs)
+        )
+        for category, chars, failure in results:
+            tally = stats.setdefault(
+                category, {"pdfs": 0, "empty": 0, "errors": 0, "chars": 0}
+            )
+            tally["pdfs"] += 1
+            tally["chars"] += chars
+            if not chars:
+                tally["empty"] += 1
+            if failure:
+                tally["errors"] += 1
+
+    written = sum(1 for _ in Path(out_root).rglob("*.md"))
+    print(f"[candidate] {written} markdown files for {len(pdfs)} PDFs -> {out_root}")
+    print(f"{'category':16} {'pdfs':>5} {'empty':>6} {'errors':>7} {'chars/pdf':>10}")
+    for category in sorted(stats):
+        tally = stats[category]
+        mean = tally["chars"] / tally["pdfs"]
+        print(
+            f"{category:16} {tally['pdfs']:5} {tally['empty']:6}"
+            f" {tally['errors']:7} {mean:10.0f}"
+        )
+    if written < len(pdfs):
+        raise SystemExit("fewer outputs than PDFs — the scorer would hard-fail")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("bench_data", help="the dataset's bench_data directory")
+    ap.add_argument("--candidate", default="pdfboss", help="candidate folder name")
+    ap.add_argument(
+        "--workers",
+        type=int,
+        default=min(8, os.cpu_count() or 1),
+        help="parallel extraction processes",
+    )
+    args = ap.parse_args()
+    run(args.bench_data, args.candidate, args.workers)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/results-olmocr.json
+++ b/benchmarks/results-olmocr.json
@@ -1,0 +1,30 @@
+{
+  "dataset": "allenai/olmOCR-bench",
+  "scorer": "olmocr.bench.benchmark (github.com/allenai/olmocr@f7cfe4c, 2026-08-25)",
+  "pdfboss": "0.17.1",
+  "protocol": "full 8-bucket run, markdown extraction, one repeat (deterministic)",
+  "pdfs": 1403,
+  "overall_macro": 0.258,
+  "overall_ci95": 0.009,
+  "born_digital_macro": 0.428,
+  "born_digital_buckets": ["baseline", "table_tests", "multi_column", "headers_footers"],
+  "buckets": {
+    "baseline": {"passed": 1217, "total": 1394, "rate": 0.873},
+    "table_tests": {"passed": 307, "total": 1022, "rate": 0.300},
+    "headers_footers": {"passed": 266, "total": 760, "rate": 0.350},
+    "multi_column": {"passed": 167, "total": 884, "rate": 0.189},
+    "long_tiny_text": {"passed": 98, "total": 442, "rate": 0.222},
+    "old_scans": {"passed": 70, "total": 526, "rate": 0.133},
+    "old_scans_math": {"passed": 0, "total": 458, "rate": 0.0},
+    "arxiv_math": {"passed": 0, "total": 2927, "rate": 0.0}
+  },
+  "text_layer_census_empty_of_total": {
+    "arxiv_math": [0, 522],
+    "headers_footers": [13, 266],
+    "long_tiny_text": [23, 62],
+    "multi_column": [11, 231],
+    "old_scans": [98, 98],
+    "old_scans_math": [21, 36],
+    "tables": [12, 188]
+  }
+}


### PR DESCRIPTION
Adds benchmarks/olmocr/ (candidate generator + recipe) and results-olmocr.json from a full 8-bucket run (scorer pinned to allenai/olmocr@f7cfe4c, pdfboss 0.17.1).

Measured: overall macro 25.8% ±0.9%; born-digital subset 42.8%. Per bucket: baseline 87.3, headers_footers 35.0, table_tests 30.0, long_tiny_text 22.2, multi_column 18.9, old_scans 13.3, old_scans_math 0, arxiv_math 0 (image-only/LaTeX buckets — expected for a non-OCR engine, framed honestly in the README).

Verified: 1403/1403 candidate files generated, single-jsonl runs cross-check the full run's rows exactly, macro arithmetic re-verified independently.