### PR TITLE
bench: wire pdfboss into ParseBench and publish first scores

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,7 +1,8 @@
 # Benchmarks
 
 Three scripts, because opening, rendering and scanned PDFs are different
-workloads.
+workloads — plus a quality benchmark under `parsebench/`, because speed
+means nothing if the output is wrong.
 
 `bench.py` compares pdfboss against other Python PDF libraries on the two
 operations they all produce comparable output for:
@@ -97,3 +98,19 @@ shown in the top-level README); `bench_render.py` writes
 Both datasets are local corpora of real-world PDFs and are not committed —
 `bench_scans.py` records the document's page count and geometry, never its
 name.
+
+## Method — ParseBench (quality)
+
+`parsebench/` wires pdfboss into
+[run-llama/ParseBench](https://github.com/run-llama/ParseBench): 2,078
+human-verified pages, five quality dimensions, ~169k deterministic rules,
+no LLM judge. `parsebench/pdfboss_provider.py` is a drop-in provider for
+their tree (per-page markdown, pipe tables converted to HTML for the table
+metrics the same way their pdf_inspector provider does it); the wiring
+steps, full method and score interpretation live in
+[`parsebench/README.md`](parsebench/README.md). Scores are rule-based and
+deterministic, so unlike the timing benchmarks they are load-insensitive
+and published as measured: **28.00 overall** for pdfboss 0.17.1 (Content
+Faithfulness 61.50, Semantic Formatting 33.78, Tables 28.89, Visual
+Grounding 10.77, Charts 5.04), from a full 2,078-example run at ParseBench
+commit 34b7345. Raw aggregates land in `results-parsebench.json`.

--- a/benchmarks/parsebench/README.md
+++ b/benchmarks/parsebench/README.md
@@ -1,0 +1,102 @@
+# ParseBench
+
+[run-llama/ParseBench](https://github.com/run-llama/ParseBench) measures
+document parsing quality on 2,078 human-verified enterprise pages
+(insurance/finance/government) across five dimensions — Tables, Charts,
+Content Faithfulness, Semantic Formatting, Visual Grounding — with ~169k
+deterministic test rules and no LLM judge. It is the quality complement to
+the timing benchmarks in this directory: same engines, different question.
+
+`pdfboss_provider.py` is a drop-in provider for the ParseBench tree. It
+extracts per-page markdown with `Page.extract_markdown()` and converts the
+pipe tables to HTML `<table>` markup in `normalize()` — the Tables
+similarity metrics (TEDS/GriTS/TableRecordMatch) consume HTML tables only,
+while the rule metrics parse both forms. That conversion (markdown2 with the
+`tables` extra, a core harness dependency) is the same normalization the
+pdf_inspector provider applies, so the comparison stays fair. Non-PDF inputs
+are rejected with their `ProviderPermanentError`, which is how the
+pypdf/PyMuPDF baselines handle the 42 jpg/png Visual Grounding inputs too.
+
+## Wiring (verified against ParseBench commit 34b7345)
+
+```bash
+git clone https://github.com/run-llama/ParseBench && cd ParseBench
+uv sync --extra runners --extra fast   # fast = numba-JIT TEDS, identical scores
+uv add pdfboss==0.17.1
+
+cp /path/to/pdfboss/benchmarks/parsebench/pdfboss_provider.py \
+   src/parse_bench/inference/providers/parse/pdfboss.py
+```
+
+Then two registrations:
+
+- `src/parse_bench/inference/providers/parse/__init__.py` — add
+  `"pdfboss"` to `_PROVIDER_MODULES`.
+- `src/parse_bench/inference/pipelines/parse.py` — inside
+  `register_parse_pipelines()`:
+
+```python
+register_fn(
+    PipelineSpec(
+        pipeline_name="pdfboss_markdown",
+        provider_name="pdfboss",
+        product_type=ProductType.PARSE,
+        config={},
+    )
+)
+```
+
+## Running
+
+```bash
+uv run parse-bench run pdfboss_markdown --test              # smoke: 3 files/category
+uv run parse-bench run pdfboss_markdown --max_concurrent 8  # full: auto-downloads ~0.6 GB from HF
+uv run parse-bench run pdfboss_markdown --group table       # one dimension
+uv run parse-bench serve output/pdfboss_markdown            # per-rule drill-down
+```
+
+No API keys: local engines run offline, LLM normalization is off by
+default, and every metric is rule-based and deterministic — the scores are
+reproducible and load-insensitive, so they are published as measured.
+
+## Results — pdfboss 0.17.1, full run (2,078 examples)
+
+| Dimension | Headline metric | Score |
+|---|---|--:|
+| Content Faithfulness | content_faithfulness | 61.50 |
+| Semantic Formatting | semantic_formatting | 33.78 |
+| Tables | grits_trm_composite | 28.89 |
+| Visual Grounding | rule_pass_rate | 10.77 |
+| Charts | chart_data_point_pass_rate | 5.04 |
+| **Overall** | mean of the five | **28.00** |
+
+Raw aggregates in `../results-parsebench.json`. Against the public
+leaderboard's "Open Source - Local" bracket (numbers from the repo's
+`leaderboard.csv` at the same commit, not rerun locally):
+
+| Engine | Overall |
+|---|--:|
+| Warp Ingest | 40.18 |
+| LiteParse (no OCR) | 32.80 |
+| OpenDataLoader | 29.40 |
+| **pdfboss** | **28.00** |
+| pdf-inspector | 26.59 |
+| MarkItDown | 18.63 |
+| PyMuPDF (HTML) | 16.62 |
+| PyMuPDF (Text) | 16.02 |
+| pypdf | 14.87 |
+
+## Reading the numbers
+
+- **Charts is effectively ML-only** — the pages are chart images, and
+  text-layer engines land at 0–7 across the board.
+- **Visual Grounding** scores only the 64 reading-order examples; the other
+  436 need a per-page layout payload (`ParseLayoutPageIR` items with
+  normalized bboxes) that this provider does not emit, plus the 42 image
+  inputs. The zeroing is identical for the pypdf/PyMuPDF baselines
+  (verified in-harness). Follow-up: expose block geometry from pdfboss's
+  layout IR through the Python bindings and emit the payload — no non-ML
+  local engine on the public leaderboard does.
+- **Content Faithfulness** is dragged by two by-design choices: pdfboss
+  markdown drops page headers/footers (the is_header/is_footer rules score
+  zero) and scan-only pages have no text layer to extract.

--- a/benchmarks/parsebench/pdfboss_provider.py
+++ b/benchmarks/parsebench/pdfboss_provider.py
@@ -1,0 +1,188 @@
+"""Provider for pdfboss PARSE.
+
+Drop this file into a run-llama/ParseBench checkout as
+``src/parse_bench/inference/providers/parse/pdfboss.py`` and register it as
+described in this directory's README.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from parse_bench.inference.providers.base import (
+    Provider,
+    ProviderConfigError,
+    ProviderPermanentError,
+)
+from parse_bench.inference.providers.registry import register_provider
+from parse_bench.schemas.parse_output import PageIR, ParseOutput
+from parse_bench.schemas.pipeline import PipelineSpec
+from parse_bench.schemas.pipeline_io import (
+    InferenceRequest,
+    InferenceResult,
+    RawInferenceResult,
+)
+from parse_bench.schemas.product import ProductType
+
+
+def convert_md_tables_to_html(content: str) -> str:
+    """
+    Convert markdown pipe tables to HTML tables.
+
+    The Tables dimension's similarity metrics (TEDS/GriTS/TableRecordMatch)
+    consume HTML ``<table>`` markup only, while the rule metrics parse both
+    forms — the same normalization the pdf_inspector provider applies.
+    """
+    import markdown2
+
+    parts: list[str] = []
+    table_lines: list[str] = []
+
+    def flush() -> None:
+        nonlocal table_lines
+        lines, table_lines = table_lines, []
+        if len(lines) < 2:
+            parts.extend(lines)
+            return
+        html = markdown2.markdown("\n".join(lines), extras=["tables"]).strip()
+        if "<table>" not in html.lower():
+            parts.extend(lines)
+            return
+        parts.append(html)
+
+    for line in content.split("\n"):
+        if line.strip().startswith("|"):
+            table_lines.append(line)
+            continue
+        flush()
+        parts.append(line)
+    flush()
+    return "\n".join(parts)
+
+
+@register_provider("pdfboss")
+class PdfbossProvider(Provider):
+    """
+    Provider for pdfboss PARSE.
+
+    Extracts per-page markdown from the embedded text layer using the
+    pdfboss library (Rust engine, Python bindings): ATX headings ranked by
+    font size, lists, and pipe tables inferred from layout. No OCR.
+    """
+
+    def extract_markdown_pages(self, pdf_path: str) -> dict[str, Any]:
+        """
+        Extract per-page markdown from a PDF using pdfboss.
+
+        :param pdf_path: Path to the PDF file
+        :return: Raw extraction result with page-level markdown
+        :raises ProviderError: For any extraction errors
+        """
+        try:
+            import pdfboss
+        except ImportError as e:
+            raise ProviderConfigError("pdfboss package not installed. Run: pip install pdfboss") from e
+
+        try:
+            doc = pdfboss.Document(pdf_path)
+        except Exception as e:
+            raise ProviderPermanentError(f"Cannot read PDF: {e}") from e
+
+        pages: list[dict[str, Any]] = []
+        for page_index in range(doc.page_count):
+            try:
+                markdown = doc[page_index].extract_markdown()
+            except Exception as e:
+                pages.append({"page_index": page_index, "text": "", "error": str(e)})
+                continue
+            pages.append({"page_index": page_index, "text": markdown})
+
+        return {
+            "pages": pages,
+            "num_pages": doc.page_count,
+            "metadata": doc.metadata,
+        }
+
+    def run_inference(self, pipeline: PipelineSpec, request: InferenceRequest) -> RawInferenceResult:
+        """
+        Run inference and return raw results.
+
+        :param pipeline: Pipeline specification
+        :param request: Inference request
+        :return: Raw inference result
+        :raises ProviderError: For any provider-related failures
+        """
+        if request.product_type != ProductType.PARSE:
+            raise ProviderPermanentError(
+                f"PdfbossProvider only supports PARSE product type, got {request.product_type}"
+            )
+
+        pdf_path = Path(request.source_file_path)
+        if pdf_path.suffix.lower() != ".pdf":
+            raise ProviderPermanentError(f"PdfbossProvider only supports .pdf files, got {pdf_path.suffix}")
+
+        if not pdf_path.exists():
+            raise ProviderPermanentError(f"PDF file not found: {pdf_path}")
+
+        started_at = datetime.now()
+
+        try:
+            raw_output = self.extract_markdown_pages(str(pdf_path))
+        except (ProviderPermanentError, ProviderConfigError):
+            raise
+        except Exception as e:
+            raise ProviderPermanentError(f"Unexpected error during inference: {e}") from e
+
+        completed_at = datetime.now()
+        latency_ms = int((completed_at - started_at).total_seconds() * 1000)
+
+        return RawInferenceResult(
+            request=request,
+            pipeline=pipeline,
+            pipeline_name=pipeline.pipeline_name,
+            product_type=request.product_type,
+            raw_output=raw_output,
+            started_at=started_at,
+            completed_at=completed_at,
+            latency_in_ms=latency_ms,
+        )
+
+    def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+        """
+        Normalize raw inference result to produce ParseOutput.
+
+        :param raw_result: Raw inference result from run_inference()
+        :return: Inference result with both raw and normalized outputs
+        :raises ProviderError: For any normalization failures
+        """
+        if raw_result.product_type != ProductType.PARSE:
+            raise ProviderPermanentError(
+                f"PdfbossProvider only supports PARSE product type, got {raw_result.product_type}"
+            )
+
+        pages: list[PageIR] = []
+        page_texts: list[str] = []
+        for page_data in raw_result.raw_output.get("pages", []):
+            page_index = page_data.get("page_index", 0)
+            text = convert_md_tables_to_html(page_data.get("text", ""))
+            pages.append(PageIR(page_index=page_index, markdown=text))
+            page_texts.append(text)
+
+        output = ParseOutput(
+            task_type="parse",
+            example_id=raw_result.request.example_id,
+            pipeline_name=raw_result.pipeline_name,
+            pages=pages,
+            markdown="\n\n".join(page_texts),
+        )
+
+        return InferenceResult(
+            request=raw_result.request,
+            pipeline_name=raw_result.pipeline_name,
+            product_type=raw_result.product_type,
+            raw_output=raw_result.raw_output,
+            output=output,
+            started_at=raw_result.started_at,
+            completed_at=raw_result.completed_at,
+            latency_in_ms=raw_result.latency_in_ms,
+        )

--- a/benchmarks/results-parsebench.json
+++ b/benchmarks/results-parsebench.json
@@ -1,0 +1,81 @@
+{
+  "benchmark": "run-llama/ParseBench",
+  "harness_commit": "34b7345",
+  "dataset": "llamaindex/ParseBench (Hugging Face)",
+  "pipeline": "pdfboss_markdown",
+  "pdfboss": "0.17.1",
+  "scoring": {
+    "llm_normalization": "off (harness default)",
+    "fast_teds": "on (harness default, identical scores)",
+    "overall": "mean of the five dimension headline scores, the public leaderboard's formula"
+  },
+  "inference": {
+    "examples": 2078,
+    "parsed": 2036,
+    "rejected_non_pdf": 42
+  },
+  "overall": 28.0,
+  "dimensions": {
+    "table": {
+      "examples": 503,
+      "headline_metric": "grits_trm_composite",
+      "score": 28.89,
+      "grits_con": 36.42,
+      "table_record_match": 20.07,
+      "table_record_match_perfect": 14.32,
+      "tables_expected_avg": 1.779,
+      "tables_emitted_avg": 1.1913
+    },
+    "chart": {
+      "examples": 568,
+      "headline_metric": "rule_chart_data_point_pass_rate",
+      "score": 5.04
+    },
+    "text_content": {
+      "examples": 506,
+      "headline_metric": "content_faithfulness",
+      "score": 61.5,
+      "text_correctness": 68.39,
+      "reading_order": 46.76,
+      "page_header_rule_pass_rate": 0.0,
+      "page_footer_rule_pass_rate": 0.0
+    },
+    "text_formatting": {
+      "examples": 476,
+      "headline_metric": "semantic_formatting",
+      "score": 33.78,
+      "title_accuracy": 35.47,
+      "title_hierarchy": 31.95,
+      "bold": 37.55,
+      "italic": 41.25,
+      "text_styling": 32.3
+    },
+    "layout": {
+      "examples": 500,
+      "scored": 64,
+      "headline_metric": "rule_pass_rate",
+      "score": 10.77,
+      "note": "436 examples score zero: 394 need a layout payload the provider does not emit, 42 are jpg/png inputs a PDF-only provider rejects. Identical accounting to the pypdf/PyMuPDF baselines (verified: pypdf_baseline fails the same examples in this harness)."
+    }
+  },
+  "peers_open_source_local": {
+    "source": "leaderboard.csv in run-llama/ParseBench at 34b7345 (public numbers, not rerun locally)",
+    "overall": {
+      "pypdf": 14.87,
+      "PyMuPDF (Text)": 16.02,
+      "PyMuPDF (HTML)": 16.62,
+      "MarkItDown": 18.63,
+      "pdf-inspector": 26.59,
+      "pdfboss (this run)": 28.0,
+      "OpenDataLoader": 29.4,
+      "LiteParse (no OCR)": 32.8,
+      "Warp Ingest": 40.18
+    }
+  },
+  "notes": [
+    "Deterministic rule-based scoring; quality scores are load-insensitive and published as measured.",
+    "pdfboss markdown drops page headers/footers by design, so the is_header/is_footer rules in Content Faithfulness score zero.",
+    "Markdown pipe tables are converted to HTML tables in the provider's normalize(), the same step the pdf_inspector provider applies, because the Tables similarity metrics consume HTML tables only.",
+    "No Visual Grounding layout payload yet: the pdfboss Python bindings do not expose block geometry; emitting it from the layout IR is follow-up work in pdfboss."
+  ]
+}


### PR DESCRIPTION
Adds benchmarks/parsebench/ (drop-in provider for run-llama/ParseBench @34b7345 + wiring recipe) and results-parsebench.json from the full 2,078-example run (deterministic rules, LLM normalization off).

Measured: overall 28.00 — Content Faithfulness 61.50, Semantic Formatting 33.78, Tables (GTRM) 28.89, Visual Grounding 10.77, Charts 5.04. Open Source–Local bracket context: pypdf 14.87 … pdf-inspector 26.59 … pdfboss 28.00 … OpenDataLoader 29.40 … LiteParse 32.8.

Provider converts pipe tables to HTML tables in normalize() (the Tables similarity metrics consume HTML only — same pattern as their pdf-inspector provider). Smoke --test run caught that; GTRM went 0→0.26 on the smoke set after the fix. 42 jpg/png layout inputs correctly zero out like the other PDF-only baselines. Deferred: emitting the Visual Grounding layout payload from pdfboss geometry (needs a bindings surface; genuine differentiator, no non-ML local emits one).