### PR TITLE
feat: honor optional content (ISO 32000-1 §8.11) in rendering and extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ What still does not paint: `/Symbol` and `/ZapfDingbats` have no license-clean s
 
 `JPXDecode` implements ITU-T T.800 (JPEG 2000 Part 1) with known approximations, each reported as a render warning rather than passed off silently. Embedded ICC profiles are not interpreted; colour is approximated from the channel count, and sYCC conversion is approximate. Part 2 (ISO/IEC 15444-2) extensions are tolerated in the container but not decoded. Every output sample is normalized to 8 bits per channel, so sources deeper than 8 bits (the spec allows up to 38) lose their extra precision.
 
+Optional content groups (PDF layers, ISO 32000 §8.11) are honored per the document's default configuration: rendering and text extraction skip layers it turns off, counting them on the reports' `hidden` counters.
+
 Not yet supported (they error or degrade gracefully, and are on the roadmap): mesh shadings (types 4–7 and the function-based type 1) and PostScript-calculator functions · the JBIG2 features listed above · the unpainted faces listed above · the non-separable blend modes (Hue, Saturation, Color, Luminosity) and `/SMask` transfer functions.
 
 Rendering is lenient: content pdfboss cannot read is skipped so the rest of the page still rasterizes. It says so rather than passing the result off as a faithful render. `pdfboss render` prints a warning line per dropped item on stderr and annotates its summary. The TUI preview raises a status-bar notice. The libraries expose the detail through `render_page_reporting` (Rust) and `Page.render_reporting()` (Python), which return the pixels plus a report of everything dropped or approximated.

--- a/crates/pdfboss-aio/src/document.rs
+++ b/crates/pdfboss-aio/src/document.rs
@@ -1362,6 +1362,15 @@ impl AsyncDocument {
         Some(decode_text_string(value.as_str_bytes()?))
     }
 
+    /// The document's optional-content visibility under its default
+    /// configuration, or `None` when the catalog declares no
+    /// `/OCProperties` — the async twin of the sync document's `oc_state`.
+    /// A rendering caller passes it on through
+    /// `pdfboss_render::RenderOptions::oc`.
+    pub async fn oc_state(&self) -> Option<pdfboss_core::OcState> {
+        pdfboss_core::OcState::load_with(self, &self.inner.xref.trailer).await
+    }
+
     /// Number of pages: the flattened page tree's length. The tree is
     /// flattened once at open, so this is synchronous and authoritative —
     /// mirroring the sync document once its tree has been flattened.

--- a/crates/pdfboss-aio/tests/parity.rs
+++ b/crates/pdfboss-aio/tests/parity.rs
@@ -330,14 +330,13 @@ async fn shared_algorithms_run_over_the_async_document() {
             let text = pdfboss_output::extract_text_with(doc.clone(), &page)
                 .await
                 .expect("async text");
-            let (pix, _) = pdfboss_render::render_page_reporting_with(
-                doc,
-                &page,
-                1.0,
-                &pdfboss_render::RenderOptions::default(),
-            )
-            .await
-            .expect("async render");
+            let opts = pdfboss_render::RenderOptions {
+                oc: doc.oc_state().await.map(std::sync::Arc::new),
+                ..Default::default()
+            };
+            let (pix, _) = pdfboss_render::render_page_reporting_with(doc, &page, 1.0, &opts)
+                .await
+                .expect("async render");
             (text, pix)
         });
         let (text, pix) = handle.await.expect("spawned task");
@@ -347,6 +346,67 @@ async fn shared_algorithms_run_over_the_async_document() {
             "page {i}: rendered pixels must be byte-identical"
         );
     }
+}
+
+/// A document with optional content renders identically over both
+/// documents once the async caller passes `AsyncDocument::oc_state` through
+/// the render options — the synchronous entry reads the same configuration
+/// itself. Leaving the options bare paints the hidden layer, so the
+/// comparison genuinely exercises the gate.
+#[tokio::test]
+async fn optional_content_renders_identically() {
+    let mut b = PdfBuilder::new();
+    b.object(
+        1,
+        "<< /Type /Catalog /Pages 2 0 R /OCProperties \
+         << /OCGs [8 0 R] /D << /OFF [8 0 R] >> >> >>",
+    );
+    b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    b.object(
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+         /Resources << /Properties << /H 8 0 R >> >> /Contents 4 0 R >>",
+    );
+    b.stream(4, "", b"1 0 0 rg /OC /H BDC 10 10 80 80 re f EMC");
+    b.object(8, "<< /Type /OCG /Name (layer) >>");
+    let bytes = b.build(1);
+
+    let sync_doc = Document::load(bytes.clone()).expect("sync load");
+    let sync_page = sync_doc.page(0).expect("sync page");
+    let (expected, report) = pdfboss_render::render_page_reporting(
+        &sync_doc,
+        &sync_page,
+        1.0,
+        &pdfboss_render::RenderOptions::default(),
+    )
+    .expect("sync render");
+    assert_eq!(report.hidden, 1, "the sync entry reads the configuration");
+
+    let async_doc = AsyncDocument::from_bytes(bytes).await.expect("async open");
+    let page = async_doc.page(0).expect("async page");
+    let opts = pdfboss_render::RenderOptions {
+        oc: async_doc.oc_state().await.map(std::sync::Arc::new),
+        ..Default::default()
+    };
+    let (pix, report) =
+        pdfboss_render::render_page_reporting_with(async_doc.clone(), &page, 1.0, &opts)
+            .await
+            .expect("async render");
+    assert_eq!(report.hidden, 1);
+    assert_eq!(pix.data, expected.data, "pixels must be byte-identical");
+
+    let (bare, _) = pdfboss_render::render_page_reporting_with(
+        async_doc,
+        &page,
+        1.0,
+        &pdfboss_render::RenderOptions::default(),
+    )
+    .await
+    .expect("bare async render");
+    assert_ne!(
+        bare.data, expected.data,
+        "without the state the hidden layer paints, so the parity above is real"
+    );
 }
 
 /// An RC4-encrypted document (Standard handler, empty user password) opens

--- a/crates/pdfboss-cli/src/main.rs
+++ b/crates/pdfboss-cli/src/main.rs
@@ -602,6 +602,7 @@ fn cmd_render(
     let opts = pdfboss_render::RenderOptions {
         glyph_painting: fonts.to_painting(),
         substitutes,
+        ..Default::default()
     };
     let (pixmap, report) =
         pdfboss_render::render_page_reporting(&doc, &p, scale, &opts).map_err(|e| e.to_string())?;

--- a/crates/pdfboss-core/src/document.rs
+++ b/crates/pdfboss-core/src/document.rs
@@ -478,6 +478,17 @@ impl Document {
         meta
     }
 
+    /// The document's optional-content visibility under its default
+    /// configuration (ISO 32000-1 §8.11.4.3), or `None` when the catalog
+    /// declares no `/OCProperties` — no optional content, everything
+    /// visible. Computed per call from a handful of object reads.
+    pub fn oc_state(&self) -> Option<crate::oc::OcState> {
+        block_on(crate::oc::OcState::load_with(
+            &Immediate(self),
+            &self.xref.trailer,
+        ))
+    }
+
     /// Reads `key` from an info dictionary as a decoded text string.
     fn meta_string(&self, dict: &Dict, key: &str) -> Option<String> {
         let value = self.resolve(dict.get(key)?).ok()?;

--- a/crates/pdfboss-core/src/lib.rs
+++ b/crates/pdfboss-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod hash;
 pub mod lexer;
 pub mod object;
 pub mod objstm;
+pub mod oc;
 pub mod parser;
 pub mod pretty;
 pub mod source;
@@ -29,6 +30,7 @@ pub use error::{Error, Result};
 pub use geom::{Matrix, Point, Rect};
 pub use hash::{FastMap, FastSet, FxHasher};
 pub use object::{Dict, Name, ObjRef, Object, Stream};
+pub use oc::OcState;
 pub use source::{
     block_on, resolve_sync_with, resolve_with, AsyncObjectSource, BoxFuture, Immediate,
     ObjectSource, MAX_RESOLVE_DEPTH,

--- a/crates/pdfboss-core/src/oc.rs
+++ b/crates/pdfboss-core/src/oc.rs
@@ -1,0 +1,549 @@
+//! Optional-content visibility (ISO 32000-1 §8.11): which optional content
+//! groups the document's default configuration turns off, and whether
+//! content gated by an `/OC` entry or a `BDC /OC` span is visible.
+
+use std::sync::Arc;
+
+use crate::hash::FastSet;
+use crate::object::{Dict, ObjRef, Object};
+use crate::source::AsyncObjectSource;
+
+/// Maximum `/VE` visibility-expression nesting depth. Real expressions are
+/// one or two levels deep; past the cap the expression reads as malformed,
+/// and malformed means visible.
+const MAX_VE_DEPTH: u32 = 8;
+
+/// The document's optional-content visibility under its default
+/// configuration (`/OCProperties` `/D`, ISO 32000-1 §8.11.4.3): the set of
+/// groups that configuration turns off. A group's identity is its indirect
+/// reference — groups are shared by reference between the configuration,
+/// marked-content properties, and `/OC` entries (§8.11.2.1).
+///
+/// Everything here is lenient: an entry that is missing, malformed, or will
+/// not resolve leaves content visible, never hidden.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OcState {
+    off: FastSet<ObjRef>,
+}
+
+impl OcState {
+    /// Builds the state from the catalog's `/OCProperties`, or `None` when
+    /// the document declares none — no optional content, everything
+    /// visible. The default `/D` configuration is applied in specification
+    /// order: `/BaseState` (default `ON`), then `/ON`, then `/OFF`, so a
+    /// group named in both `/ON` and `/OFF` ends up off.
+    pub async fn load_with<S: AsyncObjectSource>(src: &S, trailer: &Dict) -> Option<OcState> {
+        let root = trailer.get("Root")?;
+        let catalog = src.resolve(root).await.ok()?;
+        let props = src
+            .resolve(catalog.as_dict()?.get("OCProperties")?)
+            .await
+            .ok()?;
+        let props = props.as_dict()?;
+        let config = match props.get("D") {
+            Some(o) => src.resolve(o).await.ok(),
+            None => None,
+        };
+        let config = config.as_ref().and_then(Object::as_dict);
+        let base_off = match config.and_then(|d| d.get("BaseState")) {
+            Some(o) => matches!(
+                src.resolve(o).await.ok().as_ref().and_then(Object::as_name),
+                Some(n) if n.0 == "OFF"
+            ),
+            None => false,
+        };
+        let mut off: FastSet<ObjRef> = FastSet::default();
+        if base_off {
+            off.extend(group_refs(src, props.get("OCGs")).await);
+        }
+        if let Some(config) = config {
+            for group in group_refs(src, config.get("ON")).await {
+                off.remove(&group);
+            }
+            off.extend(group_refs(src, config.get("OFF")).await);
+        }
+        Some(OcState { off })
+    }
+
+    /// Whether the configuration turns `group` off.
+    pub fn hidden(&self, group: ObjRef) -> bool {
+        self.off.contains(&group)
+    }
+
+    /// Whether content gated by `value` — the operand of a stream or
+    /// annotation dictionary's `/OC` entry — is visible: a group reference
+    /// is visible unless the group is off; a membership dictionary follows
+    /// [`OcState::ocmd_visible`]. A direct group dictionary has no
+    /// reference identity to be turned off by, and anything malformed is
+    /// left visible.
+    pub async fn visible_with<S: AsyncObjectSource>(&self, src: &S, value: &Object) -> bool {
+        match value {
+            Object::Ref(r) => {
+                let Ok(resolved) = src.resolve(value).await else {
+                    return true;
+                };
+                let Some(dict) = resolved.as_dict() else {
+                    return true;
+                };
+                if is_ocmd(dict) {
+                    return self.ocmd_visible(src, dict).await;
+                }
+                !self.hidden(*r)
+            }
+            Object::Dict(dict) => {
+                if is_ocmd(dict) {
+                    return self.ocmd_visible(src, dict).await;
+                }
+                true
+            }
+            _ => true,
+        }
+    }
+
+    /// Whether a `BDC /OC` span is visible: `props` is the operator's
+    /// properties operand — an inline dictionary, or a name looked up in
+    /// the resource chain's `/Properties` category. The lookup keeps the
+    /// value unresolved, because a group's on/off identity is its indirect
+    /// reference; resolving first would read every named group as visible.
+    pub async fn props_visible_with<S: AsyncObjectSource>(
+        &self,
+        src: &S,
+        chain: &[Arc<Dict>],
+        props: &Object,
+    ) -> bool {
+        let named;
+        let value = match props {
+            Object::Name(name) => {
+                named = properties_value(src, chain, &name.0).await;
+                match &named {
+                    Some(value) => value,
+                    None => return true,
+                }
+            }
+            other => other,
+        };
+        self.visible_with(src, value).await
+    }
+
+    /// A membership dictionary's visibility (§8.11.2.2): the `/VE`
+    /// visibility expression when present (taking precedence, malformed
+    /// reading as visible), else the `/OCGs` groups under the `/P` policy —
+    /// `AnyOn` (the default, and the reading of an unrecognized policy),
+    /// `AllOn`, `AnyOff`, or `AllOff`. No usable groups means visible.
+    async fn ocmd_visible<S: AsyncObjectSource>(&self, src: &S, dict: &Dict) -> bool {
+        if let Some(ve) = dict.get("VE") {
+            let Ok(Object::Array(expr)) = src.resolve(ve).await else {
+                return true;
+            };
+            return self.expression_visible(src, expr).await.unwrap_or(true);
+        }
+        let groups: Vec<ObjRef> = match dict.get("OCGs") {
+            None => return true,
+            Some(indirect @ Object::Ref(r)) => match src.resolve(indirect).await {
+                Ok(Object::Array(items)) => items.iter().filter_map(Object::as_ref).collect(),
+                Ok(Object::Dict(_)) => vec![*r],
+                _ => Vec::new(),
+            },
+            Some(Object::Array(items)) => items.iter().filter_map(Object::as_ref).collect(),
+            Some(_) => Vec::new(),
+        };
+        if groups.is_empty() {
+            return true;
+        }
+        let policy = match dict.get("P") {
+            Some(o) => src
+                .resolve(o)
+                .await
+                .ok()
+                .and_then(|o| o.as_name().map(|n| n.0.clone())),
+            None => None,
+        };
+        match policy.as_deref() {
+            Some("AllOn") => groups.iter().all(|g| !self.hidden(*g)),
+            Some("AnyOff") => groups.iter().any(|g| self.hidden(*g)),
+            Some("AllOff") => groups.iter().all(|g| self.hidden(*g)),
+            _ => groups.iter().any(|g| !self.hidden(*g)),
+        }
+    }
+
+    /// Evaluates a `/VE` array (§8.11.2.3): `[/And|/Or|/Not operands…]`,
+    /// each operand a group reference or a nested expression (directly, or
+    /// behind a reference). `None` is malformed — an unknown operator, no
+    /// operands, `/Not` with more than one, an operand that is neither
+    /// group nor expression, or nesting past [`MAX_VE_DEPTH`] — and reads
+    /// as visible at the caller.
+    ///
+    /// An explicit work stack rather than recursion: a recursive `async fn`
+    /// must box itself, and a `Send`-boxed future would demand `S: Sync`,
+    /// which the synchronous `Immediate` source cannot supply — the same
+    /// shape as the content executors' frame stacks.
+    async fn expression_visible<S: AsyncObjectSource>(
+        &self,
+        src: &S,
+        expr: Vec<Object>,
+    ) -> Option<bool> {
+        let mut stack = vec![VeFrame::new(src, expr).await?];
+        loop {
+            let top = stack.len() - 1;
+            let Some(operand) = stack[top].operands.get(stack[top].next).cloned() else {
+                let done = stack.pop()?;
+                let value = match done.operator.as_str() {
+                    "And" => done.all,
+                    "Or" => done.any,
+                    _ => !done.any,
+                };
+                let Some(parent) = stack.last_mut() else {
+                    return Some(value);
+                };
+                parent.fold(value);
+                continue;
+            };
+            stack[top].next += 1;
+            let value = match operand {
+                Object::Array(items) => {
+                    if stack.len() > MAX_VE_DEPTH as usize {
+                        return None;
+                    }
+                    stack.push(VeFrame::new(src, items).await?);
+                    continue;
+                }
+                Object::Ref(group) => match src.resolve(&operand).await.ok()? {
+                    Object::Array(items) => {
+                        if stack.len() > MAX_VE_DEPTH as usize {
+                            return None;
+                        }
+                        stack.push(VeFrame::new(src, items).await?);
+                        continue;
+                    }
+                    Object::Dict(_) => !self.hidden(group),
+                    _ => return None,
+                },
+                _ => return None,
+            };
+            stack[top].fold(value);
+        }
+    }
+}
+
+/// One suspended `/VE` subexpression: its operator, its operands, how far
+/// evaluation has got, and the conjunction/disjunction accumulated so far.
+struct VeFrame {
+    operator: String,
+    operands: Vec<Object>,
+    next: usize,
+    all: bool,
+    any: bool,
+}
+
+impl VeFrame {
+    /// Validates and frames one expression array; `None` is malformed.
+    async fn new<S: AsyncObjectSource>(src: &S, mut expr: Vec<Object>) -> Option<VeFrame> {
+        let operator = match expr.first()? {
+            Object::Name(n) => n.0.clone(),
+            other => src.resolve(other).await.ok()?.as_name()?.0.clone(),
+        };
+        if !matches!(operator.as_str(), "And" | "Or" | "Not") {
+            return None;
+        }
+        let operands = expr.split_off(1);
+        if operands.is_empty() || (operator == "Not" && operands.len() != 1) {
+            return None;
+        }
+        Some(VeFrame {
+            operator,
+            operands,
+            next: 0,
+            all: true,
+            any: false,
+        })
+    }
+
+    /// Accumulates one operand's value.
+    fn fold(&mut self, value: bool) {
+        self.all &= value;
+        self.any |= value;
+    }
+}
+
+/// Whether a dictionary reached through an `/OC`-shaped value is a
+/// membership dictionary rather than a group: `/Type /OCMD` says so, and a
+/// dictionary with no `/Type` carrying `/OCGs` or `/VE` is read as one too —
+/// a group never carries those keys, and files omit `/Type`.
+fn is_ocmd(dict: &Dict) -> bool {
+    match dict.get_name("Type") {
+        Some(n) => n.0 == "OCMD",
+        None => dict.get("OCGs").is_some() || dict.get("VE").is_some(),
+    }
+}
+
+/// The group references in a (possibly indirect) array. Null entries and
+/// non-reference values are ignored (§8.11.2.2); a value that is not an
+/// array yields nothing.
+async fn group_refs<S: AsyncObjectSource>(src: &S, value: Option<&Object>) -> Vec<ObjRef> {
+    let Some(value) = value else {
+        return Vec::new();
+    };
+    let Ok(Object::Array(items)) = src.resolve(value).await else {
+        return Vec::new();
+    };
+    items.iter().filter_map(Object::as_ref).collect()
+}
+
+/// The raw `/Properties` resource value for `name`, innermost dictionary
+/// first — deliberately unresolved, so a reference keeps the identity the
+/// off set is keyed by.
+async fn properties_value<S: AsyncObjectSource>(
+    src: &S,
+    chain: &[Arc<Dict>],
+    name: &str,
+) -> Option<Object> {
+    for res in chain {
+        let Some(cat) = res.get("Properties") else {
+            continue;
+        };
+        let Ok(Object::Dict(dict)) = src.resolve(cat).await else {
+            continue;
+        };
+        let Some(value) = dict.get(name) else {
+            continue;
+        };
+        return Some(value.clone());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{block_on, Document, Immediate, Name};
+    use pdfboss_testkit::PdfBuilder;
+
+    fn gref(num: u32) -> ObjRef {
+        ObjRef { num, gen: 0 }
+    }
+
+    /// A document whose catalog carries `oc_props` as `/OCProperties`
+    /// (skipped entirely when empty) and whose objects 10 and 11 are two
+    /// groups; `extra` adds more objects (membership dictionaries etc.).
+    fn doc_with_oc(oc_props: &str, extra: impl FnOnce(&mut PdfBuilder)) -> Document {
+        let mut b = PdfBuilder::new();
+        let oc = if oc_props.is_empty() {
+            String::new()
+        } else {
+            format!(" /OCProperties {oc_props}")
+        };
+        b.object(1, &format!("<< /Type /Catalog /Pages 2 0 R{oc} >>"));
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] >>");
+        b.object(10, "<< /Type /OCG /Name (one) >>");
+        b.object(11, "<< /Type /OCG /Name (two) >>");
+        extra(&mut b);
+        Document::load(b.build(1)).expect("load")
+    }
+
+    fn visible(doc: &Document, state: &OcState, value: &Object) -> bool {
+        block_on(state.visible_with(&Immediate(doc), value))
+    }
+
+    #[test]
+    fn no_ocproperties_means_no_state() {
+        let doc = doc_with_oc("", |_| {});
+        assert_eq!(doc.oc_state(), None);
+    }
+
+    #[test]
+    fn base_state_defaults_on_and_off_hides() {
+        let doc = doc_with_oc("<< /OCGs [10 0 R 11 0 R] /D << /OFF [11 0 R] >> >>", |_| {});
+        let state = doc.oc_state().expect("state");
+        assert!(!state.hidden(gref(10)));
+        assert!(state.hidden(gref(11)));
+    }
+
+    #[test]
+    fn base_state_off_hides_all_but_on() {
+        let doc = doc_with_oc(
+            "<< /OCGs [10 0 R 11 0 R] /D << /BaseState /OFF /ON [10 0 R] >> >>",
+            |_| {},
+        );
+        let state = doc.oc_state().expect("state");
+        assert!(!state.hidden(gref(10)));
+        assert!(state.hidden(gref(11)));
+    }
+
+    /// §8.11.4.3 applies `/BaseState`, then `/ON`, then `/OFF`: a group
+    /// named in both lists ends up off.
+    #[test]
+    fn off_is_applied_after_on() {
+        let doc = doc_with_oc(
+            "<< /OCGs [10 0 R] /D << /ON [10 0 R] /OFF [10 0 R] >> >>",
+            |_| {},
+        );
+        let state = doc.oc_state().expect("state");
+        assert!(state.hidden(gref(10)));
+    }
+
+    /// Indirection at every level: the configuration, its arrays, and the
+    /// base state name all resolve through references.
+    #[test]
+    fn configuration_resolves_indirection() {
+        let doc = doc_with_oc("<< /OCGs 20 0 R /D 21 0 R >>", |b| {
+            b.object(20, "[10 0 R 11 0 R]");
+            b.object(21, "<< /BaseState 22 0 R /ON 23 0 R >>");
+            b.object(22, "/OFF");
+            b.object(23, "[10 0 R]");
+        });
+        let state = doc.oc_state().expect("state");
+        assert!(!state.hidden(gref(10)));
+        assert!(state.hidden(gref(11)));
+    }
+
+    /// Group 10 is on, group 11 off, for every membership test below.
+    fn split_state() -> (Document, OcState) {
+        let doc = doc_with_oc("<< /OCGs [10 0 R 11 0 R] /D << /OFF [11 0 R] >> >>", |b| {
+            b.object(30, "<< /Type /OCMD /OCGs [10 0 R 11 0 R] >>");
+            b.object(31, "<< /Type /OCMD /OCGs [10 0 R 11 0 R] /P /AllOn >>");
+            b.object(32, "<< /Type /OCMD /OCGs [10 0 R 11 0 R] /P /AnyOff >>");
+            b.object(33, "<< /Type /OCMD /OCGs [10 0 R 11 0 R] /P /AllOff >>");
+            b.object(34, "<< /Type /OCMD /OCGs [11 0 R] >>");
+            b.object(35, "<< /Type /OCMD /OCGs [] /P /AllOff >>");
+            b.object(36, "<< /Type /OCMD /OCGs [null null] /P /AllOff >>");
+            b.object(37, "<< /Type /OCMD /OCGs 11 0 R /P /AnyOn >>");
+            b.object(38, "<< /Type /OCMD /OCGs [11 0 R] /P /Bogus >>");
+        });
+        let state = doc.oc_state().expect("state");
+        (doc, state)
+    }
+
+    #[test]
+    fn group_reference_visibility_follows_the_off_set() {
+        let (doc, state) = split_state();
+        assert!(visible(&doc, &state, &Object::Ref(gref(10))));
+        assert!(!visible(&doc, &state, &Object::Ref(gref(11))));
+    }
+
+    #[test]
+    fn membership_policies_follow_the_specification() {
+        let (doc, state) = split_state();
+        let ocmd = |num| Object::Ref(gref(num));
+        assert!(visible(&doc, &state, &ocmd(30)), "AnyOn default: 10 is on");
+        assert!(!visible(&doc, &state, &ocmd(31)), "AllOn: 11 is off");
+        assert!(visible(&doc, &state, &ocmd(32)), "AnyOff: 11 is off");
+        assert!(!visible(&doc, &state, &ocmd(33)), "AllOff: 10 is on");
+        assert!(
+            !visible(&doc, &state, &ocmd(34)),
+            "AnyOn over one off group"
+        );
+        assert!(visible(&doc, &state, &ocmd(35)), "empty /OCGs is visible");
+        assert!(visible(&doc, &state, &ocmd(36)), "nulls are ignored");
+        assert!(
+            !visible(&doc, &state, &ocmd(37)),
+            "single group by reference"
+        );
+        assert!(
+            !visible(&doc, &state, &ocmd(38)),
+            "unknown policy reads AnyOn"
+        );
+    }
+
+    #[test]
+    fn malformed_values_stay_visible() {
+        let (doc, state) = split_state();
+        assert!(visible(&doc, &state, &Object::Null));
+        assert!(visible(&doc, &state, &Object::Int(3)));
+        assert!(visible(&doc, &state, &Object::Ref(gref(999))), "dangling");
+        let direct_group = Object::Dict({
+            let mut d = Dict::new();
+            d.insert(Name("Type".into()), Object::Name(Name("OCG".into())));
+            d
+        });
+        assert!(
+            visible(&doc, &state, &direct_group),
+            "a direct group dictionary has no identity to be off"
+        );
+    }
+
+    fn ve_doc(ve: &str) -> (Document, OcState) {
+        let doc = doc_with_oc("<< /OCGs [10 0 R 11 0 R] /D << /OFF [11 0 R] >> >>", |b| {
+            b.object(40, &format!("<< /Type /OCMD /OCGs [10 0 R] /VE {ve} >>"));
+        });
+        let state = doc.oc_state().expect("state");
+        (doc, state)
+    }
+
+    fn ve_visible(ve: &str) -> bool {
+        let (doc, state) = ve_doc(ve);
+        visible(&doc, &state, &Object::Ref(gref(40)))
+    }
+
+    #[test]
+    fn visibility_expressions_evaluate() {
+        assert!(ve_visible("[/Not 11 0 R]"), "Not of an off group");
+        assert!(!ve_visible("[/Not 10 0 R]"), "Not of an on group");
+        assert!(!ve_visible("[/And 10 0 R 11 0 R]"));
+        assert!(ve_visible("[/Or 10 0 R 11 0 R]"));
+        assert!(!ve_visible("[/Or 11 0 R 11 0 R]"));
+        assert!(
+            ve_visible("[/Or 11 0 R [/Not 11 0 R]]"),
+            "nested expression"
+        );
+        assert!(
+            !ve_visible("[/And 10 0 R [/Not [/Not 11 0 R]]]"),
+            "double negation"
+        );
+    }
+
+    /// `/VE` takes precedence over `/OCGs` and `/P`: object 40 carries
+    /// `/OCGs [10 0 R]` (on, so AnyOn would show it), yet an expression
+    /// naming only the off group hides it.
+    #[test]
+    fn expression_takes_precedence_over_policy() {
+        assert!(!ve_visible("[/And 11 0 R]"));
+    }
+
+    #[test]
+    fn malformed_expressions_are_visible() {
+        assert!(ve_visible("[]"), "no operator");
+        assert!(ve_visible("[/And]"), "no operands");
+        assert!(ve_visible("[/Not 11 0 R 11 0 R]"), "Not takes one operand");
+        assert!(ve_visible("[/Xor 11 0 R]"), "unknown operator");
+        assert!(ve_visible("[/And 11 0 R (text)]"), "non-group operand");
+    }
+
+    #[test]
+    fn expression_depth_is_capped() {
+        let mut ve = "11 0 R".to_string();
+        for _ in 0..(MAX_VE_DEPTH + 2) {
+            ve = format!("[/Not {ve}]");
+        }
+        assert!(ve_visible(&ve), "past the cap reads as visible");
+    }
+
+    /// The properties operand of `BDC /OC` may be a resource name; the
+    /// lookup keeps the reference, so the named group's off state applies.
+    #[test]
+    fn named_properties_keep_group_identity() {
+        let (doc, state) = split_state();
+        let mut properties = Dict::new();
+        properties.insert(Name("On".into()), Object::Ref(gref(10)));
+        properties.insert(Name("Off".into()), Object::Ref(gref(11)));
+        let mut res = Dict::new();
+        res.insert(Name("Properties".into()), Object::Dict(properties));
+        let chain = vec![Arc::new(res)];
+        let src = Immediate(&doc);
+        let named = |name: &str| Object::Name(Name(name.into()));
+        assert!(block_on(state.props_visible_with(
+            &src,
+            &chain,
+            &named("On")
+        )));
+        assert!(!block_on(state.props_visible_with(
+            &src,
+            &chain,
+            &named("Off")
+        )));
+        assert!(
+            block_on(state.props_visible_with(&src, &chain, &named("Nope"))),
+            "an unresolvable name stays visible"
+        );
+    }
+}

--- a/crates/pdfboss-output/src/lib.rs
+++ b/crates/pdfboss-output/src/lib.rs
@@ -6,7 +6,7 @@ mod markdown;
 mod output;
 mod structure;
 
-use pdfboss_core::{block_on, AsyncObjectSource, Document, Immediate, Page, Result};
+use pdfboss_core::{AsyncObjectSource, Document, Page, Result};
 
 pub use ir::{BBox, Block, Cell, Inline, Line, ListItem, Marker, PageLayout, Role};
 pub use markdown::Markdown;
@@ -26,16 +26,20 @@ pub use structure::{
 /// parse yields no text rather than an error, so one unreadable stream
 /// never costs a caller the rest of the document. Use
 /// [`extract_text_reporting`] to see what (if anything) was left out.
+///
+/// Optional-content layers the document's default configuration turns off
+/// are excluded, exactly as `pdfboss_text`'s document-level entries exclude
+/// them; the source-generic `_with` twins have no document to read that
+/// configuration from and extract every layer.
 pub fn extract_text(doc: &Document, page: &Page) -> Result<String> {
-    block_on(extract_text_with(Immediate(doc), page))
+    let (text, _) = extract_text_reporting(doc, page)?;
+    Ok(text)
 }
 
 /// [`extract_text`] against any object source, awaiting whatever I/O the
-/// source needs to read the page.
-///
-/// This is the implementation; [`extract_text`] is this function over
-/// [`Immediate`], driven to completion on the calling thread. The two cannot
-/// disagree about what a document says, because there is only one of them.
+/// source needs to read the page — the same span extraction and layout,
+/// minus the document's optional-content configuration, which a bare
+/// source cannot supply: every layer extracts here.
 ///
 /// The source is taken by value and the page by reference. That combination is
 /// what a consumer needs to spawn the result: the future is `Send` over a source
@@ -53,11 +57,13 @@ pub async fn extract_text_with<S: AsyncObjectSource>(src: S, page: &Page) -> Res
 /// bytes, unparseable content, missing resources, exhausted form limits.
 /// An empty text with an empty report really is an empty page.
 pub fn extract_text_reporting(doc: &Document, page: &Page) -> Result<(String, ExtractReport)> {
-    block_on(extract_text_reporting_with(Immediate(doc), page))
+    let (spans, report) = pdfboss_text::extract_spans_reporting(doc, page)?;
+    Ok((Text.render(&[page_layout(&spans)]), report))
 }
 
 /// [`extract_text_reporting`] against any object source. Signed like
-/// [`extract_text_with`], for the same reasons.
+/// [`extract_text_with`], for the same reasons — every optional-content
+/// layer included.
 pub async fn extract_text_reporting_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
@@ -124,11 +130,13 @@ pub fn extract_markdown_reporting(doc: &Document) -> Result<(String, Vec<Extract
 /// [`extract_markdown`] is the better answer whenever the document is at
 /// hand — a page whose text is all one size has no heading to find.
 pub fn extract_page_markdown(doc: &Document, page: &Page) -> Result<String> {
-    block_on(extract_page_markdown_with(Immediate(doc), page))
+    let (spans, rulings, _) = pdfboss_text::extract_spans_and_rulings_reporting(doc, page)?;
+    Ok(Markdown.render(&[page_layout_with_rulings(&spans, &rulings)]))
 }
 
 /// [`extract_page_markdown`] against any object source. Signed like
-/// [`extract_text_with`], for the same reasons.
+/// [`extract_text_with`], for the same reasons — every optional-content
+/// layer included.
 ///
 /// There is no document-level `_with`: an asynchronous caller collects each
 /// page's spans and rulings with
@@ -147,7 +155,7 @@ pub async fn extract_page_markdown_with<S: AsyncObjectSource>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pdfboss_core::{resolve_with, BoxFuture, ObjRef, Object, Stream};
+    use pdfboss_core::{block_on, resolve_with, BoxFuture, ObjRef, Object, Stream};
     use pdfboss_testkit::{doc_with_graphics, multi_page_doc, simple_doc, PdfBuilder};
     use std::future::Future;
 

--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -250,6 +250,7 @@ fn resolve_render_options(
     Ok(pdfboss_render::RenderOptions {
         glyph_painting,
         substitutes,
+        ..Default::default()
     })
 }
 
@@ -1004,6 +1005,11 @@ impl AsyncDocument {
                 Some(wanted) => wanted,
                 None => (0..inner.page_count()).collect(),
             });
+            // The document's optional-content configuration, read once and
+            // shared by every worker — the async twin of what the sync
+            // entry points do per render.
+            let mut opts = opts;
+            opts.oc = inner.oc_state().await.map(Arc::new);
             let opts = Arc::new(opts);
             let next = Arc::new(std::sync::atomic::AtomicUsize::new(0));
             let workers = std::thread::available_parallelism()

--- a/crates/pdfboss-render/benches/tiers.rs
+++ b/crates/pdfboss-render/benches/tiers.rs
@@ -140,6 +140,7 @@ fn bench_group(
         let opts = RenderOptions {
             glyph_painting: *painting,
             substitutes: substitutes.clone(),
+            ..Default::default()
         };
         group.bench_function(*label, |b| {
             b.iter(|| black_box(render_page_with_options(doc, page, 1.0, &opts).unwrap()));

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -397,11 +397,15 @@ pub(crate) fn render_page_reporting(
     scale: f32,
     opts: &RenderOptions,
 ) -> Result<(Pixmap, RenderReport)> {
+    let mut opts = opts.clone();
+    if opts.oc.is_none() {
+        opts.oc = doc.oc_state().map(Arc::new);
+    }
     block_on(render_page_reporting_with(
         Immediate(doc),
         page,
         scale,
-        opts,
+        &opts,
     ))
 }
 
@@ -468,6 +472,7 @@ pub(crate) async fn render_page_reporting_with<S: AsyncObjectSource>(
         painting: opts.glyph_painting,
         color_locked: false,
         provider,
+        oc: opts.oc.clone(),
         glyph_blit: Vec::new(),
         raster: RasterScratch::default(),
         clip_cache: FastMap::default(),
@@ -516,6 +521,9 @@ struct Executor<'a, S> {
     /// `/Type0` and `/Type3` fonts never consult it (see `glyph.rs`'s module
     /// doc).
     provider: Option<Box<dyn SubstituteProvider>>,
+    /// The document's optional-content visibility from
+    /// [`RenderOptions::oc`]; `None` renders every layer.
+    oc: Option<Arc<pdfboss_core::OcState>>,
     /// Reused scratch for painting a cached glyph outline: the flattened
     /// (origin-relative) subpaths from [`GlyphFont::flattened`] are copied
     /// here translated to the glyph's device origin, so a whole page of text
@@ -606,6 +614,12 @@ struct Frame {
     /// default space, so fills through `cm` changes do not drag the pattern
     /// with them.
     pattern_base: Matrix,
+    /// The marked-content stack: one entry per open `BMC`/`BDC`, `true` for
+    /// a `BDC /OC` span the optional-content configuration hides. Per frame
+    /// and not part of [`GState`] — `BMC`/`EMC` nesting is not `q`/`Q`
+    /// scoped, and it never crosses a content-stream boundary. A stray
+    /// `EMC` pops nothing.
+    marks: Vec<bool>,
 }
 
 /// What kind of content stream a [`Frame`] is running, and therefore what
@@ -664,7 +678,15 @@ impl Frame {
             pending_t3: None,
             kind,
             pattern_base,
+            marks: Vec::new(),
         }
+    }
+
+    /// Whether the frame is inside a marked-content span the
+    /// optional-content configuration hides: state still executes, marks
+    /// are suppressed.
+    fn suppressed(&self) -> bool {
+        self.marks.iter().any(|hidden| *hidden)
     }
 }
 
@@ -1046,6 +1068,14 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             }
             None => Vec::new(),
         };
+        // A hidden optional-content span suppresses the marks but not the
+        // state: nothing fills or strokes (and no pattern loads or tiles),
+        // while a pending `W`/`W*` still narrows the clip below — clipping
+        // is graphics state, carried past `EMC`, not a mark on the page.
+        if frame.suppressed() {
+            self.clip_frame(frame, &polys);
+            return;
+        }
         let fill_pattern = if how.fill.is_some() && frame.gs.fill_pattern && !polys.is_empty() {
             let name = frame.gs.fill_pattern_name.clone();
             self.resolve_pattern(&frame.chain, name.as_deref(), frame.pattern_base)
@@ -1125,14 +1155,20 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                 ),
             }
         }
-        if let Some(rule) = frame.pending_clip.take() {
-            let rasterized = self.rasterize_clip(&polys, rule);
-            let gs = &mut frame.gs;
-            gs.clip = Some(match &gs.clip {
-                Some(old) => Arc::new(Mask::intersected(&rasterized, old)),
-                None => rasterized,
-            });
-        }
+        self.clip_frame(frame, &polys);
+    }
+
+    /// Applies a pending `W`/`W*` clip from the painted path, if any.
+    fn clip_frame(&mut self, frame: &mut Frame, polys: &[Subpath]) {
+        let Some(rule) = frame.pending_clip.take() else {
+            return;
+        };
+        let rasterized = self.rasterize_clip(polys, rule);
+        let gs = &mut frame.gs;
+        gs.clip = Some(match &gs.clip {
+            Some(old) => Arc::new(Mask::intersected(&rasterized, old)),
+            None => rasterized,
+        });
     }
 
     /// Resolves the named pattern to something paintable: a shading with
@@ -1638,13 +1674,17 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
     /// CharProc frames are pushed by the driver, one at a time, before the
     /// frame's next operator.
     fn show_text(&mut self, frame: &mut Frame, bytes: &[u8]) {
-        // Modes 3 and 7 show nothing (ISO 32000-1 §9.3.6); the advances
+        // Modes 3 and 7 show nothing (ISO 32000-1 §9.3.6), and a hidden
+        // optional-content span shows nothing either (§8.11); the advances
         // below still happen, so a visible run that follows stays placed.
-        let visible = !matches!(frame.gs.text_render, 3 | 7);
+        let suppressed = frame.suppressed();
+        let visible = !matches!(frame.gs.text_render, 3 | 7) && !suppressed;
         // Modes 4-7 also ask the glyph outlines to join the clipping path,
         // which this renderer does not do: whatever the author clipped to
         // the text paints unclipped, and that approximation is reported.
-        if matches!(frame.gs.text_render, 4..=7) && !bytes.is_empty() {
+        // Not from a hidden span: its text was configured away, so nothing
+        // the report owes the caller was lost.
+        if matches!(frame.gs.text_render, 4..=7) && !bytes.is_empty() && !suppressed {
             self.skip(SkippedKind::TextClip, SkipReason::Unsupported);
         }
         if let Some(t3) = frame.ts.type3.clone() {
@@ -1929,17 +1969,51 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                 gs.stroke_rgb = ColorSpace::DeviceCMYK.to_rgb(&[*c, *m, *y, *k]);
             }
             Op::XObject(name) => {
+                // Inside a hidden span the whole invocation is part of the
+                // span: nothing is resolved, drawn, scheduled, or reported.
+                if frame.suppressed() {
+                    return None;
+                }
                 return self
                     .do_xobject(name, &frame.chain, &frame.gs, frame.depth)
                     .await;
             }
             Op::InlineImage(img) => {
+                if frame.suppressed() {
+                    return None;
+                }
                 self.draw_inline_image(img, &frame.chain, &frame.gs).await;
             }
-            // Text and marked content: state-only in v0.1, nothing painted.
+            // Marked content: only a `BDC /OC` span changes what paints —
+            // every open is pushed (hidden or not) so `EMC` stays balanced.
+            Op::BeginMarkedContent(_) => frame.marks.push(false),
+            Op::BeginMarkedContentProps(tag, props) => {
+                let hidden = self.marked_hidden(tag, props, &frame.chain).await;
+                if hidden {
+                    self.report.hidden += 1;
+                }
+                frame.marks.push(hidden);
+            }
+            Op::EndMarkedContent => {
+                frame.marks.pop();
+            }
+            // Text state and points: nothing painted.
             _ => {}
         }
         None
+    }
+
+    /// Whether a `BDC` opens a span the optional-content configuration
+    /// hides: only `/OC` tags gate anything, and with no configuration (or
+    /// anything unresolvable) every span is visible.
+    async fn marked_hidden(&self, tag: &Name, props: &Object, chain: &[Arc<Dict>]) -> bool {
+        let Some(oc) = &self.oc else {
+            return false;
+        };
+        if tag.0 != "OC" {
+            return false;
+        }
+        !oc.props_visible_with(self.src, chain, props).await
     }
 }
 
@@ -2161,17 +2235,23 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         else {
             return;
         };
-        match dict.get("SMask") {
-            None => {}
-            Some(obj) => match self.src.resolve(obj).await {
-                Ok(Object::Name(n)) if n.0 == "None" => frame.gs.soft_mask = None,
-                Ok(Object::Dict(sm)) => {
-                    if let Some(group) = self.soft_mask_group(&sm, frame).await {
-                        frame.pending_smask = Some(Box::new(group));
+        // A hidden span leaves the soft-mask machinery alone: the group
+        // frame it would schedule is a paint-bearing child, and the
+        // matching `/None` reset stays skipped so the pair is symmetric.
+        // Every scalar entry below is plain graphics state and applies.
+        if !frame.suppressed() {
+            match dict.get("SMask") {
+                None => {}
+                Some(obj) => match self.src.resolve(obj).await {
+                    Ok(Object::Name(n)) if n.0 == "None" => frame.gs.soft_mask = None,
+                    Ok(Object::Dict(sm)) => {
+                        if let Some(group) = self.soft_mask_group(&sm, frame).await {
+                            frame.pending_smask = Some(Box::new(group));
+                        }
                     }
-                }
-                _ => self.skip(SkippedKind::SoftMask, SkipReason::Missing),
-            },
+                    _ => self.skip(SkippedKind::SoftMask, SkipReason::Missing),
+                },
+            }
         }
         match blend_mode_entry(self.src, &dict).await {
             Some(Ok(mode)) => frame.gs.blend_mode = mode,
@@ -2325,6 +2405,14 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             self.skip(SkippedKind::XObject, SkipReason::Missing);
             return None;
         };
+        // An `/OC` entry gates the whole XObject — image and form alike
+        // (§8.11.3.5). Hidden is configured behavior: counted, not skipped.
+        if let (Some(oc), Some(gate)) = (self.oc.clone(), stream.dict.get("OC")) {
+            if !oc.visible_with(self.src, gate).await {
+                self.report.hidden += 1;
+                return None;
+            }
+        }
         // `/Subtype` may be indirect like any dictionary value (ISO 32000-1
         // 7.3.8.1): a direct name answers on the spot, a reference resolves.
         let resolved;
@@ -2381,6 +2469,14 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             };
             if dict.get_int("F").unwrap_or(0) & INVISIBLE_ANNOTS != 0 {
                 continue;
+            }
+            // An `/OC` entry hides the annotation exactly like the Hidden
+            // flag (§8.11.3.5), silently but counted.
+            if let (Some(oc), Some(gate)) = (self.oc.clone(), dict.get("OC")) {
+                if !oc.visible_with(self.src, gate).await {
+                    self.report.hidden += 1;
+                    continue;
+                }
             }
             if dict.get_name("Subtype").is_some_and(|n| n.0 == "Popup") {
                 continue;
@@ -2567,6 +2663,9 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
     /// Unsupported shading kinds and every structural failure report as a
     /// dropped shading — the page loses a gradient either way.
     async fn sh_operator(&mut self, name: &str, frame: &mut Frame) {
+        if frame.suppressed() {
+            return;
+        }
         let Some(obj) = self.find_res(&frame.chain, "Shading", name).await else {
             self.skip(SkippedKind::Shading, SkipReason::Missing);
             return;
@@ -3074,6 +3173,310 @@ mod tests {
         );
         let pix = render(bytes, 1.0);
         assert_eq!(px(&pix, 25, 50), BLACK, "text after Q must paint");
+    }
+
+    /// A one-page 100x100 document like [`small_doc`], with two optional
+    /// content groups: object 8 stays on and object 9 is off in the default
+    /// configuration, reachable from content as `/Properties` entries `/V`
+    /// (visible) and `/H` (hidden).
+    fn oc_doc(resources: &str, content: &[u8], extra: impl FnOnce(&mut PdfBuilder)) -> Vec<u8> {
+        let mut b = PdfBuilder::new();
+        b.object(
+            1,
+            "<< /Type /Catalog /Pages 2 0 R /OCProperties \
+             << /OCGs [8 0 R 9 0 R] /D << /OFF [9 0 R] >> >> >>",
+        );
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            &format!(
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+                 /Resources << /Properties << /V 8 0 R /H 9 0 R >> {resources} >> \
+                 /Contents 4 0 R >>"
+            ),
+        );
+        b.stream(4, "", content);
+        b.object(8, "<< /Type /OCG /Name (shown) >>");
+        b.object(9, "<< /Type /OCG /Name (hidden) >>");
+        extra(&mut b);
+        b.build(1)
+    }
+
+    /// A `BDC /OC` span whose group the default configuration turns off
+    /// paints nothing; a span whose group stays on paints normally. Hidden
+    /// content is configured behavior: one count on the dedicated counter,
+    /// nothing in the drop list, and the report still reads empty.
+    #[test]
+    fn hidden_span_suppresses_marks_and_counts() {
+        let bytes = oc_doc(
+            "",
+            b"1 0 0 rg /OC /H BDC 10 10 30 30 re f EMC /OC /V BDC 60 60 30 30 re f EMC",
+            |_| {},
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 25, 75), WHITE, "the hidden span must not paint");
+        assert_eq!(px(&pix, 75, 25), RED, "the visible span paints");
+        assert_eq!(report.hidden, 1);
+        assert_eq!(drops(&report), vec![], "hidden is not a drop");
+        assert!(report.is_empty(), "hidden does not dirty the report");
+    }
+
+    /// Suppression nests as a stack: a visible span inside a hidden one
+    /// stays suppressed, and a hidden span inside a visible one suppresses
+    /// only itself. State set inside a hidden span (here the fill color)
+    /// still executes and survives the span.
+    #[test]
+    fn suppression_nests_and_state_survives() {
+        let bytes = oc_doc(
+            "",
+            b"/OC /H BDC 1 0 0 rg /OC /V BDC 10 10 30 30 re f EMC EMC 60 60 30 30 re f",
+            |_| {},
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 25, 75), WHITE, "visible-in-hidden is suppressed");
+        assert_eq!(px(&pix, 75, 25), RED, "after EMC the red state persists");
+        assert_eq!(report.hidden, 1);
+
+        let bytes = oc_doc(
+            "",
+            b"1 0 0 rg /OC /V BDC 10 10 30 30 re f /OC /H BDC 60 60 30 30 re f EMC EMC",
+            |_| {},
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 25, 75), RED, "the visible outer span paints");
+        assert_eq!(px(&pix, 75, 25), WHITE, "hidden-in-visible is suppressed");
+        assert_eq!(report.hidden, 1);
+    }
+
+    /// A stray `EMC` pops nothing, and a hidden span left open at the end
+    /// of the stream suppresses to the end without leaking anywhere else.
+    #[test]
+    fn stray_emc_clamps_and_open_spans_end_with_the_stream() {
+        let bytes = oc_doc(
+            "",
+            b"EMC 1 0 0 rg 10 10 30 30 re f /OC /H BDC 60 60 30 30 re f",
+            |_| {},
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 25, 75), RED, "a stray EMC must not suppress");
+        assert_eq!(px(&pix, 75, 25), WHITE, "the open hidden span suppresses");
+        assert_eq!(report.hidden, 1);
+    }
+
+    /// The properties name may resolve to a membership dictionary; its
+    /// `/OCGs` groups keep their reference identity through the raw
+    /// `/Properties` lookup, so the off group hides the span. With no
+    /// `/OCProperties` at all the same span paints — nothing to be off.
+    #[test]
+    fn membership_properties_and_absent_configuration() {
+        let bytes = oc_doc(
+            "/Properties << /M 30 0 R >>",
+            b"1 0 0 rg /OC /M BDC 10 10 30 30 re f EMC",
+            |b| {
+                b.object(30, "<< /Type /OCMD /OCGs [9 0 R] >>");
+            },
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 25, 75), WHITE, "the membership hides the span");
+        assert_eq!(report.hidden, 1);
+
+        let bytes = small_doc(
+            "/Properties << /H 8 0 R >>",
+            b"1 0 0 rg /OC /H BDC 10 10 30 30 re f EMC",
+            |b| {
+                b.object(8, "<< /Type /OCG /Name (loose) >>");
+            },
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 25, 75), RED, "no configuration, every layer on");
+        assert_eq!(report.hidden, 0);
+    }
+
+    /// Text in a hidden span paints nothing but still advances — a visible
+    /// run after `EMC` lands where the hidden one left off (the same
+    /// contract as `3 Tr`), with no no-glyph noise from the hidden run.
+    #[test]
+    fn hidden_span_text_advances_without_painting() {
+        let bytes = oc_doc(
+            "/Font << /T3 5 0 R >>",
+            b"BT /T3 100 Tf 0 20 Td /OC /H BDC <41> Tj EMC <41> Tj ET",
+            |b| {
+                b.object(
+                    5,
+                    "<< /Type /Font /Subtype /Type3 /FontBBox [0 0 1000 1000] \
+                     /FontMatrix [0.001 0 0 0.001 0 0] \
+                     /Encoding << /Differences [65 /box] >> \
+                     /CharProcs << /box 6 0 R >> /FirstChar 65 /Widths [500] >>",
+                );
+                b.stream(6, "", b"500 0 d0 0 0 500 500 re f");
+            },
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 25, 50), WHITE, "hidden glyph painted");
+        assert_eq!(px(&pix, 75, 50), BLACK, "visible glyph after the advance");
+        assert_eq!(report.hidden, 1);
+        assert!(report.is_empty(), "no reports from the hidden run");
+    }
+
+    /// `W n` inside a hidden span still narrows the clip: clipping is
+    /// graphics state carried past `EMC`, not a mark on the page.
+    #[test]
+    fn clip_from_hidden_span_still_applies() {
+        let bytes = oc_doc(
+            "",
+            b"/OC /H BDC 20 20 40 40 re W n EMC 0 0 100 100 re f",
+            |_| {},
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 40, 60), BLACK, "inside the hidden span's clip");
+        assert_eq!(px(&pix, 10, 10), WHITE, "outside it");
+        assert_eq!(report.hidden, 1);
+    }
+
+    /// No paint-bearing child runs out of a hidden span: a form `Do` is not
+    /// scheduled (and reports nothing, not even a missing resource), and a
+    /// pattern fill neither loads nor reports its pattern.
+    #[test]
+    fn hidden_span_schedules_no_children_and_reports_nothing() {
+        let bytes = oc_doc(
+            "/XObject << /Fx 5 0 R >>",
+            b"/OC /H BDC /Fx Do /Nope Do /Pattern cs /P1 scn 10 10 30 30 re f EMC",
+            |b| {
+                b.stream(
+                    5,
+                    "/Type /XObject /Subtype /Form /BBox [0 0 100 100]",
+                    b"1 0 0 rg 0 0 100 100 re f",
+                );
+            },
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 50, 50), WHITE, "the form must not run");
+        assert_eq!(drops(&report), vec![], "a hidden span reports nothing");
+        assert_eq!(report.hidden, 1);
+    }
+
+    /// A `gs` inside a hidden span leaves the soft-mask machinery alone: no
+    /// offscreen group runs, and the paint after `EMC` composites unmasked.
+    #[test]
+    fn hidden_span_skips_soft_mask_groups() {
+        let bytes = oc_doc(
+            "/ExtGState << /GS1 << /SMask << /S /Luminosity /G 5 0 R >> >> >>",
+            b"/OC /H BDC /GS1 gs EMC 1 0 0 rg 10 10 30 30 re f",
+            |b| {
+                b.stream(
+                    5,
+                    "/Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+                     /Group << /S /Transparency >>",
+                    b"",
+                );
+            },
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 25, 75), RED, "no mask was harvested");
+        assert_eq!(drops(&report), vec![]);
+        assert_eq!(report.hidden, 1);
+    }
+
+    /// An `/OC` entry on the XObject itself gates both arms: a hidden form
+    /// and a hidden image draw nothing and count once each; the same form
+    /// under the on group draws.
+    #[test]
+    fn xobject_oc_entry_gates_forms_and_images() {
+        let form = |oc: &str| {
+            oc_doc("/XObject << /Fx 5 0 R >>", b"/Fx Do", |b| {
+                b.stream(
+                    5,
+                    &format!("/Type /XObject /Subtype /Form /BBox [0 0 100 100] /OC {oc}"),
+                    b"1 0 0 rg 0 0 100 100 re f",
+                );
+            })
+        };
+        let (pix, report) = render_reporting(form("9 0 R"));
+        assert_eq!(px(&pix, 50, 50), WHITE, "the off form must not draw");
+        assert_eq!(report.hidden, 1);
+        assert_eq!(drops(&report), vec![]);
+        let (pix, report) = render_reporting(form("8 0 R"));
+        assert_eq!(px(&pix, 50, 50), RED, "the on form draws");
+        assert_eq!(report.hidden, 0);
+
+        let bytes = oc_doc(
+            "/XObject << /Im 5 0 R >>",
+            b"q 100 0 0 100 0 0 cm /Im Do Q",
+            |b| {
+                b.stream(
+                    5,
+                    "/Type /XObject /Subtype /Image /Width 1 /Height 1 \
+                     /ColorSpace /DeviceGray /BitsPerComponent 8 /OC 9 0 R",
+                    &[0x00],
+                );
+            },
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 50, 50), WHITE, "the off image must not draw");
+        assert_eq!(report.hidden, 1);
+        assert_eq!(drops(&report), vec![]);
+    }
+
+    /// An annotation's `/OC` entry hides it like the Hidden flag — silent
+    /// in the drop list, counted on the dedicated counter — and an on-group
+    /// annotation paints exactly as without the entry.
+    #[test]
+    fn annotation_oc_entry_gates_the_appearance() {
+        let stamp = |oc: &str, extra: &mut PdfBuilder| {
+            extra.object(
+                10,
+                &format!(
+                    "<< /Type /Annot /Subtype /Stamp /Rect [20 20 60 60] \
+                     /OC {oc} /AP << /N 20 0 R >> >>"
+                ),
+            );
+            extra.stream(
+                20,
+                "/Type /XObject /Subtype /Form /BBox [0 0 10 10]",
+                b"1 0 0 rg 0 0 10 10 re f",
+            );
+        };
+        let with = |oc: &'static str| {
+            let mut b = PdfBuilder::new();
+            b.object(
+                1,
+                "<< /Type /Catalog /Pages 2 0 R /OCProperties \
+                 << /OCGs [8 0 R 9 0 R] /D << /OFF [9 0 R] >> >> >>",
+            );
+            b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+            b.object(
+                3,
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+                 /Contents 4 0 R /Annots [10 0 R] >>",
+            );
+            b.stream(4, "", b"");
+            b.object(8, "<< /Type /OCG /Name (shown) >>");
+            b.object(9, "<< /Type /OCG /Name (hidden) >>");
+            stamp(oc, &mut b);
+            render_reporting(b.build(1))
+        };
+        let (pix, report) = with("9 0 R");
+        assert_eq!(px(&pix, 40, 60), WHITE, "the off annotation must not paint");
+        assert_eq!(report.hidden, 1);
+        assert_eq!(drops(&report), vec![]);
+        let (pix, report) = with("8 0 R");
+        assert_eq!(px(&pix, 40, 60), RED, "the on annotation paints");
+        assert_eq!(report.hidden, 0);
+    }
+
+    /// An inline image inside a hidden span is a mark like any other.
+    #[test]
+    fn hidden_span_suppresses_inline_images() {
+        let bytes = oc_doc(
+            "",
+            b"/OC /H BDC q 100 0 0 100 0 0 cm \
+              BI /W 1 /H 1 /CS /G /BPC 8 ID \x00 EI Q EMC",
+            |_| {},
+        );
+        let (pix, report) = render_reporting(bytes);
+        assert_eq!(px(&pix, 50, 50), WHITE, "the inline image must not draw");
+        assert_eq!(report.hidden, 1);
+        assert_eq!(drops(&report), vec![]);
     }
 
     #[test]
@@ -5294,6 +5697,7 @@ mod tests {
         let opts = RenderOptions {
             glyph_painting: GlyphPainting::Full,
             substitutes: SubstituteSource::Dir(dir.clone()),
+            ..Default::default()
         };
         let pix = render_page_with_options(&doc, &page, 1.0, &opts).expect("render");
         assert!(
@@ -5345,6 +5749,7 @@ mod tests {
         let opts = RenderOptions {
             glyph_painting: GlyphPainting::Full,
             substitutes: SubstituteSource::Dir(dir.clone()),
+            ..Default::default()
         };
         let pix = render_page_with_options(&doc, &page, 1.0, &opts).expect("render");
         assert!(

--- a/crates/pdfboss-render/src/glyph.rs
+++ b/crates/pdfboss-render/src/glyph.rs
@@ -2069,6 +2069,7 @@ mod tests {
             RenderOptions {
                 glyph_painting: GlyphPainting::Full,
                 substitutes: SubstituteSource::Dir(dir.clone()),
+                ..Default::default()
             },
         );
         assert!(
@@ -2083,6 +2084,7 @@ mod tests {
             RenderOptions {
                 glyph_painting: GlyphPainting::Full,
                 substitutes: SubstituteSource::None,
+                ..Default::default()
             },
         );
         assert!(
@@ -2097,6 +2099,7 @@ mod tests {
             RenderOptions {
                 glyph_painting: GlyphPainting::AllEmbedded,
                 substitutes: SubstituteSource::Dir(dir.clone()),
+                ..Default::default()
             },
         );
         assert!(
@@ -2132,6 +2135,7 @@ mod tests {
             RenderOptions {
                 glyph_painting: GlyphPainting::Full,
                 substitutes: SubstituteSource::Dir(dir.clone()),
+                ..Default::default()
             },
         );
         assert!(
@@ -2164,6 +2168,7 @@ mod tests {
             RenderOptions {
                 glyph_painting: GlyphPainting::Full,
                 substitutes: SubstituteSource::Dir(dir.clone()),
+                ..Default::default()
             },
         );
         assert!(
@@ -2199,6 +2204,7 @@ mod tests {
             RenderOptions {
                 glyph_painting: GlyphPainting::Full,
                 substitutes: SubstituteSource::Dir(dir.clone()),
+                ..Default::default()
             },
         );
         assert!(
@@ -2253,6 +2259,7 @@ mod tests {
             RenderOptions {
                 glyph_painting: GlyphPainting::Full,
                 substitutes: SubstituteSource::Builtin,
+                ..Default::default()
             },
         );
         assert!(
@@ -2278,6 +2285,7 @@ mod tests {
             RenderOptions {
                 glyph_painting: GlyphPainting::Full,
                 substitutes: SubstituteSource::Builtin,
+                ..Default::default()
             },
         );
         assert!(

--- a/crates/pdfboss-render/src/lib.rs
+++ b/crates/pdfboss-render/src/lib.rs
@@ -46,8 +46,9 @@ mod type1;
 mod type3;
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use pdfboss_core::{AsyncObjectSource, Document, Error, Page, Result};
+use pdfboss_core::{AsyncObjectSource, Document, Error, OcState, Page, Result};
 
 /// An RGBA8 raster image with straight (non-premultiplied) alpha, row-major
 /// from the top-left.
@@ -184,6 +185,14 @@ pub struct RenderOptions {
     /// Where `Full`-tier substitution draws replacement faces from. Ignored
     /// at every other tier.
     pub substitutes: SubstituteSource,
+    /// The document's optional-content visibility (ISO 32000-1 §8.11):
+    /// content in groups the default configuration turns off is not
+    /// painted, counted in [`RenderReport::hidden`]. The synchronous entry
+    /// points fill this from the document when it is `None`; an
+    /// asynchronous caller builds it itself (e.g.
+    /// `AsyncDocument::oc_state`), and leaving it `None` there renders
+    /// every layer.
+    pub oc: Option<Arc<OcState>>,
 }
 
 /// Whether this binary was built with the `substitute-fonts` feature, i.e.
@@ -234,7 +243,9 @@ pub fn render_page_reporting(
 /// Renders a page like [`render_page_reporting`] against any object source,
 /// awaiting whatever I/O the source needs — this is the asynchronous entry
 /// point, and the synchronous ones above are this implementation over
-/// `pdfboss_core::Immediate`, so the two APIs cannot render differently.
+/// `pdfboss_core::Immediate` (with [`RenderOptions::oc`] filled from the
+/// document when the caller left it unset), so under the same options the
+/// two APIs cannot render differently.
 ///
 /// The source is taken by value and the page by reference, which is the
 /// combination a consumer needs to spawn the result: the future is `Send`
@@ -428,6 +439,13 @@ pub struct RenderReport {
     /// Drops that arrived after `skipped` reached its 64-entry cap and so
     /// are counted but not described.
     pub unlisted: u64,
+    /// Content the document's optional-content configuration turns off
+    /// (ISO 32000-1 §8.11): one count per `BDC /OC` span whose own
+    /// membership evaluated hidden, per XObject with a hidden `/OC` entry,
+    /// and per annotation with a hidden `/OC` entry. Configured behavior,
+    /// not a loss, so it plays no part in [`RenderReport::is_empty`],
+    /// [`RenderReport::summary`], or [`RenderReport::warnings`].
+    pub hidden: u64,
 }
 
 impl RenderReport {

--- a/crates/pdfboss-text/src/extract.rs
+++ b/crates/pdfboss-text/src/extract.rs
@@ -5,8 +5,8 @@ use crate::font::Font;
 use crate::{Ruling, TextSpan};
 use pdfboss_core::content::{parse_content, Op, TextItem};
 use pdfboss_core::{
-    content_stream_data_with, page_content_with, AsyncObjectSource, Dict, Matrix, ObjRef, Object,
-    Page, Point,
+    content_stream_data_with, page_content_with, AsyncObjectSource, Dict, Matrix, Name, ObjRef,
+    Object, OcState, Page, Point,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -39,11 +39,20 @@ const RULING_MAX_FILL_THICKNESS: f32 = 3.0;
 pub struct ExtractReport {
     /// Every piece of content that yielded no text, in encounter order.
     pub skipped: Vec<SkippedText>,
+    /// Content the document's optional-content configuration turns off
+    /// (ISO 32000-1 §8.11): one count per `BDC /OC` span whose own
+    /// membership evaluated hidden and per form XObject with a hidden
+    /// `/OC` entry — a counter rather than entries, so a layer-heavy page
+    /// cannot balloon `skipped`. Configured behavior, not a loss:
+    /// [`ExtractReport::is_complete`] ignores it.
+    pub hidden: u64,
 }
 
 impl ExtractReport {
     /// True when every operator stream was fetched, parsed, and executed —
-    /// nothing the extraction saw was left out of the result.
+    /// nothing the extraction saw was left out of the result. Content the
+    /// document's optional-content configuration hides (`hidden`) was read
+    /// and deliberately excluded, so it does not count against this.
     pub fn is_complete(&self) -> bool {
         self.skipped.is_empty()
     }
@@ -171,6 +180,7 @@ pub async fn page_spans_and_rulings_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
     fonts: Option<&FontCache>,
+    oc: Option<&OcState>,
 ) -> (Vec<TextSpan>, Vec<Ruling>, ExtractReport) {
     let mut report = ExtractReport::default();
     let content = match page_content_with(&src, page).await {
@@ -196,6 +206,7 @@ pub async fn page_spans_and_rulings_with<S: AsyncObjectSource>(
         report,
         loaded: HashMap::new(),
         shared: fonts,
+        oc,
     };
     let root = Frame::new(
         ops.into(),
@@ -386,6 +397,11 @@ struct Frame {
     /// Loaded fonts, per operator stream: every form invocation starts with an
     /// empty cache, as it did when each invocation was its own `run` call.
     fonts: HashMap<String, Arc<Font>>,
+    /// The marked-content stack: one entry per open `BMC`/`BDC`, `true` for
+    /// a `BDC /OC` span the optional-content configuration hides. Per frame
+    /// like `tm`/`tlm` — `BMC`/`EMC` nesting is not `q`/`Q` scoped and never
+    /// crosses a stream boundary. A stray `EMC` pops nothing.
+    marks: Vec<bool>,
 }
 
 impl Frame {
@@ -401,7 +417,15 @@ impl Frame {
             tlm: Matrix::identity(),
             subpaths: Vec::new(),
             fonts: HashMap::new(),
+            marks: Vec::new(),
         }
+    }
+
+    /// Whether the frame is inside a marked-content span the
+    /// optional-content configuration hides: state still executes, but the
+    /// span's text and rulings are excluded from the result.
+    fn suppressed(&self) -> bool {
+        self.marks.iter().any(|hidden| *hidden)
     }
 
     fn move_to(&mut self, x: f32, y: f32) {
@@ -478,6 +502,9 @@ struct Executor<'a, S> {
     /// Fonts carried across page walks, when the caller extracts a whole
     /// document and passes one [`FontCache`] to every page.
     shared: Option<&'a FontCache>,
+    /// The document's optional-content visibility; `None` extracts every
+    /// layer.
+    oc: Option<&'a OcState>,
 }
 
 impl<S: AsyncObjectSource> Executor<'_, S> {
@@ -626,6 +653,11 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                         }
                     }
                     Op::XObject(name) => {
+                        // Inside a hidden span the whole invocation is part
+                        // of the span: never entered, never reported.
+                        if frame.suppressed() {
+                            continue;
+                        }
                         let entered = self
                             .form_frame(&name.0, &frame.chain, &frame.gs, frame.depth)
                             .await;
@@ -638,6 +670,13 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                             frames.push(child);
                             continue 'frames;
                         }
+                    }
+                    Op::BeginMarkedContentProps(tag, props) => {
+                        let hidden = self.marked_hidden(tag, props, &frame.chain).await;
+                        if hidden {
+                            self.report.hidden += 1;
+                        }
+                        frame.marks.push(hidden);
                     }
                     op => self.step(&mut frame, op),
                 }
@@ -748,10 +787,32 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             // `W`/`W*` never commit by themselves: the paint operator that
             // must follow them does, and after a clip that operator is `n`.
             Op::EndPath => frame.subpaths.clear(),
-            // Text render mode 3 (invisible) is still extracted, so `Tr` and
-            // everything else is a no-op here.
+            // Marked content: every open is pushed (hidden or not) so `EMC`
+            // stays balanced; `BDC` needs I/O and is handled in `run`.
+            Op::BeginMarkedContent(_) => frame.marks.push(false),
+            Op::EndMarkedContent => {
+                frame.marks.pop();
+            }
+            // Text render mode 3 (invisible) is still extracted — the
+            // document shows that text, a viewer just paints it blank.
+            // Optional content is the opposite species: the document
+            // declares the layer off, so a hidden span IS skipped (see
+            // `emit`). `Tr` and everything else is a no-op here.
             _ => {}
         }
+    }
+
+    /// Whether a `BDC` opens a span the optional-content configuration
+    /// hides: only `/OC` tags gate anything, and with no configuration (or
+    /// anything unresolvable) every span is visible.
+    async fn marked_hidden(&self, tag: &Name, props: &Object, chain: &[Arc<Dict>]) -> bool {
+        let Some(oc) = self.oc else {
+            return false;
+        };
+        if tag.0 != "OC" {
+            return false;
+        }
+        !oc.props_visible_with(self.src, chain, props).await
     }
 
     /// Commits the accumulated path on a painting operator and clears it.
@@ -759,6 +820,12 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
     /// device-space line width; filled subpaths yield the centerline of a
     /// thin axis-aligned rectangle. Poisoned subpaths yield nothing.
     fn commit_rulings(&mut self, frame: &mut Frame, stroke: bool, fill: bool) {
+        // A hidden span's lines are configured away with its text; the
+        // path still clears, exactly as a paint operator leaves it.
+        if frame.suppressed() {
+            frame.subpaths.clear();
+            return;
+        }
         let ctm = frame.gs.ctm;
         let width = frame.gs.line_width * ctm_scale(&ctm);
         for sub in frame.subpaths.drain(..) {
@@ -785,10 +852,15 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         }
     }
 
-    /// Shows one string, appending the span it produces (if any) to the page.
+    /// Shows one string, appending the span it produces (if any) to the
+    /// page. Inside a hidden optional-content span the advance still runs —
+    /// `show` moves the text matrix either way — but the text is excluded.
     fn emit(&mut self, frame: &mut Frame, bytes: &[u8]) {
+        let suppressed = frame.suppressed();
         if let Some(span) = self.show(&frame.gs, &mut frame.tm, bytes) {
-            self.spans.push(span);
+            if !suppressed {
+                self.spans.push(span);
+            }
         }
     }
 
@@ -887,6 +959,14 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         if !is_form {
             return None; // images and other XObjects carry no text
         }
+        // A form with a hidden `/OC` entry is configured away with its
+        // whole subtree: counted on the dedicated counter, never a skip.
+        if let (Some(oc), Some(gate)) = (self.oc, stream.dict.get("OC")) {
+            if !oc.visible_with(self.src, gate).await {
+                self.report.hidden += 1;
+                return None;
+            }
+        }
         // Through the content chokepoint, not raw stream_data: a form whose
         // trailing /Filter is an image codec holds passthrough bytes, not
         // operators (see `content_stream_data_with`). The refusal is a
@@ -964,17 +1044,151 @@ mod tests {
     /// asserts on exactly what a synchronous caller receives. The report is
     /// asserted complete: no test here expects to lose content.
     fn page_spans(doc: &Document, page: &Page) -> Vec<TextSpan> {
-        let (spans, _, report) = block_on(page_spans_and_rulings_with(Immediate(doc), page, None));
+        let (spans, _, report) = extract_all(doc, page);
         assert!(report.is_complete(), "unexpected skips: {report:?}");
         spans
     }
 
     /// The synchronous rulings accessor, the twin of [`page_spans`].
     fn page_rulings(doc: &Document, page: &Page) -> Vec<Ruling> {
-        let (_, rulings, report) =
-            block_on(page_spans_and_rulings_with(Immediate(doc), page, None));
+        let (_, rulings, report) = extract_all(doc, page);
         assert!(report.is_complete(), "unexpected skips: {report:?}");
         rulings
+    }
+
+    /// One walk with the document's own optional-content configuration —
+    /// exactly what the `lib.rs` document-level entries drive.
+    fn extract_all(doc: &Document, page: &Page) -> (Vec<TextSpan>, Vec<Ruling>, ExtractReport) {
+        let oc = doc.oc_state();
+        block_on(page_spans_and_rulings_with(
+            Immediate(doc),
+            page,
+            None,
+            oc.as_ref(),
+        ))
+    }
+
+    /// One page over two optional content groups: object 8 stays on,
+    /// object 9 is off in the default configuration, reachable from
+    /// content as `/Properties` entries `/V` and `/H`; `/Fx` is a form
+    /// gated off by its own `/OC` entry.
+    fn oc_doc(content: &[u8]) -> Document {
+        use pdfboss_testkit::PdfBuilder;
+        let mut b = PdfBuilder::new();
+        b.object(
+            1,
+            "<< /Type /Catalog /Pages 2 0 R /OCProperties \
+             << /OCGs [8 0 R 9 0 R] /D << /OFF [9 0 R] >> >> >>",
+        );
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> \
+             /Properties << /V 8 0 R /H 9 0 R >> \
+             /XObject << /Fx 6 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", content);
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        b.stream(
+            6,
+            "/Type /XObject /Subtype /Form /BBox [0 0 612 792] /OC 9 0 R",
+            b"BT /F1 12 Tf 72 600 Td (formtext) Tj ET",
+        );
+        b.object(8, "<< /Type /OCG /Name (shown) >>");
+        b.object(9, "<< /Type /OCG /Name (hidden) >>");
+        Document::load(b.build(1)).expect("load")
+    }
+
+    /// A hidden layer's text is excluded and counted once per span, while
+    /// its advances still run: the visible text that follows starts where
+    /// the hidden run ended, and the walk is still complete.
+    #[test]
+    fn hidden_layer_text_is_excluded_but_still_advances() {
+        let doc = oc_doc(
+            b"BT /F1 12 Tf 72 720 Td /OC /H BDC (wide hidden run) Tj EMC (kept) Tj \
+              /OC /V BDC ( on) Tj EMC ET",
+        );
+        let page = doc.page(0).unwrap();
+        let (spans, _, report) = extract_all(&doc, &page);
+        let texts: Vec<&str> = spans.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(texts, ["kept", " on"]);
+        assert!(
+            spans[0].x > 100.0,
+            "the hidden run must still advance: x = {}",
+            spans[0].x
+        );
+        assert_eq!(report.hidden, 1);
+        assert!(report.is_complete(), "hidden is not a skip: {report:?}");
+    }
+
+    /// A form whose own `/OC` entry is off contributes nothing — no spans,
+    /// no skip entry, one count — and rulings drawn in a hidden span are
+    /// excluded with the text.
+    #[test]
+    fn hidden_forms_and_rulings_are_excluded() {
+        let doc = oc_doc(b"/Fx Do /OC /H BDC 72 700 m 272 700 l S EMC 72 650 m 272 650 l S");
+        let page = doc.page(0).unwrap();
+        let (spans, rulings, report) = extract_all(&doc, &page);
+        assert_eq!(spans, vec![], "the gated form must not run");
+        assert_eq!(rulings.len(), 1, "only the visible line survives");
+        assert!((rulings[0].start.y - 650.0).abs() < 1e-3);
+        assert_eq!(report.hidden, 2, "one form, one span");
+        assert!(report.is_complete());
+    }
+
+    /// `3 Tr` text is a viewer-invisible layer the document still shows —
+    /// searchable-scan OCR — and stays extracted; an off optional-content
+    /// layer is declared off by the document itself and is excluded. The
+    /// two must not be conflated.
+    #[test]
+    fn invisible_render_mode_survives_where_hidden_layers_do_not() {
+        let doc = oc_doc(
+            b"BT /F1 12 Tf 3 Tr 72 720 Td (ocr) Tj ET \
+              /OC /H BDC BT /F1 12 Tf 72 700 Td (gone) Tj ET EMC",
+        );
+        let page = doc.page(0).unwrap();
+        let (spans, _, report) = extract_all(&doc, &page);
+        let texts: Vec<&str> = spans.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(texts, ["ocr"]);
+        assert_eq!(report.hidden, 1);
+    }
+
+    /// Without `/OCProperties` there is no configuration to be off in:
+    /// every `/OC` span extracts and nothing is counted.
+    #[test]
+    fn absent_configuration_extracts_every_layer() {
+        use pdfboss_testkit::PdfBuilder;
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> \
+             /Properties << /H 8 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(
+            4,
+            "",
+            b"BT /F1 12 Tf 72 720 Td /OC /H BDC (loose) Tj EMC ET",
+        );
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        b.object(8, "<< /Type /OCG /Name (loose) >>");
+        let doc = Document::load(b.build(1)).expect("load");
+        let page = doc.page(0).unwrap();
+        let (spans, _, report) = extract_all(&doc, &page);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "loose");
+        assert_eq!(report.hidden, 0);
     }
 
     /// Raw spans of a one-page document with `content` as its raw content
@@ -1101,8 +1315,12 @@ mod tests {
         let page = doc.page(0).unwrap();
         // Raw call: exhausting the budget is this test's point, so the
         // report is legitimately incomplete here.
-        let (spans, _, report) =
-            block_on(page_spans_and_rulings_with(Immediate(&doc), &page, None));
+        let (spans, _, report) = block_on(page_spans_and_rulings_with(
+            Immediate(&doc),
+            &page,
+            None,
+            None,
+        ));
         assert!(!spans.is_empty()); // nested forms still extract text
         assert!(
             spans.len() <= MAX_FORM_INVOCATIONS,

--- a/crates/pdfboss-text/src/lib.rs
+++ b/crates/pdfboss-text/src/lib.rs
@@ -58,16 +58,30 @@ pub struct Ruling {
 /// parse yields no spans rather than an error, so one unreadable stream
 /// never costs a caller the rest of the document. Use
 /// [`extract_spans_reporting`] to see what (if anything) was left out.
+///
+/// Content in optional-content layers the document's default configuration
+/// turns off (ISO 32000-1 §8.11) is excluded, counted in
+/// [`ExtractReport::hidden`]. The document-level entry points here read
+/// that configuration themselves; the source-generic `_with` twins have no
+/// document to read it from and extract every layer.
 pub fn extract_spans(doc: &Document, page: &Page) -> Result<Vec<TextSpan>> {
-    block_on(extract_spans_with(Immediate(doc), page))
+    let oc = doc.oc_state();
+    let (spans, _, _) = block_on(extract::page_spans_and_rulings_with(
+        Immediate(doc),
+        page,
+        None,
+        oc.as_ref(),
+    ));
+    Ok(spans)
 }
 
 /// [`extract_spans`] against any object source, awaiting whatever I/O the
 /// source needs to read the page.
 ///
-/// This is the implementation; [`extract_spans`] is this function over
-/// [`Immediate`], driven to completion on the calling thread. The two cannot
-/// disagree about what a document says, because there is only one of them.
+/// This is the shared implementation [`extract_spans`] drives over
+/// [`Immediate`] on the calling thread; the one thing the document-level
+/// entry adds is the document's optional-content configuration, which a
+/// bare source cannot supply — this function extracts every layer.
 ///
 /// The source is taken by value and the page by reference. That combination is
 /// what a consumer needs to spawn the result: the future is `Send` over a source
@@ -78,7 +92,7 @@ pub async fn extract_spans_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
 ) -> Result<Vec<TextSpan>> {
-    let (spans, _, _) = extract::page_spans_and_rulings_with(src, page, None).await;
+    let (spans, _, _) = extract::page_spans_and_rulings_with(src, page, None, None).await;
     Ok(spans)
 }
 
@@ -91,16 +105,24 @@ pub fn extract_spans_reporting(
     doc: &Document,
     page: &Page,
 ) -> Result<(Vec<TextSpan>, ExtractReport)> {
-    block_on(extract_spans_reporting_with(Immediate(doc), page))
+    let oc = doc.oc_state();
+    let (spans, _, report) = block_on(extract::page_spans_and_rulings_with(
+        Immediate(doc),
+        page,
+        None,
+        oc.as_ref(),
+    ));
+    Ok((spans, report))
 }
 
 /// [`extract_spans_reporting`] against any object source. Signed like
-/// [`extract_spans_with`], for the same reasons.
+/// [`extract_spans_with`], for the same reasons — including extracting
+/// every optional-content layer, which a bare source cannot gate.
 pub async fn extract_spans_reporting_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
 ) -> Result<(Vec<TextSpan>, ExtractReport)> {
-    let (spans, _, report) = extract::page_spans_and_rulings_with(src, page, None).await;
+    let (spans, _, report) = extract::page_spans_and_rulings_with(src, page, None, None).await;
     Ok((spans, report))
 }
 
@@ -119,21 +141,26 @@ pub fn extract_spans_reporting_cached(
     page: &Page,
     fonts: &FontCache,
 ) -> Result<(Vec<TextSpan>, ExtractReport)> {
-    block_on(extract_spans_reporting_cached_with(
+    let oc = doc.oc_state();
+    let (spans, _, report) = block_on(extract::page_spans_and_rulings_with(
         Immediate(doc),
         page,
-        fonts,
-    ))
+        Some(fonts),
+        oc.as_ref(),
+    ));
+    Ok((spans, report))
 }
 
 /// [`extract_spans_reporting_cached`] against any object source. Signed like
-/// [`extract_spans_with`], for the same reasons.
+/// [`extract_spans_with`], for the same reasons — including extracting
+/// every optional-content layer, which a bare source cannot gate.
 pub async fn extract_spans_reporting_cached_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
     fonts: &FontCache,
 ) -> Result<(Vec<TextSpan>, ExtractReport)> {
-    let (spans, _, report) = extract::page_spans_and_rulings_with(src, page, Some(fonts)).await;
+    let (spans, _, report) =
+        extract::page_spans_and_rulings_with(src, page, Some(fonts), None).await;
     Ok((spans, report))
 }
 
@@ -145,19 +172,25 @@ pub fn extract_spans_and_rulings_reporting(
     doc: &Document,
     page: &Page,
 ) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
-    block_on(extract_spans_and_rulings_reporting_with(
+    let oc = doc.oc_state();
+    let (spans, rulings, report) = block_on(extract::page_spans_and_rulings_with(
         Immediate(doc),
         page,
-    ))
+        None,
+        oc.as_ref(),
+    ));
+    Ok((spans, rulings, report))
 }
 
 /// [`extract_spans_and_rulings_reporting`] against any object source. Signed
-/// like [`extract_spans_with`], for the same reasons.
+/// like [`extract_spans_with`], for the same reasons — including extracting
+/// every optional-content layer, which a bare source cannot gate.
 pub async fn extract_spans_and_rulings_reporting_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
 ) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
-    let (spans, rulings, report) = extract::page_spans_and_rulings_with(src, page, None).await;
+    let (spans, rulings, report) =
+        extract::page_spans_and_rulings_with(src, page, None, None).await;
     Ok((spans, rulings, report))
 }
 
@@ -172,22 +205,26 @@ pub fn extract_spans_and_rulings_reporting_cached(
     page: &Page,
     fonts: &FontCache,
 ) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
-    block_on(extract_spans_and_rulings_reporting_cached_with(
+    let oc = doc.oc_state();
+    let (spans, rulings, report) = block_on(extract::page_spans_and_rulings_with(
         Immediate(doc),
         page,
-        fonts,
-    ))
+        Some(fonts),
+        oc.as_ref(),
+    ));
+    Ok((spans, rulings, report))
 }
 
 /// [`extract_spans_and_rulings_reporting_cached`] against any object source.
-/// Signed like [`extract_spans_with`], for the same reasons.
+/// Signed like [`extract_spans_with`], for the same reasons — including
+/// extracting every optional-content layer, which a bare source cannot gate.
 pub async fn extract_spans_and_rulings_reporting_cached_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
     fonts: &FontCache,
 ) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
     let (spans, rulings, report) =
-        extract::page_spans_and_rulings_with(src, page, Some(fonts)).await;
+        extract::page_spans_and_rulings_with(src, page, Some(fonts), None).await;
     Ok((spans, rulings, report))
 }
 


### PR DESCRIPTION
Hidden layers previously painted and extracted with no way to know. Four commits:
- core: OcState visibility model from /OCProperties (/BaseState -> /ON -> /OFF in spec order), OCMD /P policies AnyOn/AllOn/AnyOff/AllOff, /VE And/Or/Not on an explicit work stack (depth cap 8), malformed-anything = visible. Group identity is the indirect reference — the BDC /Properties name is looked up raw, NOT through the resolving resource helper, or every named layer would read as permanently visible.
- render: per-frame marks stack for BDC/EMC spans (not q/Q-scoped); while suppressed only marks stop — state ops run, text still advances, W n still narrows the clip; no paint-bearing children scheduled from hidden spans (forms, tiles, smask groups; Type3 plans advance-only); XObject /OC gates Image and Form; annotation /OC gates like the Hidden flag. Silent-by-spec: RenderReport gains a hidden: u64 counter, no SkippedKind.
- text: same gating in extraction; Tr-3 invisible text stays extracted (deliberate, unchanged) — OC-off layers are skipped; ExtractReport.hidden counter. Async _with text entries stay OC-blind (documented); render async parity via RenderOptions::oc (aio + py async render_pages build it).
- consumers: cli, py, aio threading + docs.

Verification: 1703 workspace tests (29 new: policies, /VE nesting/depth/malformed, exact hidden/visible/nested-span pixels, stray EMC, advance-past-hidden-text, clip persistence, unscheduled children, gates, sync/async pixel parity on a layered doc with an assert_ne control). Corpus: 16 files carry /OCProperties, all default-ON — 505/505 baseline page shas byte-identical and hidden=0 everywhere, verified independently by the controller on a provenance-checked wheel; a synthetic layered PDF shows the feature live (hidden square+text gone, hidden=2). 118 pytest green.