### PR TITLE
feat(render): per-glyph substitute fallback and Standard encoding for nonsymbolic substitutes

### DIFF
--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -21,7 +21,7 @@ use pdfboss_core::{
 };
 
 use crate::color::{self, ColorSpace};
-use crate::glyph::GlyphFont;
+use crate::glyph::{GlyphFallback, GlyphFont};
 use crate::image::{self, DrawParams};
 use crate::path::{PathBuilder, Subpath};
 use crate::raster::{fill_path, BlendMode, FillRule, Mask, RasterScratch};
@@ -188,9 +188,11 @@ impl GState {
 
 /// A loaded, paintable outline font paired with the name report entries
 /// know it by — its `/BaseFont`, or the `Tf` resource name when the
-/// dictionary has none — or `None` for a font whose glyphs cannot be drawn
-/// (the [`crate::GlyphPainting`] tier, or a load failure).
-type LoadedFont = Option<(Arc<GlyphFont>, Arc<str>)>;
+/// dictionary has none — and its per-glyph fallback plan (`Some` only for
+/// an embedded simple font at `Full` with a provider, see
+/// [`GlyphFont::fallback`]) — or `None` for a font whose glyphs cannot be
+/// drawn (the [`crate::GlyphPainting`] tier, or a load failure).
+type LoadedFont = Option<(Arc<GlyphFont>, Arc<str>, Option<Arc<GlyphFallback>>)>;
 
 /// Upper bound on tiles one pattern paint may plan. Real hatchings use
 /// hundreds to a few thousand cells; the cap only stops a hostile step
@@ -1573,9 +1575,20 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             .map_or(name, |n| n.0.as_str())
             .into();
         let loaded = match dict {
-            Some(d) => GlyphFont::load_with(self.src, &d, self.painting, self.provider.as_deref())
-                .await
-                .map(|f| (Arc::new(f), label)),
+            Some(d) => {
+                match GlyphFont::load_with(self.src, &d, self.painting, self.provider.as_deref())
+                    .await
+                {
+                    Some(f) => {
+                        let fallback = f
+                            .fallback(self.src, &d, self.painting, self.provider.as_deref())
+                            .await
+                            .map(Arc::new);
+                        Some((Arc::new(f), label, fallback))
+                    }
+                    None => None,
+                }
+            }
             None => None,
         };
         cache.insert(name.to_string(), loaded.clone());
@@ -1630,6 +1643,63 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         );
     }
 
+    /// Paints `code` from the font's per-glyph fallback face (see
+    /// [`GlyphFallback`]), building the face on first use. `true` means the
+    /// code is handled — painted, or mapped to a genuinely empty outline —
+    /// so no `NoGlyph` report applies; `false` leaves the caller's report to
+    /// fire exactly as without a fallback (none planned, no provider face,
+    /// the fallback misses too, or a non-finite transform).
+    ///
+    /// `params` is the text-space parameter matrix `show_text` built for
+    /// this glyph; the device transform is recomposed here from the FALLBACK
+    /// face's own units-per-em, which need not match the primary font's. The
+    /// advance is untouched: it stays the primary font's (`/Widths` is keyed
+    /// per code, not per face).
+    fn paint_fallback(
+        &mut self,
+        fallback: Option<&GlyphFallback>,
+        code: u32,
+        params: Matrix,
+        tm: Matrix,
+        gs: &GState,
+        fill: [u8; 4],
+    ) -> bool {
+        let Some(fallback) = fallback else {
+            return false;
+        };
+        let Some(provider) = self.provider.as_deref() else {
+            return false;
+        };
+        let Some(font) = fallback.font(provider) else {
+            return false;
+        };
+        let gid = font.gid(code);
+        if gid == 0 {
+            return false;
+        }
+        let upm = font.units_per_em();
+        let to_device = Matrix::scale(1.0 / upm, 1.0 / upm)
+            .concat(params)
+            .concat(tm)
+            .concat(gs.ctm);
+        if !finite_matrix(&to_device) {
+            return false;
+        }
+        let linear = Matrix {
+            a: to_device.a,
+            b: to_device.b,
+            c: to_device.c,
+            d: to_device.d,
+            e: 0.0,
+            f: 0.0,
+        };
+        let polys = font.flattened(gid, linear);
+        if !polys.is_empty() {
+            self.blit_glyph(&polys, to_device.e, to_device.f, fill, gs);
+        }
+        true
+    }
+
     /// Paints one show-string's glyphs and advances the text matrix. Codes with
     /// no drawable glyph still advance, so surrounding text stays positioned.
     ///
@@ -1659,7 +1729,7 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         }
         let gs = &frame.gs;
         let ts = &mut frame.ts;
-        let Some((font, label)) = ts.font.clone() else {
+        let Some((font, label, fallback)) = ts.font.clone() else {
             return;
         };
         let upm = font.units_per_em();
@@ -1712,19 +1782,24 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                     self.blit_glyph(&polys, to_device.e, to_device.f, fill, gs);
                 }
             } else if gid == 0 && !(n == 1 && code == 32) {
-                // A loaded font with no glyph for this code: the advance
-                // below still happens, so surrounding text stays positioned,
-                // but nothing painted here — report it so a lossy render is
-                // never mistaken for a clean one. The single-byte space is
-                // exempt because a space paints nothing whether or not the
-                // font maps it; a two-byte 0x20 is a real CID, not a space.
-                self.skip(
-                    SkippedKind::Glyph,
-                    SkipReason::NoGlyph {
-                        code,
-                        font: label.to_string(),
-                    },
-                );
+                // A loaded font with no glyph for this code: at `Full` with
+                // a provider, a per-glyph substitute face gets the code
+                // first (`paint_fallback`); only an unhandled miss is
+                // reported, so a lossy render is never mistaken for a clean
+                // one. The advance below still happens either way, so
+                // surrounding text stays positioned. The single-byte space
+                // is exempt because a space paints nothing whether or not
+                // the font maps it; a two-byte 0x20 is a real CID, not a
+                // space.
+                if !self.paint_fallback(fallback.as_deref(), code, params, ts.tm, gs, fill) {
+                    self.skip(
+                        SkippedKind::Glyph,
+                        SkipReason::NoGlyph {
+                            code,
+                            font: label.to_string(),
+                        },
+                    );
+                }
             }
 
             // Advance: (w0·Tfs + Tc + Tw[single-byte space]) · Th.
@@ -5353,5 +5428,206 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A one-page 200x200 document showing `content` with `/F0`, a simple
+    /// EMBEDDED `/TrueType` font over [`crate::truetype::tests::build_font`]
+    /// -- whose cmap maps ONLY 'A' (0x41) -- under `/WinAnsiEncoding`, with
+    /// `/Widths` giving codes 65..=67 an advance of 500. Every other drawn
+    /// code resolves to gid 0 in the font's own program.
+    fn doc_with_incomplete_truetype_font(content: &[u8]) -> Vec<u8> {
+        let mut b = PdfBuilder::new().version(1, 5);
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+             /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", content);
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /TrueType /BaseFont /IncompleteFace \
+             /FirstChar 65 /Widths [500 500 500] /Encoding /WinAnsiEncoding \
+             /FontDescriptor 6 0 R >>",
+        );
+        b.object(
+            6,
+            "<< /Type /FontDescriptor /FontName /IncompleteFace /Flags 32 \
+             /FontFile2 7 0 R >>",
+        );
+        b.stream(7, "", &crate::truetype::tests::build_font());
+        b.build(1)
+    }
+
+    /// Renders page 0 of `bytes` at `Full` with a Dir provider whose sans
+    /// face (`Arimo[wght].ttf`, the style `/IncompleteFace` requests) is a
+    /// 2048-upm fixture mapping ONLY 'B' (0x42) to the rect glyph.
+    fn render_full_with_b_only_fallback(tag: &str, bytes: &[u8]) -> (Pixmap, RenderReport) {
+        let dir = write_temp_face(
+            tag,
+            "Arimo[wght].ttf",
+            &crate::truetype::tests::build_font_with(2048, 0x42),
+        );
+        let doc = Document::load(bytes.to_vec()).expect("load");
+        let page = doc.page(0).expect("page");
+        let opts = RenderOptions {
+            glyph_painting: GlyphPainting::Full,
+            substitutes: SubstituteSource::Dir(dir.clone()),
+        };
+        let out = crate::render_page_reporting(&doc, &page, 1.0, &opts).expect("render");
+        std::fs::remove_dir_all(&dir).ok();
+        out
+    }
+
+    #[test]
+    fn embedded_font_missing_code_paints_via_per_glyph_fallback() {
+        // <4142>: 'A' paints from the embedded program's own cmap; 'B' has
+        // no glyph there (gid 0) and must paint from the fallback face
+        // instead of being reported. The fallback fixture's 2048 upm pins
+        // the device transform to the FALLBACK face's own units-per-em (a
+        // primary-upm transform would paint the 2048-unit rect at twice the
+        // size). The advance between the two glyphs is the PRIMARY font's
+        // /Widths entry (500/1000 em = 50pt at 100pt), so 'A' fills device
+        // x in [30,80] and 'B' x in [80,130], both y in [80,150].
+        let (pix, report) = render_full_with_b_only_fallback(
+            "per-glyph-fallback",
+            &doc_with_incomplete_truetype_font(b"BT /F0 100 Tf 20 50 Td <4142> Tj ET"),
+        );
+        assert!(
+            dark_at(&pix, 55, 115),
+            "'A' paints from the embedded program"
+        );
+        assert!(dark_at(&pix, 105, 115), "'B' paints from the fallback face");
+        assert!(
+            report.is_empty(),
+            "a fallback-painted code is not a drop: {:?}",
+            report.warnings()
+        );
+    }
+
+    #[test]
+    fn code_missing_from_fallback_too_still_reports_no_glyph() {
+        // 'C' (0x43) is in neither the embedded program's cmap nor the
+        // fallback face's ('B'-only): today's NoGlyph report must fire
+        // exactly as it would with no fallback at all.
+        let (pix, report) = render_full_with_b_only_fallback(
+            "per-glyph-fallback-miss",
+            &doc_with_incomplete_truetype_font(b"BT /F0 100 Tf 20 50 Td <43> Tj ET"),
+        );
+        assert!(
+            !dark_at(&pix, 55, 115),
+            "nothing painted for the double miss"
+        );
+        assert_eq!(
+            drops(&report),
+            vec![(
+                SkippedKind::Glyph,
+                SkipReason::NoGlyph {
+                    code: 67,
+                    font: "IncompleteFace".to_string(),
+                },
+                1
+            )]
+        );
+    }
+
+    #[test]
+    fn single_byte_space_stays_silent_with_fallback_available() {
+        // The single-byte space paints nothing whether or not any face maps
+        // it: no fallback paint, no report, exactly as without a provider.
+        let (pix, report) = render_full_with_b_only_fallback(
+            "per-glyph-fallback-space",
+            &doc_with_incomplete_truetype_font(b"BT /F0 100 Tf 20 50 Td <20> Tj ET"),
+        );
+        assert!(!dark_at(&pix, 55, 115), "a space paints nothing");
+        assert!(report.is_empty(), "a space is not a drop");
+    }
+
+    #[test]
+    fn type0_missing_gid_never_falls_back() {
+        // An embedded Type0/CIDFontType2 showing CID 0 (gid 0 under the
+        // Identity map): composite codes are two bytes wide, so the 1-byte
+        // fallback table never applies -- the NoGlyph report fires even at
+        // `Full` with a provider face on hand.
+        let mut b = PdfBuilder::new().version(1, 5);
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+             /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F0 100 Tf 20 50 Td <0000> Tj ET");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type0 /BaseFont /X /Encoding /Identity-H \
+             /DescendantFonts [6 0 R] >>",
+        );
+        b.object(
+            6,
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /X \
+             /FontDescriptor 7 0 R /DW 1000 >>",
+        );
+        b.object(
+            7,
+            "<< /Type /FontDescriptor /FontName /X /Flags 4 /FontFile2 8 0 R >>",
+        );
+        b.stream(8, "", &crate::truetype::tests::build_font());
+        let (pix, report) = render_full_with_b_only_fallback("type0-no-fallback", &b.build(1));
+        assert!(!dark_at(&pix, 55, 115), "nothing painted for CID 0");
+        assert_eq!(
+            drops(&report),
+            vec![(
+                SkippedKind::Glyph,
+                SkipReason::NoGlyph {
+                    code: 0,
+                    font: "X".to_string(),
+                },
+                1
+            )]
+        );
+    }
+
+    #[test]
+    fn metrics_only_font_never_falls_back() {
+        // Non-embedded /Symbol loads metrics-only at every tier (no
+        // license-clean substitute), so its unpainted codes are configured
+        // tier behavior: no fallback paint and no report, even at `Full`
+        // with a provider face that could draw the code.
+        let mut b = PdfBuilder::new().version(1, 5);
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+             /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F0 100 Tf 20 50 Td <41> Tj ET");
+        b.object(5, "<< /Type /Font /Subtype /Type1 /BaseFont /Symbol >>");
+        let bytes = b.build(1);
+
+        let dir = write_temp_face(
+            "metrics-only-no-fallback",
+            "Arimo[wght].ttf",
+            &crate::truetype::tests::build_font(),
+        );
+        let doc = Document::load(bytes).expect("load");
+        let page = doc.page(0).expect("page");
+        let opts = RenderOptions {
+            glyph_painting: GlyphPainting::Full,
+            substitutes: SubstituteSource::Dir(dir.clone()),
+        };
+        let (pix, report) = crate::render_page_reporting(&doc, &page, 1.0, &opts).expect("render");
+        std::fs::remove_dir_all(&dir).ok();
+        assert!(
+            !dark_at(&pix, 55, 115),
+            "a metrics-only font paints nothing"
+        );
+        assert!(
+            report.is_empty(),
+            "metrics-only codes are configured behavior, not drops: {:?}",
+            report.warnings()
+        );
     }
 }

--- a/crates/pdfboss-render/src/glyph.rs
+++ b/crates/pdfboss-render/src/glyph.rs
@@ -10,7 +10,10 @@
 //! `/TrueType`, `/Type1`, or `/MMType1` font, including the standard 14)
 //! instead substitutes a provider-supplied TrueType face
 //! (`crate::substitute`), with Adobe Core-14 AFM metrics filling in for a
-//! missing `/Widths`. Substitution is scoped to simple font subtypes only:
+//! missing `/Widths`; and an EMBEDDED simple font whose program lacks a
+//! drawn code falls back per glyph to the same provider-supplied face
+//! ([`GlyphFallback`]), keeping its own program for every code it does
+//! cover. Substitution is scoped to simple font subtypes only:
 //! a `/Type0` composite font's codes are two bytes wide and a substitute's
 //! 1-byte table would mis-split them, so a non-embedded `/Type0` never
 //! substitutes, at any tier. `/Type3` (whose glyphs paint via
@@ -20,7 +23,7 @@
 //! than guessing.
 
 use pdfboss_core::FastMap;
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 
 #[cfg(test)]
 use pdfboss_core::{block_on, Document, Immediate};
@@ -93,6 +96,7 @@ enum GlyphKind {
 /// fonts, which rely on the embedded program's own `hmtx` table instead, so
 /// `GlyphFont::advance` must fall back to the program advance rather than
 /// treating every code as width 0.
+#[derive(Clone)]
 struct WidthMap {
     map: FastMap<u32, f32>,
     default: f32,
@@ -341,6 +345,39 @@ impl GlyphFont {
     /// configured tier behavior rather than reportable drops.
     pub(crate) fn paints(&self) -> bool {
         !matches!(self.outlines, Outlines::Metrics)
+    }
+
+    /// The per-glyph fallback for this loaded font (see [`GlyphFallback`]),
+    /// or `None` when fallback never applies: below the `Full` tier or with
+    /// no provider; a metrics-only font (unpainted codes there are
+    /// configured tier behavior); a composite font (two-byte codes that a
+    /// fallback's 1-byte table would mis-split); a substitute (its table was
+    /// already built through the substitute cmap, so a miss is final); or a
+    /// font with no substitute style at all (Symbol/ZapfDingbats).
+    pub(crate) async fn fallback<S: AsyncObjectSource>(
+        &self,
+        src: &S,
+        font: &Dict,
+        painting: GlyphPainting,
+        provider: Option<&dyn SubstituteProvider>,
+    ) -> Option<GlyphFallback> {
+        if painting != GlyphPainting::Full || provider.is_none() {
+            return None;
+        }
+        if !self.paints() {
+            return None;
+        }
+        if !matches!(self.kind, GlyphKind::Simple(_)) {
+            return None;
+        }
+        if matches!(self.outlines, Outlines::Substitute(_)) {
+            return None;
+        }
+        let inputs = SubstituteInputs::gather(src, font).await?;
+        Some(GlyphFallback {
+            inputs,
+            slot: OnceLock::new(),
+        })
     }
 }
 
@@ -758,66 +795,123 @@ async fn load_substitute<S: AsyncObjectSource>(
     font: &Dict,
     provider: &dyn SubstituteProvider,
 ) -> Option<GlyphFont> {
-    let req = FaceRequest::from_font_dict(src, font).await?;
-    let bytes = provider.face(&req)?;
-    let tt = TrueType::parse(bytes)?;
+    SubstituteInputs::gather(src, font).await?.build(provider)
+}
 
-    let base_font = font
-        .get_name("BaseFont")
-        .map(|n| n.0.as_str())
-        .unwrap_or("");
+/// The font-dictionary-derived inputs a substitute face is built from:
+/// everything [`load_substitute`] reads through the async object source,
+/// gathered apart from the synchronous [`SubstituteInputs::build`] so a
+/// per-glyph fallback ([`GlyphFallback`]) can construct the face inside the
+/// executor's show loop, which cannot await.
+struct SubstituteInputs {
+    req: FaceRequest,
+    base: Option<fn(u8) -> Option<char>>,
+    diffs: FastMap<u8, String>,
+    widths: WidthMap,
+    afm_widths: FastMap<u32, f32>,
+}
 
-    // `base_encoding` returns `None` when the font dict has no `/Encoding`
-    // key at all -- the COMMON shape for a non-embedded standard-14 font
-    // (e.g. bare `/Type1 /Helvetica`, no `/Encoding`, no `/Differences`).
-    // Left as `None`, every code below falls through to `.notdef` and this
-    // substitute paints nothing, even though the AFM width path further
-    // down (`is_standard_encoding`) already defaults an absent `/Encoding`
-    // to StandardEncoding for advances. Match that default here for the
-    // code -> glyph mapping too: a recognized standard-14 `/BaseFont` with
-    // no `/Encoding` key implies StandardEncoding (ISO 32000-1 9.6.6's
-    // built-in encoding for the standard 14), so this substitute face's
-    // `cmap` gets a real code -> char accessor instead of none at all. A
-    // `/Differences` entry (checked first, below) still takes precedence
-    // over this default, exactly as it does over an explicit `/Encoding`.
-    let base = base_encoding(src, font).await.or_else(|| {
-        pdfboss_encoding::is_standard_14(base_font)
-            .then_some(pdfboss_encoding::standard as fn(u8) -> Option<char>)
-    });
-    let diffs = differences(src, font).await;
+impl SubstituteInputs {
+    /// Resolves the substitute inputs from `font`, or `None` when the font
+    /// has no substitute style at all ([`FaceRequest::from_font_dict`]'s
+    /// Symbol/ZapfDingbats exclusion).
+    async fn gather<S: AsyncObjectSource>(src: &S, font: &Dict) -> Option<SubstituteInputs> {
+        let req = FaceRequest::from_font_dict(src, font).await?;
+        let base_font = font
+            .get_name("BaseFont")
+            .map(|n| n.0.as_str())
+            .unwrap_or("");
 
-    let mut table = Box::new([0u16; 256]);
-    for (code, slot) in table.iter_mut().enumerate() {
-        let code = code as u8;
-        // 1. A /Differences name, through the glyph list, into the
-        // SUBSTITUTE's own cmap.
-        if let Some(name) = diffs.get(&code) {
-            if let Some(ch) = pdfboss_encoding::glyph_to_unicode(name) {
+        // `base_encoding` returns `None` when the font dict has no `/Encoding`
+        // key at all -- the COMMON shape for a non-embedded standard-14 font
+        // (e.g. bare `/Type1 /Helvetica`, no `/Encoding`, no `/Differences`).
+        // Left as `None`, every code below falls through to `.notdef` and this
+        // substitute paints nothing, even though the AFM width path further
+        // down (`is_standard_encoding`) already defaults an absent `/Encoding`
+        // to StandardEncoding for advances. Match that default here for the
+        // code -> glyph mapping too: a recognized standard-14 `/BaseFont` with
+        // no `/Encoding` key implies StandardEncoding (ISO 32000-1 9.6.6's
+        // built-in encoding for the standard 14), so this substitute face's
+        // `cmap` gets a real code -> char accessor instead of none at all. A
+        // `/Differences` entry (checked first, below) still takes precedence
+        // over this default, exactly as it does over an explicit `/Encoding`.
+        let base = base_encoding(src, font).await.or_else(|| {
+            pdfboss_encoding::is_standard_14(base_font)
+                .then_some(pdfboss_encoding::standard as fn(u8) -> Option<char>)
+        });
+        let diffs = differences(src, font).await;
+        let widths = simple_widths(src, font).await;
+        let afm_widths = afm_14_widths(src, font, base_font, &diffs).await;
+
+        Some(SubstituteInputs {
+            req,
+            base,
+            diffs,
+            widths,
+            afm_widths,
+        })
+    }
+
+    /// Builds the substitute [`GlyphFont`] from the gathered inputs, or
+    /// `None` when `provider` has no face for the style or the face fails to
+    /// parse.
+    fn build(&self, provider: &dyn SubstituteProvider) -> Option<GlyphFont> {
+        let bytes = provider.face(&self.req)?;
+        let tt = TrueType::parse(bytes)?;
+
+        let mut table = Box::new([0u16; 256]);
+        for (code, slot) in table.iter_mut().enumerate() {
+            let code = code as u8;
+            // 1. A /Differences name, through the glyph list, into the
+            // SUBSTITUTE's own cmap.
+            if let Some(name) = self.diffs.get(&code) {
+                if let Some(ch) = pdfboss_encoding::glyph_to_unicode(name) {
+                    if let Some(gid) = tt.gid_for_unicode(ch as u32).filter(|&g| g != 0) {
+                        *slot = gid;
+                        continue;
+                    }
+                }
+            }
+            // 2. The base encoding's character, via the substitute's cmap.
+            if let Some(ch) = self.base.and_then(|f| f(code)) {
                 if let Some(gid) = tt.gid_for_unicode(ch as u32).filter(|&g| g != 0) {
                     *slot = gid;
-                    continue;
                 }
             }
         }
-        // 2. The base encoding's character, via the substitute's cmap.
-        if let Some(ch) = base.and_then(|f| f(code)) {
-            if let Some(gid) = tt.gid_for_unicode(ch as u32).filter(|&g| g != 0) {
-                *slot = gid;
-            }
-        }
+
+        Some(GlyphFont {
+            outline_cache: Mutex::new(FastMap::default()),
+            flat_cache: Mutex::new(FastMap::default()),
+            outlines: Outlines::Substitute(tt),
+            kind: GlyphKind::Simple(table),
+            widths: self.widths.clone(),
+            afm_widths: self.afm_widths.clone(),
+        })
     }
+}
 
-    let widths = simple_widths(src, font).await;
-    let afm_widths = afm_14_widths(src, font, base_font, &diffs).await;
+/// A per-font substitute face consulted glyph by glyph when an EMBEDDED
+/// simple font's own program lacks a drawn code (`gid` 0 at show time) --
+/// the `Full`-tier counterpart, for incomplete embedded programs, of the
+/// whole-font substitution [`load_substitute`] applies to non-embedded
+/// fonts. The inputs are gathered while the primary font loads (the async
+/// side); the face itself is built at most once, on the first miss, and a
+/// failed build is memoized as `None` so later misses stay cheap.
+pub(crate) struct GlyphFallback {
+    inputs: SubstituteInputs,
+    slot: OnceLock<Option<Arc<GlyphFont>>>,
+}
 
-    Some(GlyphFont {
-        outline_cache: Mutex::new(FastMap::default()),
-        flat_cache: Mutex::new(FastMap::default()),
-        outlines: Outlines::Substitute(tt),
-        kind: GlyphKind::Simple(table),
-        widths,
-        afm_widths,
-    })
+impl GlyphFallback {
+    /// The substitute face, built on first use and memoized -- including a
+    /// failed build (no provider face for the style, or an unparseable
+    /// face), so a page of misses pays for one attempt.
+    pub(crate) fn font(&self, provider: &dyn SubstituteProvider) -> Option<Arc<GlyphFont>> {
+        self.slot
+            .get_or_init(|| self.inputs.build(provider).map(Arc::new))
+            .clone()
+    }
 }
 
 /// The Adobe Core-14 AFM advance table for a recognized standard-14
@@ -2049,6 +2143,81 @@ mod tests {
         let doc = Document::load(bytes.to_vec()).expect("load");
         let page = doc.page(0).expect("page");
         crate::render_page_with_options(&doc, &page, 1.0, &opts).expect("render")
+    }
+
+    /// Whether `GlyphFont::fallback` plans a per-glyph fallback for the font
+    /// at object 5 of `doc`, loaded and consulted with the same tier and
+    /// provider.
+    fn plans_fallback(
+        doc: &Document,
+        painting: GlyphPainting,
+        provider: Option<&dyn crate::substitute::SubstituteProvider>,
+    ) -> bool {
+        use pdfboss_core::ObjRef;
+        let font_obj = doc.get(ObjRef { num: 5, gen: 0 }).expect("font object");
+        let font = font_obj.as_dict().expect("font is a dict");
+        let gf = super::GlyphFont::load(doc, font, painting, provider).expect("font loads");
+        pdfboss_core::block_on(gf.fallback(&pdfboss_core::Immediate(doc), font, painting, provider))
+            .is_some()
+    }
+
+    /// `GlyphFont::fallback`'s scope guards, checked directly: a per-glyph
+    /// fallback is planned exactly for a paintable EMBEDDED simple font at
+    /// `Full` with a provider -- never below the tier, without a provider,
+    /// for a composite font, for a whole-font substitute, or for a
+    /// metrics-only font.
+    #[test]
+    fn per_glyph_fallback_plans_only_for_embedded_simple_fonts_at_full() {
+        use crate::substitute::{DirProvider, SubstituteProvider};
+
+        let dir = write_temp_face("Arimo[wght].ttf", &build_font());
+        let provider = DirProvider { dir: dir.clone() };
+        let provider: Option<&dyn SubstituteProvider> = Some(&provider);
+
+        let embedded = Document::load(simple_font_doc(
+            "/Encoding /WinAnsiEncoding",
+            b"BT /F0 10 Tf (A) Tj ET",
+        ))
+        .expect("load");
+        assert!(plans_fallback(&embedded, GlyphPainting::Full, provider));
+        assert!(
+            !plans_fallback(&embedded, GlyphPainting::AllEmbedded, provider),
+            "below Full no fallback is planned"
+        );
+        assert!(
+            !plans_fallback(&embedded, GlyphPainting::Full, None),
+            "no provider, no fallback"
+        );
+
+        let type0 = cid_map_doc("", &[0, 0, 0, 1]);
+        assert!(
+            !plans_fallback(&type0, GlyphPainting::Full, provider),
+            "two-byte codes never fall back"
+        );
+
+        let substituted = Document::load(non_embedded_font_doc(
+            "Helvetica",
+            "/Encoding /WinAnsiEncoding",
+            b"BT /F0 10 Tf (A) Tj ET",
+        ))
+        .expect("load");
+        assert!(
+            !plans_fallback(&substituted, GlyphPainting::Full, provider),
+            "a whole-font substitute's miss is final"
+        );
+
+        let metrics_only = Document::load(non_embedded_font_doc(
+            "Symbol",
+            "/FirstChar 65 /Widths [500]",
+            b"BT /F0 10 Tf (A) Tj ET",
+        ))
+        .expect("load");
+        assert!(
+            !plans_fallback(&metrics_only, GlyphPainting::Full, provider),
+            "a metrics-only font's unpainted codes are tier behavior"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/crates/pdfboss-render/src/glyph.rs
+++ b/crates/pdfboss-render/src/glyph.rs
@@ -31,7 +31,7 @@ use pdfboss_core::{decoded_stream_data_with, AsyncObjectSource, Dict, Matrix, Ob
 
 use crate::cff::CffFont;
 use crate::path::{PathBuilder, Subpath};
-use crate::substitute::{FaceRequest, SubstituteProvider};
+use crate::substitute::{nonsymbolic, FaceRequest, SubstituteProvider};
 use crate::truetype::{Seg, TrueType};
 use crate::type1::Type1Font;
 use crate::GlyphPainting;
@@ -829,16 +829,24 @@ impl SubstituteInputs {
         // substitute paints nothing, even though the AFM width path further
         // down (`is_standard_encoding`) already defaults an absent `/Encoding`
         // to StandardEncoding for advances. Match that default here for the
-        // code -> glyph mapping too: a recognized standard-14 `/BaseFont` with
-        // no `/Encoding` key implies StandardEncoding (ISO 32000-1 9.6.6's
-        // built-in encoding for the standard 14), so this substitute face's
-        // `cmap` gets a real code -> char accessor instead of none at all. A
-        // `/Differences` entry (checked first, below) still takes precedence
-        // over this default, exactly as it does over an explicit `/Encoding`.
-        let base = base_encoding(src, font).await.or_else(|| {
-            pdfboss_encoding::is_standard_14(base_font)
-                .then_some(pdfboss_encoding::standard as fn(u8) -> Option<char>)
-        });
+        // code -> glyph mapping too, in two spec-anchored cases: a recognized
+        // standard-14 `/BaseFont` with no `/Encoding` key implies
+        // StandardEncoding (ISO 32000-1 9.6.6's built-in encoding for the
+        // standard 14); and a descriptor whose `/Flags` declare Nonsymbolic
+        // states outright that the font uses the Adobe standard Latin
+        // character set (Table 121), whose built-in encoding is the standard
+        // one (Annex D) -- without the font program the built-in table itself
+        // is unreadable, and StandardEncoding is its defined shape. A
+        // symbolic font's built-in encoding is unknowable here, so it is
+        // never guessed. A `/Differences` entry (checked first, below) still
+        // takes precedence over this default, exactly as it does over an
+        // explicit `/Encoding`.
+        let mut base = base_encoding(src, font).await;
+        if base.is_none()
+            && (pdfboss_encoding::is_standard_14(base_font) || nonsymbolic(src, font).await)
+        {
+            base = Some(pdfboss_encoding::standard);
+        }
         let diffs = differences(src, font).await;
         let widths = simple_widths(src, font).await;
         let afm_widths = afm_14_widths(src, font, base_font, &diffs).await;
@@ -2215,6 +2223,84 @@ mod tests {
         assert!(
             !plans_fallback(&metrics_only, GlyphPainting::Full, provider),
             "a metrics-only font's unpainted codes are tier behavior"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A one-page 200x200 document showing `content` with a NON-embedded
+    /// `/Type1 /PlainText` font (a name matching no standard-14 entry and no
+    /// family keyword) whose descriptor carries `flags` and whose dict has
+    /// no `/Encoding` at all -- the shape whose substitute table hinges
+    /// entirely on the descriptor's Nonsymbolic bit.
+    fn no_encoding_font_doc(flags: i64, content: &[u8]) -> Vec<u8> {
+        let mut b = PdfBuilder::new().version(1, 5);
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+             /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", content);
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /PlainText \
+             /FontDescriptor 6 0 R >>",
+        );
+        b.object(
+            6,
+            &format!("<< /Type /FontDescriptor /FontName /PlainText /Flags {flags} >>"),
+        );
+        b.build(1)
+    }
+
+    #[test]
+    fn nonsymbolic_font_without_encoding_substitutes_via_standard_encoding() {
+        let dir = write_temp_face("Tinos-Regular.ttf", &build_font());
+        let opts = || RenderOptions {
+            glyph_painting: GlyphPainting::Full,
+            substitutes: SubstituteSource::Dir(dir.clone()),
+        };
+
+        // Serif (0x2) + Nonsymbolic (0x20): the descriptor states the font
+        // uses the standard Latin character set, so the absent `/Encoding`
+        // defaults to StandardEncoding and 'A' resolves through the
+        // substitute face's cmap.
+        let bytes = no_encoding_font_doc(0x22, b"BT /F0 100 Tf 20 50 Td <41> Tj ET");
+        let pix = render_with(&bytes, opts());
+        assert!(
+            dark_pixel_at(&pix, 55, 115),
+            "a nonsymbolic font with no /Encoding substitutes via StandardEncoding"
+        );
+
+        // Serif (0x2) + Symbolic (0x4): the built-in encoding is unknowable
+        // without the font program and is never guessed -- the code stays
+        // unpainted and is reported, exactly as before.
+        let bytes = no_encoding_font_doc(0x6, b"BT /F0 100 Tf 20 50 Td <41> Tj ET");
+        let doc = Document::load(bytes).expect("load");
+        let page = doc.page(0).expect("page");
+        let (pix, report) =
+            crate::render_page_reporting(&doc, &page, 1.0, &opts()).expect("render");
+        assert!(
+            !dark_pixel_at(&pix, 55, 115),
+            "a symbolic font's built-in encoding is never guessed"
+        );
+        let drops: Vec<_> = report
+            .skipped
+            .iter()
+            .map(|s| (s.kind, s.reason.clone(), s.count))
+            .collect();
+        assert_eq!(
+            drops,
+            vec![(
+                crate::SkippedKind::Glyph,
+                crate::SkipReason::NoGlyph {
+                    code: 65,
+                    font: "PlainText".to_string(),
+                },
+                1,
+            )],
         );
 
         std::fs::remove_dir_all(&dir).ok();

--- a/crates/pdfboss-render/src/lib.rs
+++ b/crates/pdfboss-render/src/lib.rs
@@ -141,7 +141,9 @@ pub enum GlyphPainting {
     /// Every embedded program: TrueType, CFF, Type1 and Type3. No bundled assets.
     #[default]
     AllEmbedded,
-    /// Also substitute bundled or caller-provided faces for non-embedded fonts.
+    /// Also substitute bundled or caller-provided faces for non-embedded
+    /// fonts, and per glyph for codes an embedded simple font's program
+    /// lacks.
     Full,
 }
 

--- a/crates/pdfboss-render/src/substitute.rs
+++ b/crates/pdfboss-render/src/substitute.rs
@@ -72,8 +72,28 @@ pub(crate) trait SubstituteProvider: Send + Sync {
 /// `/FontDescriptor /Flags` bits consulted here (ISO 32000-1 Table 121).
 const FLAG_FIXED_PITCH: i64 = 0x1;
 const FLAG_SERIF: i64 = 0x2;
+const FLAG_NONSYMBOLIC: i64 = 0x20;
 const FLAG_ITALIC: i64 = 0x40;
 const FLAG_FORCE_BOLD: i64 = 0x40000;
+
+/// Whether `font`'s descriptor declares the Nonsymbolic flag (ISO 32000-1
+/// Table 121): the font uses the Adobe standard Latin character set. An
+/// absent descriptor or absent `/Flags` reads as `false` -- unknown is
+/// never nonsymbolic.
+pub(crate) async fn nonsymbolic<S: AsyncObjectSource>(src: &S, font: &Dict) -> bool {
+    let Some(obj) = font.get("FontDescriptor") else {
+        return false;
+    };
+    let Some(descriptor) = src
+        .resolve(obj)
+        .await
+        .ok()
+        .and_then(|o| o.as_dict().cloned())
+    else {
+        return false;
+    };
+    descriptor.get_int("Flags").unwrap_or(0) & FLAG_NONSYMBOLIC != 0
+}
 
 /// Strips a subset prefix (`ABCDEF+Name` -> `Name`, ISO 32000-1 9.6.4): six
 /// uppercase ASCII letters followed by `+`. Names that don't match this exact

--- a/crates/pdfboss-render/src/truetype.rs
+++ b/crates/pdfboss-render/src/truetype.rs
@@ -720,9 +720,9 @@ pub(crate) mod tests {
         g
     }
 
-    fn table_head() -> Vec<u8> {
+    fn table_head(upm: u16) -> Vec<u8> {
         let mut t = vec![0u8; 54];
-        t[18..20].copy_from_slice(&be(1000)); // unitsPerEm
+        t[18..20].copy_from_slice(&be(upm)); // unitsPerEm
         t[50..52].copy_from_slice(&be(0)); // indexToLocFormat = short
         t
     }
@@ -733,8 +733,8 @@ pub(crate) mod tests {
         t
     }
 
-    /// Format-4 cmap mapping `'A'` (0x41) to glyph 1.
-    fn table_cmap() -> Vec<u8> {
+    /// Format-4 cmap mapping the single character `ch` to glyph 1.
+    fn table_cmap(ch: u16) -> Vec<u8> {
         let mut sub = Vec::new();
         sub.extend_from_slice(&be(4)); // format
         sub.extend_from_slice(&be(0)); // length placeholder
@@ -743,12 +743,12 @@ pub(crate) mod tests {
         sub.extend_from_slice(&be(0)); // searchRange
         sub.extend_from_slice(&be(0)); // entrySelector
         sub.extend_from_slice(&be(0)); // rangeShift
-        sub.extend_from_slice(&be(0x0041)); // endCode[0]
+        sub.extend_from_slice(&be(ch)); // endCode[0]
         sub.extend_from_slice(&be(0xFFFF)); // endCode[1]
         sub.extend_from_slice(&be(0)); // reservedPad
-        sub.extend_from_slice(&be(0x0041)); // startCode[0]
+        sub.extend_from_slice(&be(ch)); // startCode[0]
         sub.extend_from_slice(&be(0xFFFF)); // startCode[1]
-        sub.extend_from_slice(&be((1i32 - 0x41) as u16)); // idDelta[0] → gid 1
+        sub.extend_from_slice(&be((1i32 - i32::from(ch)) as u16)); // idDelta[0] → gid 1
         sub.extend_from_slice(&be(1)); // idDelta[1]
         sub.extend_from_slice(&be(0)); // idRangeOffset[0]
         sub.extend_from_slice(&be(0)); // idRangeOffset[1]
@@ -781,7 +781,15 @@ pub(crate) mod tests {
 
     /// Assembles a one-glyph (plus .notdef) sfnt with head/maxp/cmap/loca/glyf.
     pub(crate) fn build_font() -> Vec<u8> {
-        let glyph1 = rect_glyph(100, 0, 600, 700);
+        build_font_with(1000, 0x41)
+    }
+
+    /// [`build_font`] generalized: `upm` design units per em (the rect
+    /// glyph's coordinates scale along, keeping the same em-relative shape)
+    /// and `ch` the single cmap-mapped character.
+    pub(crate) fn build_font_with(upm: u16, ch: u16) -> Vec<u8> {
+        let s = |v: i32| (v * i32::from(upm) / 1000) as i16;
+        let glyph1 = rect_glyph(s(100), s(0), s(600), s(700));
         let glyf = glyph1.clone(); // gid 0 empty, gid 1 at offset 0
                                    // Short loca: [gid0=0, gid1=0, end=len/2].
         let mut loca = Vec::new();
@@ -790,9 +798,9 @@ pub(crate) mod tests {
         loca.extend_from_slice(&be((glyf.len() / 2) as u16));
 
         let tables: [(&[u8; 4], Vec<u8>); 6] = [
-            (b"cmap", table_cmap()),
+            (b"cmap", table_cmap(ch)),
             (b"glyf", glyf),
-            (b"head", table_head()),
+            (b"head", table_head(upm)),
             (b"loca", loca),
             (b"maxp", table_maxp(2)),
             (b"post", table_post()),


### PR DESCRIPTION
Two commits:
1. Per-glyph fallback: at the Full tier with a provider, an embedded simple font missing a glyph for a drawn code now falls back per glyph to a substitute face (lazily built once per font via a OnceLock, painted with the fallback face's own units-per-em, advance unchanged from the primary /Widths tier). NoGlyph reports fire only when the fallback also misses. Type0, symbolic Symbol/ZapfDingbats, metrics-only fonts, and already-substituted fonts are excluded.
2. Nonsymbolic substitutes with no /Encoding default to StandardEncoding (ISO 32000-1 Table 121 + Annex D): a non-embedded nonsymbolic text font without /Encoding previously produced an empty substitute table (every code a NoGlyph). Symbolic fonts are never guessed.

Certification impact (render benchmark exclusions): 049061 (Melior) 2916 missing glyphs -> 0 across all pages; 049466 (Carta) and 049665 (WPMathA) are symbolic fonts with no encoding evidence — genuinely unmappable, unchanged by design. Expected certification 37/40 -> 38/40.

Verification: corpus sha diff vs main baseline (259 files x first 2 pages, scale 1.0, fonts=full): 493 identical, 12 changed across 7 files — every changed page confirmed to have reported NoGlyph on main (049061/049107/049365/049399/049667/049887/049915), i.e. blast radius exactly the contracted set. 1681 workspace + 314 feature-state tests green, 118 pytest green, fmt/clippy clean in both feature states. 7 new tests incl. a 2048-upm fallback-face fixture pinning the transform and advance.