### PR TITLE
feat(render): PostScript calculator functions, multi-input evaluation, DeviceN tints

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ What still does not paint: `/Symbol` and `/ZapfDingbats` have no license-clean s
 
 Optional content groups (PDF layers, ISO 32000 §8.11) are honored per the document's default configuration: rendering and text extraction skip layers it turns off, counting them on the reports' `hidden` counters.
 
-Not yet supported (they error or degrade gracefully, and are on the roadmap): mesh shadings (types 4–7 and the function-based type 1) and PostScript-calculator functions · the JBIG2 features listed above · the unpainted faces listed above · the non-separable blend modes (Hue, Saturation, Color, Luminosity) and `/SMask` transfer functions.
+Not yet supported (they error or degrade gracefully, and are on the roadmap): mesh shadings (types 4–7 and the function-based type 1) · the JBIG2 features listed above · the unpainted faces listed above · the non-separable blend modes (Hue, Saturation, Color, Luminosity) and `/SMask` transfer functions.
 
 Rendering is lenient: content pdfboss cannot read is skipped so the rest of the page still rasterizes. It says so rather than passing the result off as a faithful render. `pdfboss render` prints a warning line per dropped item on stderr and annotates its summary. The TUI preview raises a status-bar notice. The libraries expose the detail through `render_page_reporting` (Rust) and `Page.render_reporting()` (Python), which return the pixels plus a report of everything dropped or approximated.
 

--- a/crates/pdfboss-render/src/color.rs
+++ b/crates/pdfboss-render/src/color.rs
@@ -1,5 +1,6 @@
-//! Color spaces: DeviceGray/RGB/CMYK, Indexed, and approximations for the
-//! CIE-based and tint-transform families, converted to RGB.
+//! Color spaces: DeviceGray/RGB/CMYK, Indexed, Separation/DeviceN through
+//! their tint transforms, and approximations for the CIE-based families,
+//! converted to RGB.
 
 use std::sync::Arc;
 
@@ -27,22 +28,25 @@ pub(crate) enum ColorSpace {
         base: Box<ColorSpace>,
         lookup: Vec<u8>,
     },
-    /// A one-component `Separation`: its tint transform and the alternate
-    /// space the transform's output is read in (§8.6.6.4).
+    /// A `Separation` or `DeviceN` space (§8.6.6.4/§8.6.6.5): `inputs` tint
+    /// components run through the transform, whose outputs are read in the
+    /// alternate space. Separation is the one-input case.
     ///
     /// The transform is evaluated per colour, not per parse: a fill or stroke
-    /// costs one evaluation, and an image's samples reach it through the
-    /// reader's own per-value table (one entry per distinct sample, 256 at
-    /// eight bits) rather than once per pixel. `Arc` so cloning a space
-    /// shares one arena instead of copying a sampled function's data.
+    /// costs one evaluation, and a one-component image's samples reach it
+    /// through the reader's per-value table (one entry per distinct sample,
+    /// 256 at eight bits) rather than once per pixel; multi-colorant DeviceN
+    /// images pay one evaluation per pixel. `Arc` so cloning a space shares
+    /// one arena instead of copying a sampled function's data.
     Separation {
         tint: Arc<Functions>,
         alternate: Box<ColorSpace>,
+        inputs: usize,
     },
     /// Any other family, kept only for its component count. `to_rgb`
     /// approximates it as an ink tint: gray = 1 - max component (used for
-    /// `DeviceN`, whose multi-input transforms this does not evaluate, for a
-    /// `Separation` whose transform is a type 4, and for Lab).
+    /// Lab, for a `Separation`/`DeviceN` whose transform will not load, and
+    /// for `DeviceN` beyond 8 colorants).
     Other(usize),
 }
 
@@ -65,7 +69,7 @@ impl ColorSpace {
             ColorSpace::DeviceRGB => 3,
             ColorSpace::DeviceCMYK => 4,
             ColorSpace::Indexed { .. } => 1,
-            ColorSpace::Separation { .. } => 1,
+            ColorSpace::Separation { inputs, .. } => *inputs,
             ColorSpace::Other(n) => *n,
         }
     }
@@ -106,9 +110,17 @@ impl ColorSpace {
                 }
                 base.to_rgb(&base_comps[..n])
             }
-            ColorSpace::Separation { tint, alternate } => {
+            ColorSpace::Separation {
+                tint,
+                alternate,
+                inputs,
+            } => {
+                let mut tints = [0f32; MAX_COMPS];
+                for (i, slot) in tints.iter_mut().enumerate().take(*inputs) {
+                    *slot = comp(comps, i);
+                }
                 let mut components = [0f32; MAX_COMPS];
-                let written = tint.eval(&[comp(comps, 0)], &mut components);
+                let written = tint.eval(&tints[..*inputs], &mut components);
                 alternate.to_rgb(&components[..written])
             }
             ColorSpace::Other(n) => {
@@ -124,9 +136,11 @@ impl ColorSpace {
     /// Parses a color-space object from a resource dictionary. Lenient:
     /// anything unrecognized falls back to `DeviceGray`. `ICCBased` maps by
     /// `/N` (or its `/Alternate`), the CIE `Cal*` families map to their
-    /// device equivalents, `Lab` keeps its 3 components as [`Other`],
-    /// and `Separation`/`DeviceN` become [`Other`] with the documented
-    /// tint approximation (their tint transforms are not evaluated).
+    /// device equivalents, `Lab` keeps its 3 components as [`Other`], and
+    /// `Separation`/`DeviceN` evaluate their tint transforms into the
+    /// alternate space — falling back to [`Other`] with the documented ink
+    /// approximation when the transform will not load or a `DeviceN` names
+    /// more than 8 colorants.
     ///
     /// [`Other`]: ColorSpace::Other
     pub(crate) fn parse(doc: &Document, obj: &Object) -> ColorSpace {
@@ -146,11 +160,11 @@ impl ColorSpace {
     /// palettes, innermost last.
     pub(crate) async fn parse_with<S: AsyncObjectSource>(src: &S, obj: &Object) -> ColorSpace {
         let mut palettes: Vec<Vec<u8>> = Vec::new();
-        // Tint transforms met on the way down, innermost last — the same
-        // deferral `palettes` uses, for the same reason: the transform's
-        // output is read in the alternate space, which this loop has not
-        // resolved yet.
-        let mut tints: Vec<Functions> = Vec::new();
+        // Tint transforms met on the way down with their input arity,
+        // innermost last — the same deferral `palettes` uses, for the same
+        // reason: the transform's output is read in the alternate space,
+        // which this loop has not resolved yet.
+        let mut tints: Vec<(Functions, usize)> = Vec::new();
         let mut current: Object = obj.clone();
         // If the loop runs out of levels while still descending, this is the
         // answer — the same one the recursion's depth guard gave.
@@ -221,7 +235,7 @@ impl ColorSpace {
                             };
                             match (transform, items.get(2)) {
                                 (Some(funcs), Some(alternate)) => {
-                                    tints.push(funcs);
+                                    tints.push((funcs, 1));
                                     current = alternate.clone();
                                     continue;
                                 }
@@ -235,6 +249,9 @@ impl ColorSpace {
                             }
                         }
                         "DeviceN" => {
+                            // [/DeviceN names alternate transform]: Separation
+                            // with one tint per colorant (§8.6.6.5), deferred
+                            // the same way.
                             let n = match items.get(1) {
                                 Some(o) => match src.resolve(o).await {
                                     Ok(Object::Array(names)) => names.len().max(1),
@@ -242,8 +259,24 @@ impl ColorSpace {
                                 },
                                 None => 1,
                             };
-                            result = ColorSpace::Other(n);
-                            break;
+                            let transform = match items.get(3) {
+                                Some(o) if n <= MAX_COMPS => load_functions(src, o).await.ok(),
+                                _ => None,
+                            };
+                            match (transform, items.get(2)) {
+                                (Some(funcs), Some(alternate)) => {
+                                    tints.push((funcs, n));
+                                    current = alternate.clone();
+                                    continue;
+                                }
+                                // More colorants than the pipeline carries,
+                                // or a transform that will not load: the ink
+                                // approximation.
+                                _ => {
+                                    result = ColorSpace::Other(n);
+                                    break;
+                                }
+                            }
                         }
                         other => {
                             result = Self::from_name(other);
@@ -254,10 +287,11 @@ impl ColorSpace {
                 _ => break, // stays DeviceGray
             }
         }
-        for funcs in tints.into_iter().rev() {
+        for (funcs, inputs) in tints.into_iter().rev() {
             result = ColorSpace::Separation {
                 tint: Arc::new(funcs),
                 alternate: Box::new(result),
+                inputs,
             };
         }
         for lookup in palettes.into_iter().rev() {
@@ -513,6 +547,66 @@ mod tests {
         let [r, g, bl] = cs.to_rgb(&[0.5]);
         assert!((r - 0.5).abs() < 1e-5, "{r}");
         assert_eq!((g, bl), (0.0, 0.0));
+    }
+
+    /// DeviceN is Separation with n colorants (§8.6.6.5): every input
+    /// reaches the transform, whose outputs are read in the alternate space.
+    #[test]
+    fn devicen_evaluates_its_multi_input_tint_transform() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] >>");
+        b.stream(
+            5,
+            "/FunctionType 4 /Domain [0 1 0 1] /Range [0 1 0 1 0 1]",
+            b"{ 0 }",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let cs = ColorSpace::parse(&doc, &obj(b"[/DeviceN [/A /B] /DeviceRGB 5 0 R]"));
+        assert_eq!(cs.components(), 2);
+        let [r, g, bl] = cs.to_rgb(&[0.2, 0.6]);
+        assert!((r - 0.2).abs() < 1e-5, "{r}");
+        assert!((g - 0.6).abs() < 1e-5, "{g}");
+        assert_eq!(bl, 0.0);
+    }
+
+    /// The same seam over a two-input sampled grid: the tint pair lands in
+    /// the gray computed by the bilinear blend of the 2x2 table.
+    #[test]
+    fn devicen_evaluates_a_sampled_grid_tint() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] >>");
+        b.stream(
+            5,
+            "/FunctionType 0 /Domain [0 1 0 1] /Range [0 1] /Size [2 2] /BitsPerSample 8",
+            &[0, 100, 200, 255],
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let cs = ColorSpace::parse(&doc, &obj(b"[/DeviceN [/A /B] /DeviceGray 5 0 R]"));
+        let [r, g, bl] = cs.to_rgb(&[0.5, 0.5]);
+        assert!((r - 138.75 / 255.0).abs() < 1e-4, "{r}");
+        assert_eq!(r, g);
+        assert_eq!(g, bl);
+    }
+
+    /// More colorants than the pipeline carries stay on the documented
+    /// ink approximation.
+    #[test]
+    fn devicen_beyond_eight_colorants_keeps_the_ink_approximation() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] >>");
+        b.stream(5, "/FunctionType 2 /Domain [0 1] /C0 [0] /C1 [1] /N 1", b"");
+        let doc = Document::load(b.build(1)).unwrap();
+        let cs = ColorSpace::parse(
+            &doc,
+            &obj(b"[/DeviceN [/A /B /C /D /E /F /G /H /I] /DeviceGray 5 0 R]"),
+        );
+        assert_eq!(cs, ColorSpace::Other(9));
     }
 
     #[test]

--- a/crates/pdfboss-render/src/color.rs
+++ b/crates/pdfboss-render/src/color.rs
@@ -108,7 +108,7 @@ impl ColorSpace {
             }
             ColorSpace::Separation { tint, alternate } => {
                 let mut components = [0f32; MAX_COMPS];
-                let written = tint.eval(comp(comps, 0), &mut components);
+                let written = tint.eval(&[comp(comps, 0)], &mut components);
                 alternate.to_rgb(&components[..written])
             }
             ColorSpace::Other(n) => {

--- a/crates/pdfboss-render/src/color.rs
+++ b/crates/pdfboss-render/src/color.rs
@@ -216,7 +216,7 @@ impl ColorSpace {
                             // transform and carry on into the alternate space,
                             // whose components the transform's output *is*.
                             let transform = match items.get(3) {
-                                Some(o) => load_functions(src, o).await.ok().flatten(),
+                                Some(o) => load_functions(src, o).await.ok(),
                                 None => None,
                             };
                             match (transform, items.get(2)) {
@@ -225,9 +225,9 @@ impl ColorSpace {
                                     current = alternate.clone();
                                     continue;
                                 }
-                                // A type 4 transform, a malformed one, or no
-                                // alternate at all: the ink approximation is
-                                // still better than painting nothing.
+                                // A malformed transform or no alternate at
+                                // all: the ink approximation is still better
+                                // than painting nothing.
                                 _ => {
                                     result = ColorSpace::Other(1);
                                     break;
@@ -492,6 +492,27 @@ mod tests {
         let doc = Document::load(b.build(1)).unwrap();
         let cs = ColorSpace::parse(&doc, &obj(b"7 0 R"));
         assert_eq!(cs, ColorSpace::DeviceGray);
+    }
+
+    /// A `/Separation` whose tint transform is a type 4 calculator: the
+    /// program maps tint `t` to `(1-t, 0, 0)` in the DeviceRGB alternate.
+    #[test]
+    fn separation_with_a_calculator_tint_evaluates() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] >>");
+        b.stream(
+            5,
+            "/FunctionType 4 /Domain [0 1] /Range [0 1 0 1 0 1]",
+            b"{ 1 exch sub 0 0 }",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let cs = ColorSpace::parse(&doc, &obj(b"[/Separation /Spot /DeviceRGB 5 0 R]"));
+        assert!(matches!(cs, ColorSpace::Separation { .. }), "{cs:?}");
+        let [r, g, bl] = cs.to_rgb(&[0.5]);
+        assert!((r - 0.5).abs() < 1e-5, "{r}");
+        assert_eq!((g, bl), (0.0, 0.0));
     }
 
     #[test]

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -3769,8 +3769,8 @@ mod tests {
 
     #[test]
     fn separation_without_an_evaluable_transform_keeps_the_ink_approximation() {
-        // Type 4 (PostScript calculator) transforms are not evaluated here;
-        // full tint has to stay dark rather than falling back to white.
+        // A transform that fails to load (unbalanced braces); full tint has
+        // to stay dark rather than falling back to white.
         let bytes = small_doc(
             "/ColorSpace << /T 6 0 R >>",
             b"/T cs 1 scn 0 0 100 100 re f",
@@ -3778,12 +3778,32 @@ mod tests {
                 b.stream(
                     5,
                     "<< /FunctionType 4 /Domain [0 1] /Range [0 1] >>",
-                    b"{ }",
+                    b"{ 1 exch sub",
                 );
                 b.object(6, "[/Separation /Spot /DeviceGray 5 0 R]");
             },
         );
         assert_eq!(px(&render(bytes, 1.0), 50, 50), BLACK);
+    }
+
+    #[test]
+    fn separation_with_a_calculator_transform_evaluates_it() {
+        // Tint t paints gray 1-t through the calculator, so full tint is
+        // black and the transform, not the ink approximation, decides.
+        let bytes = small_doc(
+            "/ColorSpace << /T 6 0 R >>",
+            b"/T cs 0.25 scn 0 0 100 100 re f",
+            |b| {
+                b.stream(
+                    5,
+                    "<< /FunctionType 4 /Domain [0 1] /Range [0 1] >>",
+                    b"{ 1 exch sub }",
+                );
+                b.object(6, "[/Separation /Spot /DeviceGray 5 0 R]");
+            },
+        );
+        let gray = px(&render(bytes, 1.0), 50, 50);
+        assert_eq!(gray, [191, 191, 191, 255]);
     }
 
     #[test]

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -3807,6 +3807,24 @@ mod tests {
     }
 
     #[test]
+    fn devicen_paints_through_its_tint_transform() {
+        // Two tints map straight to red and green; blue stays 0.
+        let bytes = small_doc(
+            "/ColorSpace << /T 6 0 R >>",
+            b"/T cs 0.2 0.6 scn 0 0 100 100 re f",
+            |b| {
+                b.stream(
+                    5,
+                    "<< /FunctionType 4 /Domain [0 1 0 1] /Range [0 1 0 1 0 1] >>",
+                    b"{ 0 }",
+                );
+                b.object(6, "[/DeviceN [/A /B] /DeviceRGB 5 0 R]");
+            },
+        );
+        assert_eq!(px(&render(bytes, 1.0), 50, 50), [51, 153, 0, 255]);
+    }
+
+    #[test]
     fn form_xobject_matrix_paints_displaced() {
         let bytes = small_doc("/XObject << /Fm1 5 0 R >>", b"/Fm1 Do", |b| {
             b.stream(

--- a/crates/pdfboss-render/src/shading.rs
+++ b/crates/pdfboss-render/src/shading.rs
@@ -21,6 +21,11 @@ pub(crate) const MAX_COMPS: usize = 8;
 /// stops a hostile file minting nodes without limit.
 const MAX_FUNCTIONS: usize = 256;
 
+/// Upper bound on a sampled function's grid (the product of its `/Size`
+/// entries). A real tint or gradient table holds at most a few thousand
+/// samples; the cap stops a hostile `/Size` from driving giant index math.
+const MAX_SAMPLES: u64 = 1 << 24;
+
 /// One parsed function. Stitching children are arena indices, so loading
 /// needs no recursion (a queue fills the arena) and evaluation recurses
 /// over indices with the depth bounded by [`MAX_FUNCTIONS`].
@@ -42,12 +47,15 @@ enum Node {
         encode: Vec<f32>,
     },
     /// Type 0: `outputs` values per sample, `bps` bits each, big-endian,
-    /// linearly interpolated between the two nearest of `size` samples.
+    /// over a grid of `size[i]` samples per input dimension with the first
+    /// dimension varying fastest, interpolated multilinearly between the
+    /// 2^m nearest samples (§7.10.2). `domain` and `encode` hold two
+    /// entries per dimension.
     Sampled {
-        domain: [f32; 2],
-        encode: [f32; 2],
+        domain: Vec<f32>,
+        encode: Vec<f32>,
         decode: Vec<f32>,
-        size: usize,
+        size: Vec<usize>,
         bps: u32,
         outputs: usize,
         data: Vec<u8>,
@@ -63,23 +71,24 @@ pub(crate) struct Functions {
 }
 
 impl Functions {
-    /// Evaluates every root at `x` into `out`, returning how many
-    /// components were written.
-    pub(crate) fn eval(&self, x: f32, out: &mut [f32; MAX_COMPS]) -> usize {
+    /// Evaluates every root at `inputs` into `out`, returning how many
+    /// components were written. Missing inputs read as 0; every root sees
+    /// the same inputs and their outputs concatenate.
+    pub(crate) fn eval(&self, inputs: &[f32], out: &mut [f32; MAX_COMPS]) -> usize {
         let mut written = 0;
         for &root in &self.roots {
             if written >= MAX_COMPS {
                 break;
             }
-            written += self.eval_node(root, x, &mut out[written..]);
+            written += self.eval_node(root, inputs, &mut out[written..]);
         }
         written
     }
 
-    fn eval_node(&self, idx: usize, x: f32, out: &mut [f32]) -> usize {
+    fn eval_node(&self, idx: usize, inputs: &[f32], out: &mut [f32]) -> usize {
         match &self.nodes[idx] {
             Node::Exponential { domain, c0, c1, n } => {
-                let x = x.clamp(domain[0], domain[1]);
+                let x = first_input(inputs).clamp(domain[0], domain[1]);
                 // x^1 is the overwhelmingly common gradient; skip the powf.
                 let xn = if *n == 1.0 { x } else { x.powf(*n) };
                 let count = c0.len().min(out.len());
@@ -94,7 +103,7 @@ impl Functions {
                 bounds,
                 encode,
             } => {
-                let x = x.clamp(domain[0], domain[1]);
+                let x = first_input(inputs).clamp(domain[0], domain[1]);
                 // Subinterval k: bounds partition [domain0, domain1).
                 let k = bounds.iter().take_while(|&&b| x >= b).count();
                 let Some(&child) = children.get(k) else {
@@ -104,7 +113,7 @@ impl Functions {
                 let hi = bounds.get(k).copied().unwrap_or(domain[1]);
                 let (e0, e1) = (encode[2 * k], encode[2 * k + 1]);
                 let t = if hi > lo { (x - lo) / (hi - lo) } else { 0.0 };
-                self.eval_node(child, e0 + t * (e1 - e0), out)
+                self.eval_node(child, &[e0 + t * (e1 - e0)], out)
             }
             Node::Sampled {
                 domain,
@@ -115,29 +124,66 @@ impl Functions {
                 outputs,
                 data,
             } => {
-                let x = x.clamp(domain[0], domain[1]);
-                let span = domain[1] - domain[0];
-                let t = if span > 0.0 {
-                    (x - domain[0]) / span
-                } else {
-                    0.0
-                };
-                let e = (encode[0] + t * (encode[1] - encode[0])).clamp(0.0, (*size - 1) as f32);
-                let i0 = e.floor() as usize;
-                let i1 = (i0 + 1).min(*size - 1);
-                let frac = e - i0 as f32;
+                let m = size.len();
+                // Grid neighborhood per dimension: the sample below the
+                // encoded input, the one above, and the blend between them.
+                let mut lo = [0usize; MAX_COMPS];
+                let mut hi = [0usize; MAX_COMPS];
+                let mut frac = [0f32; MAX_COMPS];
+                for i in 0..m {
+                    let x = inputs
+                        .get(i)
+                        .copied()
+                        .unwrap_or(0.0)
+                        .clamp(domain[2 * i], domain[2 * i + 1]);
+                    let span = domain[2 * i + 1] - domain[2 * i];
+                    let t = if span > 0.0 {
+                        (x - domain[2 * i]) / span
+                    } else {
+                        0.0
+                    };
+                    let e = (encode[2 * i] + t * (encode[2 * i + 1] - encode[2 * i]))
+                        .clamp(0.0, (size[i] - 1) as f32);
+                    lo[i] = e.floor() as usize;
+                    hi[i] = (lo[i] + 1).min(size[i] - 1);
+                    frac[i] = e - lo[i] as f32;
+                }
                 let count = (*outputs).min(out.len()).min(decode.len() / 2);
                 let max = ((1u64 << *bps) - 1) as f32;
                 for (j, slot) in out.iter_mut().enumerate().take(count) {
-                    let s0 = sample_at(data, (i0 * outputs + j) as u64, *bps) as f32 / max;
-                    let s1 = sample_at(data, (i1 * outputs + j) as u64, *bps) as f32 / max;
-                    let s = s0 + (s1 - s0) * frac;
+                    // Multilinear blend over the 2^m corners of the
+                    // neighborhood; bit i of the corner picks lo/hi in
+                    // dimension i, and the first dimension varies fastest
+                    // in the sample stream.
+                    let mut acc = 0.0f32;
+                    for corner in 0..1usize << m {
+                        let mut weight = 1.0f32;
+                        let mut index = 0u64;
+                        let mut stride = 1u64;
+                        for i in 0..m {
+                            let up = corner & (1 << i) != 0;
+                            weight *= if up { frac[i] } else { 1.0 - frac[i] };
+                            index += if up { hi[i] as u64 } else { lo[i] as u64 } * stride;
+                            stride *= size[i] as u64;
+                        }
+                        if weight <= 0.0 {
+                            continue;
+                        }
+                        acc += weight
+                            * sample_at(data, index * *outputs as u64 + j as u64, *bps) as f32;
+                    }
+                    let s = acc / max;
                     *slot = decode[2 * j] + s * (decode[2 * j + 1] - decode[2 * j]);
                 }
                 count
             }
         }
     }
+}
+
+/// The single input the 1-input function types read, 0 when absent.
+fn first_input(inputs: &[f32]) -> f32 {
+    inputs.first().copied().unwrap_or(0.0)
 }
 
 /// Reads big-endian sample `index` of `bps` bits from a packed bit stream,
@@ -392,12 +438,26 @@ pub(crate) async fn load_functions<S: AsyncObjectSource>(
             0 => {
                 let data =
                     data.ok_or_else(|| Error::Other("sampled function carries no stream".into()))?;
-                let size = match float_array(src, dict.get("Size")).await {
-                    // Shading functions take one input; a multi-input
-                    // sampled function has no meaning here.
-                    Some(s) if s.len() == 1 && s[0] >= 1.0 => s[0] as usize,
+                let size: Vec<usize> = match float_array(src, dict.get("Size")).await {
+                    Some(s)
+                        if (1..=MAX_COMPS).contains(&s.len())
+                            && s.iter().all(|&v| (1.0..=MAX_SAMPLES as f32).contains(&v)) =>
+                    {
+                        s.iter().map(|&v| v as usize).collect()
+                    }
                     _ => return Err(Error::Other("sampled function /Size unusable".into())),
                 };
+                let samples = size
+                    .iter()
+                    .try_fold(1u64, |p, &s| p.checked_mul(s as u64))
+                    .filter(|&p| p <= MAX_SAMPLES);
+                if samples.is_none() {
+                    return Err(Error::Other("sampled function grid too large".into()));
+                }
+                let m = size.len();
+                let domain = floats(src, dict.get("Domain"), 2 * m)
+                    .await
+                    .unwrap_or_else(|| (0..m).flat_map(|_| [0.0, 1.0]).collect());
                 let bps = match dict.get_int("BitsPerSample") {
                     Some(b @ (1 | 2 | 4 | 8 | 12 | 16 | 24 | 32)) => b as u32,
                     _ => return Err(Error::Other("sampled function bits unusable".into())),
@@ -407,10 +467,9 @@ pub(crate) async fn load_functions<S: AsyncObjectSource>(
                     .filter(|r| r.len() >= 2 && r.len() % 2 == 0)
                     .ok_or_else(|| Error::Other("sampled function has no /Range".into()))?;
                 let outputs = range.len() / 2;
-                let encode = match floats(src, dict.get("Encode"), 2).await {
-                    Some(e) => [e[0], e[1]],
-                    None => [0.0, (size - 1) as f32],
-                };
+                let encode = floats(src, dict.get("Encode"), 2 * m)
+                    .await
+                    .unwrap_or_else(|| size.iter().flat_map(|&s| [0.0, (s - 1) as f32]).collect());
                 let decode = float_array(src, dict.get("Decode"))
                     .await
                     .filter(|d| d.len() == range.len())
@@ -574,7 +633,7 @@ impl Shading {
                     continue;
                 };
                 let t = self.domain[0] + (self.domain[1] - self.domain[0]) * s;
-                let n = self.functions.eval(t, &mut comps);
+                let n = self.functions.eval(&[t], &mut comps);
                 let rgb = self.cs.to_rgb(&comps[..n]);
                 let q = |v: f32| (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
                 let rgb8 = [q(rgb[0]), q(rgb[1]), q(rgb[2])];
@@ -588,5 +647,124 @@ impl Shading {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pdfboss_core::parser::{NoResolve, Parser};
+    use pdfboss_core::{block_on, Document, Immediate};
+    use pdfboss_testkit::PdfBuilder;
+
+    fn obj(src: &[u8]) -> Object {
+        Parser::new(src).parse_object(&NoResolve).unwrap()
+    }
+
+    fn load(dict: &str, data: &[u8]) -> Result<Option<Functions>, Error> {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] >>");
+        b.stream(5, dict, data);
+        let doc = Document::load(b.build(1)).unwrap();
+        block_on(load_functions(&Immediate(&doc), &obj(b"5 0 R")))
+    }
+
+    fn eval(f: &Functions, inputs: &[f32]) -> Vec<f32> {
+        let mut out = [0f32; MAX_COMPS];
+        let n = f.eval(inputs, &mut out);
+        out[..n].to_vec()
+    }
+
+    fn close(got: &[f32], want: &[f32]) {
+        assert_eq!(got.len(), want.len(), "{got:?} vs {want:?}");
+        for (g, w) in got.iter().zip(want) {
+            assert!((g - w).abs() < 1e-4, "{got:?} vs {want:?}");
+        }
+    }
+
+    /// A 2x2 sample grid interpolated per ISO 32000-2 7.10.2: the first
+    /// dimension varies fastest, so the four bytes are f(0,0), f(1,0),
+    /// f(0,1), f(1,1).
+    #[test]
+    fn a_two_input_sampled_grid_interpolates_multilinearly() {
+        let f = load(
+            "/FunctionType 0 /Domain [0 1 0 1] /Range [0 1] /Size [2 2] /BitsPerSample 8",
+            &[0, 100, 200, 255],
+        )
+        .unwrap()
+        .unwrap();
+        close(&eval(&f, &[0.0, 0.0]), &[0.0]);
+        close(&eval(&f, &[1.0, 0.0]), &[100.0 / 255.0]);
+        close(&eval(&f, &[0.0, 1.0]), &[200.0 / 255.0]);
+        close(&eval(&f, &[1.0, 1.0]), &[1.0]);
+        // Center: the plain average of all four corners.
+        close(&eval(&f, &[0.5, 0.5]), &[138.75 / 255.0]);
+        // Hand-computed bilinear blend at (0.25, 0.75):
+        // 0.1875*0 + 0.0625*100 + 0.5625*200 + 0.1875*255 = 166.5625.
+        close(&eval(&f, &[0.25, 0.75]), &[166.5625 / 255.0]);
+        // Out-of-domain inputs clamp per dimension.
+        close(&eval(&f, &[-2.0, 7.0]), &[200.0 / 255.0]);
+    }
+
+    #[test]
+    fn a_one_input_sampled_function_still_interpolates_linearly() {
+        let f = load(
+            "/FunctionType 0 /Domain [0 1] /Range [0 1] /Size [4] /BitsPerSample 8",
+            &[0, 85, 170, 255],
+        )
+        .unwrap()
+        .unwrap();
+        close(&eval(&f, &[0.0]), &[0.0]);
+        close(&eval(&f, &[0.5]), &[127.5 / 255.0]);
+        close(&eval(&f, &[1.0]), &[1.0]);
+    }
+
+    /// A missing multi-input /Encode defaults to [0 size_i-1] per dimension,
+    /// and /Decode maps samples into each output's range.
+    #[test]
+    fn multi_input_encode_and_decode_defaults_apply_per_dimension() {
+        let f = load(
+            "/FunctionType 0 /Domain [0 1 0 1] /Range [0 1] /Size [3 2] \
+             /BitsPerSample 8 /Decode [1 0]",
+            &[0, 51, 102, 153, 204, 255],
+        )
+        .unwrap()
+        .unwrap();
+        // (1, 0) encodes to grid point (2, 0): sample 102, decoded 1 - s.
+        close(&eval(&f, &[1.0, 0.0]), &[1.0 - 102.0 / 255.0]);
+        // (0.5, 1) encodes to (1, 1): sample index 1 + 2*3 = 204.
+        close(&eval(&f, &[0.5, 1.0]), &[1.0 - 204.0 / 255.0]);
+    }
+
+    #[test]
+    fn exponential_and_stitching_read_only_the_first_input() {
+        let f = load(
+            "/FunctionType 2 /Domain [0 1] /C0 [0] /C1 [1] /N 1",
+            b"unused",
+        );
+        // Type 2 is a dictionary in real files; the stream dict works too.
+        let f = f.unwrap().unwrap();
+        close(&eval(&f, &[0.25, 9.0]), &[0.25]);
+        close(&eval(&f, &[]), &[0.0]);
+    }
+
+    #[test]
+    fn oversized_sample_grids_are_refused() {
+        // Nine input dimensions overflow every consumer (MAX_COMPS is 8).
+        let nine = load(
+            "/FunctionType 0 /Domain [0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1] /Range [0 1] \
+             /Size [2 2 2 2 2 2 2 2 2] /BitsPerSample 8",
+            &[0; 512],
+        );
+        assert!(nine.is_err());
+        // A sample count beyond the cap is hostile, not a gradient.
+        let huge = load(
+            "/FunctionType 0 /Domain [0 1 0 1] /Range [0 1] /Size [100000 100000] \
+             /BitsPerSample 8",
+            &[0; 4],
+        );
+        assert!(huge.is_err());
     }
 }

--- a/crates/pdfboss-render/src/shading.rs
+++ b/crates/pdfboss-render/src/shading.rs
@@ -1,9 +1,9 @@
 //! Shading dictionaries (ISO 32000-1 §8.7.4.5): axial (type 2) and radial
 //! (type 3) shadings evaluated through function types 0 (sampled), 2
-//! (exponential) and 3 (stitching), painted per device pixel under a
-//! coverage mask. Function-based (type 1) and mesh (types 4-7) shadings and
-//! PostScript calculator functions (type 4) load as `None` so the caller
-//! reports them as unsupported instead of guessing.
+//! (exponential), 3 (stitching) and 4 (PostScript calculator), painted per
+//! device pixel under a coverage mask. Function-based (type 1) and mesh
+//! (types 4-7) shadings load as `None` so the caller reports them as
+//! unsupported instead of guessing.
 
 use pdfboss_core::geom::{Matrix, Point};
 use pdfboss_core::{decoded_stream_data_with, AsyncObjectSource, Dict, Error, Object};
@@ -25,6 +25,22 @@ const MAX_FUNCTIONS: usize = 256;
 /// entries). A real tint or gradient table holds at most a few thousand
 /// samples; the cap stops a hostile `/Size` from driving giant index math.
 const MAX_SAMPLES: u64 = 1 << 24;
+
+/// Operand-stack depth limit for calculator programs (§7.10.5.1 limits the
+/// stack to 100 entries).
+const CALC_STACK: usize = 100;
+
+/// Instructions one calculator evaluation may execute before the program is
+/// declared runaway and its outputs clamp to the bottom of `/Range`.
+const CALC_STEPS: usize = 10_000;
+
+/// Compiled calculator length cap: a longer program fails to load. Larger
+/// than [`CALC_STEPS`] because branches skip instructions.
+const MAX_CALC_OPS: usize = 65_536;
+
+/// Brace-nesting cap for calculator programs; compilation recurses over
+/// blocks, so the depth must stay bounded.
+const MAX_CALC_DEPTH: usize = 32;
 
 /// One parsed function. Stitching children are arena indices, so loading
 /// needs no recursion (a queue fills the arena) and evaluation recurses
@@ -60,6 +76,86 @@ enum Node {
         outputs: usize,
         data: Vec<u8>,
     },
+    /// Type 4: a compiled PostScript calculator program (§7.10.5).
+    /// `domain` and `range` hold two entries per input/output; a runtime
+    /// failure (stack underflow, type mismatch, runaway program) clamps
+    /// every output to the bottom of its range instead of dropping the
+    /// element being painted.
+    Calculator {
+        domain: Vec<f32>,
+        range: Vec<f32>,
+        program: Vec<Calc>,
+    },
+}
+
+/// One value on a calculator's operand stack. The boolean/number split is
+/// load-bearing: `and`, `or`, `xor` and `not` are logical on booleans and
+/// bitwise on integers, and `if`/`ifelse` demand a boolean.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Value {
+    Num(f32),
+    Bool(bool),
+}
+
+/// One flat calculator instruction. `if`/`ifelse` compile to explicit
+/// forward jumps, so evaluation is a plain loop — the language has no
+/// backward edges.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Calc {
+    Push(Value),
+    /// Unconditional jump past an else branch.
+    Jump(usize),
+    /// Pops a boolean and jumps when it is false.
+    JumpIfFalse(usize),
+    Abs,
+    Add,
+    Atan,
+    Ceiling,
+    Cos,
+    Cvi,
+    Cvr,
+    Div,
+    Exp,
+    Floor,
+    Idiv,
+    Ln,
+    Log,
+    Mod,
+    Mul,
+    Neg,
+    Round,
+    Sin,
+    Sqrt,
+    Sub,
+    Truncate,
+    And,
+    Bitshift,
+    Eq,
+    Ge,
+    Gt,
+    Le,
+    Lt,
+    Ne,
+    Not,
+    Or,
+    Xor,
+    Copy,
+    Dup,
+    Exch,
+    Index,
+    Pop,
+    Roll,
+}
+
+/// One parsed calculator token before jump resolution: a literal, a
+/// resolved operator, a brace-delimited procedure, or the conditional that
+/// consumes procedures.
+#[derive(Debug, Clone, PartialEq)]
+enum CalcItem {
+    Op(Calc),
+    If,
+    IfElse,
+    Block(Vec<CalcItem>),
 }
 
 /// The functions a shading evaluates: one n-output function, or an array of
@@ -177,6 +273,46 @@ impl Functions {
                 }
                 count
             }
+            Node::Calculator {
+                domain,
+                range,
+                program,
+            } => {
+                let m = domain.len() / 2;
+                let outputs = range.len() / 2;
+                let count = outputs.min(out.len());
+                let mut clamped = [0f32; MAX_COMPS];
+                for (i, slot) in clamped.iter_mut().enumerate().take(m) {
+                    *slot = inputs
+                        .get(i)
+                        .copied()
+                        .unwrap_or(0.0)
+                        .clamp(domain[2 * i], domain[2 * i + 1]);
+                }
+                // The program's results are the top `outputs` stack values,
+                // bottom-most first; a missing, boolean, or non-finite
+                // result fails the whole evaluation.
+                let results = run_calculator(program, &clamped[..m])
+                    .filter(|stack| stack.len() >= outputs)
+                    .and_then(|stack| {
+                        let start = stack.len() - outputs;
+                        let mut values = [0f32; MAX_COMPS];
+                        for (j, slot) in values.iter_mut().enumerate().take(count) {
+                            match stack[start + j] {
+                                Value::Num(v) if v.is_finite() => *slot = v,
+                                _ => return None,
+                            }
+                        }
+                        Some(values)
+                    })
+                    .unwrap_or([0f32; MAX_COMPS]);
+                for (j, slot) in out.iter_mut().enumerate().take(count) {
+                    // max/min instead of clamp: a reversed range must not
+                    // panic, just pin to its own bounds.
+                    *slot = results[j].max(range[2 * j]).min(range[2 * j + 1]);
+                }
+                count
+            }
         }
     }
 }
@@ -199,6 +335,398 @@ fn sample_at(data: &[u8], index: u64, bps: u32) -> u64 {
         value = (value << 1) | u64::from((b >> within) & 1);
     }
     value
+}
+
+/// The item a calculator token names, or `None` for anything that has to
+/// be a number.
+fn calc_item(token: &str) -> Option<CalcItem> {
+    let op = match token {
+        "abs" => Calc::Abs,
+        "add" => Calc::Add,
+        "atan" => Calc::Atan,
+        "ceiling" => Calc::Ceiling,
+        "cos" => Calc::Cos,
+        "cvi" => Calc::Cvi,
+        "cvr" => Calc::Cvr,
+        "div" => Calc::Div,
+        "exp" => Calc::Exp,
+        "floor" => Calc::Floor,
+        "idiv" => Calc::Idiv,
+        "ln" => Calc::Ln,
+        "log" => Calc::Log,
+        "mod" => Calc::Mod,
+        "mul" => Calc::Mul,
+        "neg" => Calc::Neg,
+        "round" => Calc::Round,
+        "sin" => Calc::Sin,
+        "sqrt" => Calc::Sqrt,
+        "sub" => Calc::Sub,
+        "truncate" => Calc::Truncate,
+        "and" => Calc::And,
+        "bitshift" => Calc::Bitshift,
+        "eq" => Calc::Eq,
+        "ge" => Calc::Ge,
+        "gt" => Calc::Gt,
+        "le" => Calc::Le,
+        "lt" => Calc::Lt,
+        "ne" => Calc::Ne,
+        "not" => Calc::Not,
+        "or" => Calc::Or,
+        "xor" => Calc::Xor,
+        "copy" => Calc::Copy,
+        "dup" => Calc::Dup,
+        "exch" => Calc::Exch,
+        "index" => Calc::Index,
+        "pop" => Calc::Pop,
+        "roll" => Calc::Roll,
+        "true" => Calc::Push(Value::Bool(true)),
+        "false" => Calc::Push(Value::Bool(false)),
+        "if" => return Some(CalcItem::If),
+        "ifelse" => return Some(CalcItem::IfElse),
+        _ => return None,
+    };
+    Some(CalcItem::Op(op))
+}
+
+/// Parses the decoded bytes of a type 4 program: one brace-delimited block,
+/// optionally surrounded by whitespace or `%` comments. Anything else —
+/// unbalanced braces, an unknown operator, trailing tokens — is a load
+/// error, so the caller's report machinery fires.
+fn parse_calculator(data: &[u8]) -> Result<Vec<CalcItem>, Error> {
+    let malformed = |what: &str| Error::Other(format!("calculator program {what}"));
+    let mut blocks: Vec<Vec<CalcItem>> = Vec::new();
+    let mut done: Option<Vec<CalcItem>> = None;
+    let mut i = 0;
+    while i < data.len() {
+        match data[i] {
+            b'\0' | b'\t' | b'\n' | b'\x0c' | b'\r' | b' ' => i += 1,
+            b'%' => {
+                while i < data.len() && !matches!(data[i], b'\n' | b'\r') {
+                    i += 1;
+                }
+            }
+            b'{' => {
+                if done.is_some() {
+                    return Err(malformed("continues after its closing brace"));
+                }
+                if blocks.len() >= MAX_CALC_DEPTH {
+                    return Err(malformed("nests too deeply"));
+                }
+                blocks.push(Vec::new());
+                i += 1;
+            }
+            b'}' => {
+                let block = blocks
+                    .pop()
+                    .ok_or_else(|| malformed("has unbalanced braces"))?;
+                match blocks.last_mut() {
+                    Some(parent) => parent.push(CalcItem::Block(block)),
+                    None => done = Some(block),
+                }
+                i += 1;
+            }
+            _ => {
+                if done.is_some() {
+                    return Err(malformed("continues after its closing brace"));
+                }
+                let start = i;
+                while i < data.len()
+                    && !data[i].is_ascii_whitespace()
+                    && !matches!(data[i], b'\0' | b'{' | b'}' | b'%')
+                {
+                    i += 1;
+                }
+                let token = std::str::from_utf8(&data[start..i])
+                    .map_err(|_| malformed("holds a non-ASCII token"))?;
+                let dest = blocks
+                    .last_mut()
+                    .ok_or_else(|| malformed("has tokens outside the braces"))?;
+                match calc_item(token) {
+                    Some(item) => dest.push(item),
+                    None => {
+                        if !matches!(token.as_bytes()[0], b'0'..=b'9' | b'+' | b'-' | b'.') {
+                            return Err(Error::Other(format!(
+                                "calculator operator {token} unknown"
+                            )));
+                        }
+                        let number: f32 = token.parse().map_err(|_| {
+                            Error::Other(format!("calculator number {token} unusable"))
+                        })?;
+                        dest.push(CalcItem::Op(Calc::Push(Value::Num(number))));
+                    }
+                }
+            }
+        }
+    }
+    done.ok_or_else(|| malformed("has unbalanced braces"))
+}
+
+/// Flattens parsed items into instructions. A procedure block is legal only
+/// as the operand of `if`/`ifelse` (§7.10.5.4), where it becomes a forward
+/// jump over the branch body.
+fn compile_calculator(items: &[CalcItem], out: &mut Vec<Calc>) -> Result<(), Error> {
+    let mut i = 0;
+    while i < items.len() {
+        if out.len() > MAX_CALC_OPS {
+            return Err(Error::Other("calculator program too long".into()));
+        }
+        match &items[i] {
+            CalcItem::Op(op) => out.push(*op),
+            CalcItem::If | CalcItem::IfElse => {
+                return Err(Error::Other(
+                    "calculator conditional lacks its procedure".into(),
+                ))
+            }
+            CalcItem::Block(body) => match (items.get(i + 1), items.get(i + 2)) {
+                (Some(CalcItem::If), _) => {
+                    let skip = out.len();
+                    out.push(Calc::JumpIfFalse(0));
+                    compile_calculator(body, out)?;
+                    out[skip] = Calc::JumpIfFalse(out.len());
+                    i += 2;
+                    continue;
+                }
+                (Some(CalcItem::Block(other)), Some(CalcItem::IfElse)) => {
+                    let skip = out.len();
+                    out.push(Calc::JumpIfFalse(0));
+                    compile_calculator(body, out)?;
+                    let done = out.len();
+                    out.push(Calc::Jump(0));
+                    out[skip] = Calc::JumpIfFalse(out.len());
+                    compile_calculator(other, out)?;
+                    out[done] = Calc::Jump(out.len());
+                    i += 3;
+                    continue;
+                }
+                _ => {
+                    return Err(Error::Other(
+                        "calculator procedure without if or ifelse".into(),
+                    ))
+                }
+            },
+        }
+        i += 1;
+    }
+    if out.len() > MAX_CALC_OPS {
+        return Err(Error::Other("calculator program too long".into()));
+    }
+    Ok(())
+}
+
+/// The integer a calculator number stands for; integer-only operators
+/// truncate toward zero and refuse non-finite operands.
+fn calc_int(v: f32) -> Option<i32> {
+    if !v.is_finite() {
+        return None;
+    }
+    Some(v.trunc() as i32)
+}
+
+/// Pushes with the §7.10.5.1 depth cap.
+fn calc_push(stack: &mut Vec<Value>, v: Value) -> Option<()> {
+    if stack.len() >= CALC_STACK {
+        return None;
+    }
+    stack.push(v);
+    Some(())
+}
+
+/// Pops a number; a boolean operand is a type error.
+fn calc_num(stack: &mut Vec<Value>) -> Option<f32> {
+    match stack.pop()? {
+        Value::Num(v) => Some(v),
+        Value::Bool(_) => None,
+    }
+}
+
+/// Replaces the top two numbers with `f` of them; `None` from `f` is a
+/// domain error (division by zero, log of a non-positive number).
+fn calc_binary(stack: &mut Vec<Value>, f: impl Fn(f32, f32) -> Option<f32>) -> Option<()> {
+    let b = calc_num(stack)?;
+    let a = calc_num(stack)?;
+    stack.push(Value::Num(f(a, b)?));
+    Some(())
+}
+
+/// Replaces the top number with `f` of it.
+fn calc_unary(stack: &mut Vec<Value>, f: impl Fn(f32) -> Option<f32>) -> Option<()> {
+    let a = calc_num(stack)?;
+    stack.push(Value::Num(f(a)?));
+    Some(())
+}
+
+/// Replaces the top two numbers with their comparison.
+fn calc_compare(stack: &mut Vec<Value>, f: impl Fn(f32, f32) -> bool) -> Option<()> {
+    let b = calc_num(stack)?;
+    let a = calc_num(stack)?;
+    stack.push(Value::Bool(f(a, b)));
+    Some(())
+}
+
+/// `and`/`or`/`xor`: bitwise over two integers, logical over two booleans,
+/// a type error over a mix.
+fn calc_logic(
+    stack: &mut Vec<Value>,
+    ints: impl Fn(i32, i32) -> i32,
+    bools: impl Fn(bool, bool) -> bool,
+) -> Option<()> {
+    let b = stack.pop()?;
+    let a = stack.pop()?;
+    let v = match (a, b) {
+        (Value::Num(a), Value::Num(b)) => Value::Num(ints(calc_int(a)?, calc_int(b)?) as f32),
+        (Value::Bool(a), Value::Bool(b)) => Value::Bool(bools(a, b)),
+        _ => return None,
+    };
+    stack.push(v);
+    Some(())
+}
+
+/// Whether two calculator values are equal; values of different types
+/// compare unequal rather than erroring.
+fn calc_equal(stack: &mut Vec<Value>) -> Option<bool> {
+    let b = stack.pop()?;
+    let a = stack.pop()?;
+    let equal = match (a, b) {
+        (Value::Num(a), Value::Num(b)) => a == b,
+        (Value::Bool(a), Value::Bool(b)) => a == b,
+        _ => false,
+    };
+    Some(equal)
+}
+
+/// Runs a compiled calculator over `inputs`. `None` is any runtime failure
+/// — stack underflow or overflow, a type mismatch, a domain error, or a
+/// runaway program — which the caller paints as range-clamped zeros.
+fn run_calculator(program: &[Calc], inputs: &[f32]) -> Option<Vec<Value>> {
+    if inputs.len() > CALC_STACK {
+        return None;
+    }
+    let mut stack: Vec<Value> = inputs.iter().map(|&v| Value::Num(v)).collect();
+    let mut pc = 0;
+    let mut steps = 0;
+    while let Some(op) = program.get(pc) {
+        steps += 1;
+        if steps > CALC_STEPS {
+            return None;
+        }
+        pc += 1;
+        match *op {
+            Calc::Push(v) => calc_push(&mut stack, v)?,
+            Calc::Jump(target) => pc = target,
+            Calc::JumpIfFalse(target) => match stack.pop()? {
+                Value::Bool(true) => {}
+                Value::Bool(false) => pc = target,
+                Value::Num(_) => return None,
+            },
+            Calc::Abs => calc_unary(&mut stack, |a| Some(a.abs()))?,
+            Calc::Add => calc_binary(&mut stack, |a, b| Some(a + b))?,
+            Calc::Atan => calc_binary(&mut stack, |num, den| {
+                let deg = num.atan2(den).to_degrees();
+                Some(if deg < 0.0 { deg + 360.0 } else { deg })
+            })?,
+            Calc::Ceiling => calc_unary(&mut stack, |a| Some(a.ceil()))?,
+            Calc::Cos => calc_unary(&mut stack, |a| Some(a.to_radians().cos()))?,
+            Calc::Cvi => calc_unary(&mut stack, |a| calc_int(a).map(|i| i as f32))?,
+            Calc::Cvr => calc_unary(&mut stack, Some)?,
+            Calc::Div => calc_binary(&mut stack, |a, b| (b != 0.0).then(|| a / b))?,
+            Calc::Exp => calc_binary(&mut stack, |a, b| Some(a.powf(b)))?,
+            Calc::Floor => calc_unary(&mut stack, |a| Some(a.floor()))?,
+            Calc::Idiv => calc_binary(&mut stack, |a, b| {
+                let (a, b) = (calc_int(a)?, calc_int(b)?);
+                (b != 0).then(|| a.wrapping_div(b) as f32)
+            })?,
+            Calc::Ln => calc_unary(&mut stack, |a| (a > 0.0).then(|| a.ln()))?,
+            Calc::Log => calc_unary(&mut stack, |a| (a > 0.0).then(|| a.log10()))?,
+            Calc::Mod => calc_binary(&mut stack, |a, b| {
+                let (a, b) = (calc_int(a)?, calc_int(b)?);
+                (b != 0).then(|| a.wrapping_rem(b) as f32)
+            })?,
+            Calc::Mul => calc_binary(&mut stack, |a, b| Some(a * b))?,
+            Calc::Neg => calc_unary(&mut stack, |a| Some(-a))?,
+            // Ties go to the greater integer, so this is not f32::round.
+            Calc::Round => calc_unary(&mut stack, |a| Some((a + 0.5).floor()))?,
+            Calc::Sin => calc_unary(&mut stack, |a| Some(a.to_radians().sin()))?,
+            Calc::Sqrt => calc_unary(&mut stack, |a| (a >= 0.0).then(|| a.sqrt()))?,
+            Calc::Sub => calc_binary(&mut stack, |a, b| Some(a - b))?,
+            Calc::Truncate => calc_unary(&mut stack, |a| Some(a.trunc()))?,
+            Calc::And => calc_logic(&mut stack, |a, b| a & b, |a, b| a && b)?,
+            Calc::Bitshift => calc_binary(&mut stack, |a, shift| {
+                let (a, shift) = (calc_int(a)?, calc_int(shift)?);
+                let shifted = match shift {
+                    32.. => 0,
+                    0..=31 => ((a as u32) << shift) as i32,
+                    -31..=-1 => ((a as u32) >> -shift) as i32,
+                    _ => 0,
+                };
+                Some(shifted as f32)
+            })?,
+            Calc::Eq => {
+                let equal = calc_equal(&mut stack)?;
+                stack.push(Value::Bool(equal));
+            }
+            Calc::Ne => {
+                let equal = calc_equal(&mut stack)?;
+                stack.push(Value::Bool(!equal));
+            }
+            Calc::Ge => calc_compare(&mut stack, |a, b| a >= b)?,
+            Calc::Gt => calc_compare(&mut stack, |a, b| a > b)?,
+            Calc::Le => calc_compare(&mut stack, |a, b| a <= b)?,
+            Calc::Lt => calc_compare(&mut stack, |a, b| a < b)?,
+            Calc::Not => {
+                let v = match stack.pop()? {
+                    Value::Bool(b) => Value::Bool(!b),
+                    Value::Num(v) => Value::Num(!calc_int(v)? as f32),
+                };
+                stack.push(v);
+            }
+            Calc::Or => calc_logic(&mut stack, |a, b| a | b, |a, b| a || b)?,
+            Calc::Xor => calc_logic(&mut stack, |a, b| a ^ b, |a, b| a ^ b)?,
+            Calc::Copy => {
+                let n = calc_int(calc_num(&mut stack)?)?;
+                if n < 0 || n as usize > stack.len() || stack.len() + n as usize > CALC_STACK {
+                    return None;
+                }
+                let start = stack.len() - n as usize;
+                for i in start..start + n as usize {
+                    let v = stack[i];
+                    stack.push(v);
+                }
+            }
+            Calc::Dup => {
+                let v = *stack.last()?;
+                calc_push(&mut stack, v)?;
+            }
+            Calc::Exch => {
+                let b = stack.pop()?;
+                let a = stack.pop()?;
+                stack.push(b);
+                stack.push(a);
+            }
+            Calc::Index => {
+                let n = calc_int(calc_num(&mut stack)?)?;
+                if n < 0 || n as usize >= stack.len() {
+                    return None;
+                }
+                let v = stack[stack.len() - 1 - n as usize];
+                calc_push(&mut stack, v)?;
+            }
+            Calc::Pop => {
+                stack.pop()?;
+            }
+            Calc::Roll => {
+                let j = calc_int(calc_num(&mut stack)?)?;
+                let n = calc_int(calc_num(&mut stack)?)?;
+                if n < 0 || n as usize > stack.len() {
+                    return None;
+                }
+                if n > 0 {
+                    let start = stack.len() - n as usize;
+                    stack[start..].rotate_right(j.rem_euclid(n) as usize);
+                }
+            }
+        }
+    }
+    Some(stack)
 }
 
 /// The geometry of a supported shading.
@@ -351,12 +879,11 @@ async fn function_dict<S: AsyncObjectSource>(
 }
 
 /// Loads `/Function` — one function or an array of them — into an arena.
-/// `Ok(None)` means a function *type* nobody evaluates here (the PostScript
-/// calculator); `Err` is a structural failure worth reporting verbatim.
+/// `Err` is a structural failure worth reporting verbatim.
 pub(crate) async fn load_functions<S: AsyncObjectSource>(
     src: &S,
     obj: &Object,
-) -> Result<Option<Functions>, Error> {
+) -> Result<Functions, Error> {
     let mut queue: Vec<Object> = Vec::new();
     match src.resolve(obj).await {
         Ok(Object::Array(items)) => queue.extend(items.iter().cloned()),
@@ -484,7 +1011,26 @@ pub(crate) async fn load_functions<S: AsyncObjectSource>(
                     data,
                 }
             }
-            4 => return Ok(None),
+            4 => {
+                let data = data
+                    .ok_or_else(|| Error::Other("calculator function carries no stream".into()))?;
+                let domain = float_array(src, dict.get("Domain"))
+                    .await
+                    .filter(|d| d.len() >= 2 && d.len() % 2 == 0 && d.len() / 2 <= MAX_COMPS)
+                    .ok_or_else(|| Error::Other("calculator function /Domain unusable".into()))?;
+                let range = float_array(src, dict.get("Range"))
+                    .await
+                    .filter(|r| r.len() >= 2 && r.len() % 2 == 0)
+                    .ok_or_else(|| Error::Other("calculator function has no /Range".into()))?;
+                let items = parse_calculator(&data)?;
+                let mut program = Vec::new();
+                compile_calculator(&items, &mut program)?;
+                Node::Calculator {
+                    domain,
+                    range,
+                    program,
+                }
+            }
             _ => return Err(Error::Other("unknown function type".into())),
         };
         let index = functions.nodes.len();
@@ -500,14 +1046,14 @@ pub(crate) async fn load_functions<S: AsyncObjectSource>(
     }
     // A stitching child that never loaded leaves usize::MAX behind; the cap
     // above is the only way to get here, and it already errored.
-    Ok(Some(functions))
+    Ok(functions)
 }
 
 impl Shading {
     /// Loads a shading dictionary (or stream — mesh shadings are streams,
-    /// and they answer `Ok(None)`). `Ok(None)` = a shading or function type
-    /// this renderer does not paint, for the caller to report as
-    /// unsupported; `Err` = a structural failure, reported verbatim.
+    /// and they answer `Ok(None)`). `Ok(None)` = a shading type this
+    /// renderer does not paint, for the caller to report as unsupported;
+    /// `Err` = a structural failure, reported verbatim.
     pub(crate) async fn load_with<S: AsyncObjectSource>(
         src: &S,
         obj: &Object,
@@ -550,10 +1096,7 @@ impl Shading {
             .ok_or_else(|| Error::Other("shading has no /ColorSpace".into()))?;
         let cs = ColorSpace::parse_with(src, cs_obj).await;
         let functions = match dict.get("Function") {
-            Some(f) => match load_functions(src, f).await? {
-                Some(functions) => functions,
-                None => return Ok(None),
-            },
+            Some(f) => load_functions(src, f).await?,
             None => return Err(Error::Other("shading has no /Function".into())),
         };
         let domain = match floats(src, dict.get("Domain"), 2).await {
@@ -661,7 +1204,7 @@ mod tests {
         Parser::new(src).parse_object(&NoResolve).unwrap()
     }
 
-    fn load(dict: &str, data: &[u8]) -> Result<Option<Functions>, Error> {
+    fn load(dict: &str, data: &[u8]) -> Result<Functions, Error> {
         let mut b = PdfBuilder::new();
         b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
         b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
@@ -693,7 +1236,6 @@ mod tests {
             "/FunctionType 0 /Domain [0 1 0 1] /Range [0 1] /Size [2 2] /BitsPerSample 8",
             &[0, 100, 200, 255],
         )
-        .unwrap()
         .unwrap();
         close(&eval(&f, &[0.0, 0.0]), &[0.0]);
         close(&eval(&f, &[1.0, 0.0]), &[100.0 / 255.0]);
@@ -714,7 +1256,6 @@ mod tests {
             "/FunctionType 0 /Domain [0 1] /Range [0 1] /Size [4] /BitsPerSample 8",
             &[0, 85, 170, 255],
         )
-        .unwrap()
         .unwrap();
         close(&eval(&f, &[0.0]), &[0.0]);
         close(&eval(&f, &[0.5]), &[127.5 / 255.0]);
@@ -730,7 +1271,6 @@ mod tests {
              /BitsPerSample 8 /Decode [1 0]",
             &[0, 51, 102, 153, 204, 255],
         )
-        .unwrap()
         .unwrap();
         // (1, 0) encodes to grid point (2, 0): sample 102, decoded 1 - s.
         close(&eval(&f, &[1.0, 0.0]), &[1.0 - 102.0 / 255.0]);
@@ -745,9 +1285,200 @@ mod tests {
             b"unused",
         );
         // Type 2 is a dictionary in real files; the stream dict works too.
-        let f = f.unwrap().unwrap();
+        let f = f.unwrap();
         close(&eval(&f, &[0.25, 9.0]), &[0.25]);
         close(&eval(&f, &[]), &[0.0]);
+    }
+
+    fn calc(domain: &str, range: &str, program: &str) -> Functions {
+        load(
+            &format!("/FunctionType 4 /Domain [{domain}] /Range [{range}]"),
+            program.as_bytes(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn calculator_arithmetic_operators_compute() {
+        let f = calc(
+            "0 1",
+            "0 2000 0 2000 0 2000 0 2000 0 2000 0 2000",
+            "{ 3 4 add 2 mul 2 10 exp 100 log 9 sqrt 7 2 div 1 ln }",
+        );
+        close(&eval(&f, &[0.0]), &[14.0, 1024.0, 2.0, 3.0, 3.5, 0.0]);
+    }
+
+    #[test]
+    fn calculator_atan_returns_degrees_in_every_quadrant() {
+        let f = calc(
+            "0 1",
+            "0 360 0 360 0 360 0 360 0 360",
+            "{ 1 1 atan 1 -1 atan -1 -1 atan -1 1 atan 1 0 atan }",
+        );
+        close(&eval(&f, &[0.0]), &[45.0, 135.0, 225.0, 315.0, 90.0]);
+    }
+
+    #[test]
+    fn calculator_integer_division_and_modulo_keep_the_dividend_sign() {
+        let f = calc(
+            "0 1",
+            "-10 10 -10 10 -10 10 -10 10",
+            "{ -7 2 idiv -7 3 mod 7 -3 mod 6 2 idiv }",
+        );
+        close(&eval(&f, &[0.0]), &[-3.0, -1.0, 1.0, 3.0]);
+    }
+
+    #[test]
+    fn calculator_roll_rotates_both_directions() {
+        let up = calc("0 1", "0 5 0 5 0 5", "{ 1 2 3 3 1 roll }");
+        close(&eval(&up, &[0.0]), &[3.0, 1.0, 2.0]);
+        let down = calc("0 1", "0 5 0 5 0 5", "{ 1 2 3 3 -1 roll }");
+        close(&eval(&down, &[0.0]), &[2.0, 3.0, 1.0]);
+    }
+
+    #[test]
+    fn calculator_stack_operators_manage_the_stack() {
+        let index = calc("0 1", "0 5 0 5 0 5 0 5", "{ 1 2 3 2 index }");
+        close(&eval(&index, &[0.0]), &[1.0, 2.0, 3.0, 1.0]);
+        let copy = calc("0 1", "0 5 0 5 0 5 0 5", "{ 1 2 2 copy }");
+        close(&eval(&copy, &[0.0]), &[1.0, 2.0, 1.0, 2.0]);
+        let mix = calc("0 1", "0 1", "{ dup 1 exch sub exch pop }");
+        close(&eval(&mix, &[0.3]), &[0.7]);
+    }
+
+    #[test]
+    fn calculator_nested_conditionals_branch() {
+        let f = calc(
+            "0 1",
+            "0 1",
+            "{ dup 0.25 lt { pop 0 } { 0.75 lt { 0.5 } { 1 } ifelse } ifelse }",
+        );
+        close(&eval(&f, &[0.1]), &[0.0]);
+        close(&eval(&f, &[0.5]), &[0.5]);
+        close(&eval(&f, &[0.9]), &[1.0]);
+    }
+
+    #[test]
+    fn calculator_logic_operators_split_on_operand_type() {
+        let ints = calc(
+            "0 1",
+            "-20 20 -20 20 -20 20 -20 20",
+            "{ 12 10 and 12 10 or 12 10 xor 7 not }",
+        );
+        close(&eval(&ints, &[0.0]), &[8.0, 14.0, 6.0, -8.0]);
+        let bools = calc(
+            "0 1",
+            "0 1 0 1",
+            "{ true false or { 1 } { 0 } ifelse true not { 1 } { 0 } ifelse }",
+        );
+        close(&eval(&bools, &[0.0]), &[1.0, 0.0]);
+    }
+
+    #[test]
+    fn calculator_bitshift_shifts_both_directions() {
+        let f = calc("0 1", "0 10 0 10", "{ 1 3 bitshift 8 -2 bitshift }");
+        close(&eval(&f, &[0.0]), &[8.0, 2.0]);
+    }
+
+    #[test]
+    fn calculator_comparisons_and_mixed_type_equality() {
+        let f = calc(
+            "0 1",
+            "0 1 0 1 0 1 0 1",
+            "{ 3 4 lt { 1 } { 0 } ifelse 3 3 ge { 1 } { 0 } ifelse \
+              1 true eq { 1 } { 0 } ifelse 1 true ne { 1 } { 0 } ifelse }",
+        );
+        close(&eval(&f, &[0.0]), &[1.0, 1.0, 0.0, 1.0]);
+    }
+
+    /// `round` resolves ties toward the greater integer, unlike a
+    /// round-half-away-from-zero.
+    #[test]
+    fn calculator_rounding_family() {
+        let f = calc(
+            "0 1",
+            "-10 10 -10 10 -10 10 -10 10 -10 10 -10 10",
+            "{ 2.5 round -2.5 round -3.7 truncate -3.7 floor 3.2 ceiling -3.7 cvi }",
+        );
+        close(&eval(&f, &[0.0]), &[3.0, -2.0, -3.0, -4.0, 4.0, -3.0]);
+    }
+
+    #[test]
+    fn calculator_inputs_arrive_in_order_and_clamp_to_domain() {
+        let f = calc("0 1 0 1", "-1 1", "{ sub }");
+        close(&eval(&f, &[0.7, 0.2]), &[0.5]);
+        close(&eval(&f, &[2.0, -1.0]), &[1.0]);
+    }
+
+    #[test]
+    fn calculator_runtime_failures_clamp_to_the_range_floor() {
+        // Stack underflow: `add` finds one operand, not two.
+        let underflow = calc("0 1", "5 10", "{ add }");
+        close(&eval(&underflow, &[0.5]), &[5.0]);
+        let zero_div = calc("0 1", "0 1", "{ pop 1 0 div }");
+        close(&eval(&zero_div, &[0.5]), &[0.0]);
+        // Bitwise `and` over a boolean and a number is a type error.
+        let mixed = calc("0 1", "0 1", "{ pop true 1 and }");
+        close(&eval(&mixed, &[0.5]), &[0.0]);
+        // A boolean is not a number, so it cannot be an output.
+        let boolean_out = calc("0 1", "0 1", "{ pop true }");
+        close(&eval(&boolean_out, &[0.5]), &[0.0]);
+    }
+
+    #[test]
+    fn calculator_success_outputs_clamp_to_range() {
+        let f = calc("0 1", "0 1 0 1", "{ pop 2 -1 }");
+        close(&eval(&f, &[0.5]), &[1.0, 0.0]);
+    }
+
+    #[test]
+    fn a_runaway_calculator_program_clamps_instead_of_hanging() {
+        let mut runaway = String::from("{ 0 ");
+        for _ in 0..8000 {
+            runaway.push_str("1 add ");
+        }
+        runaway.push('}');
+        let f = calc("0 1", "0 20000", &runaway);
+        close(&eval(&f, &[0.0]), &[0.0]);
+        // The same shape under the step budget still computes.
+        let mut fine = String::from("{ 0 ");
+        for _ in 0..100 {
+            fine.push_str("1 add ");
+        }
+        fine.push('}');
+        let f = calc("0 1", "0 20000", &fine);
+        close(&eval(&f, &[0.0]), &[100.0]);
+    }
+
+    #[test]
+    fn calculator_comments_and_whitespace_are_skipped() {
+        let f = calc("0 1", "0 10", "{ % a comment\n 3 4 add pop 5 }");
+        close(&eval(&f, &[0.0]), &[5.0]);
+    }
+
+    #[test]
+    fn malformed_calculator_programs_fail_at_load() {
+        let check = |program: &str| {
+            let loaded = load(
+                "/FunctionType 4 /Domain [0 1] /Range [0 1]",
+                program.as_bytes(),
+            );
+            assert!(loaded.is_err(), "{program:?} should not load");
+        };
+        check("{ 1 2 add");
+        check("1 2 add }");
+        check("{ 1 2 frobnicate }");
+        check("{ { 1 } }");
+        check("{ 1 if }");
+        check("{ { 1 } { 2 } if }");
+        check("{ 1 2 } }");
+        check("{ 1 } 2");
+        check("");
+    }
+
+    #[test]
+    fn a_calculator_function_without_range_fails_at_load() {
+        assert!(load("/FunctionType 4 /Domain [0 1]", b"{ 1 }").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Base of a 4-PR stack — MERGE THIS ONE FIRST (into main). #shading-blend-mask, #mesh-shadings and #nonseparable-blends stack on it; after this merges GitHub retargets them to main. Please do not squash stacked PRs into each other's branches.

- Functions::eval takes multi-input slices; type 0 gains multilinear interpolation over m-dimensional grids (first dimension fastest, 8-dim / 2^24-sample caps).
- Type 4 (PostScript calculator, ISO 32000 7.10.5): compiled to a flat instruction vec (if/ifelse become forward jumps — the language has no backward edges), tagged Num/Bool operand stack (load-bearing for logical-vs-bitwise and/or/xor/not and boolean-only if), operand stack capped at 100 per spec, 10k step budget, 32-deep brace nesting. Malformed programs fail at LOAD (existing SkippedKind::Shading report paths); runtime failures clamp outputs to the /Range floor so the page keeps painting.
- DeviceN tint transforms evaluate (Separation is the n=1 case per 8.6.6.5 — one variant carrying arity); >8 colorants keep the ink approximation.

Verification: workspace 1674 -> 1702 tests (+28, incl. atan quadrants, idiv/mod on negatives, roll both directions, negative bitshift, clamping matrix). Corpus: object-tree scan proves zero type-4/DeviceN content in all 259 files; the 8 Separation-bearing files render byte-identical (their tints are type 0, an already-supported path); controller-verified 505/505 baseline page shas identical at the stack tip. A synthetic demo file exercises all three paths (gray-approximation -> real color, dropped shading -> painted quadratic ramp).