### PR TITLE
feat(render): composite shadings through blend modes and soft masks

### DIFF
--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -1,14 +1,13 @@
 //! Content-op execution against a graphics state stack: transforms, colors,
 //! clipping, ExtGState, form XObject recursion, and paint dispatch.
 //!
-//! Limitations (v0.1): only embedded-TrueType glyph outlines are painted
-//! (other fonts are positioned but not drawn); `sh` shadings are skipped;
-//! pattern fills paint mid-gray; masks and blend modes are ignored;
-//! annotation appearance streams are not drawn. Everything on that list
-//! except the glyph tiers -- which the caller chooses -- is recorded in the
-//! [`RenderReport`] this module returns, along with every content stream and
-//! image leniency drops, so no caller is handed a blank page it cannot
-//! account for.
+//! What cannot be reproduced is reported, never silently dropped: every
+//! skipped or approximated element -- a mesh shading, a non-separable blend
+//! mode, text shown in a clipping mode, undecodable content -- lands in the
+//! [`RenderReport`] this module returns, along with every content stream
+//! and image leniency drop, so no caller is handed a blank page it cannot
+//! account for. The one exception is the glyph tiers, which the caller
+//! chooses.
 
 use pdfboss_core::FastMap;
 use std::sync::Arc;
@@ -1491,6 +1490,8 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                 tgs.clip = Some(clip);
                 tgs.fill_alpha = gs.fill_alpha;
                 tgs.stroke_alpha = gs.stroke_alpha;
+                tgs.blend_mode = gs.blend_mode;
+                tgs.soft_mask = gs.soft_mask.clone();
                 let kind = if tiling.uncolored {
                     tgs.fill_rgb = gs.fill_rgb;
                     tgs.stroke_rgb = gs.stroke_rgb;
@@ -1516,10 +1517,10 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
     }
 
     /// Paints `shading` through `polys` (the fill or stroke geometry,
-    /// rasterized under `rule` and intersected with the active clip and the
-    /// shading's own `/BBox`), first laying down `/Background` where the
-    /// shading declares one (§8.7.4.3 — pattern fills only, which is the
-    /// single caller).
+    /// rasterized under `rule` and intersected with the active clip, the
+    /// group soft mask and the shading's own `/BBox`), first laying down
+    /// `/Background` over that same region where the shading declares one
+    /// (§8.7.4.3 — pattern fills only, which is the single caller).
     fn paint_shading_through(
         &mut self,
         polys: &[Subpath],
@@ -1532,8 +1533,8 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             return;
         }
         let path_mask = self.rasterize_clip(polys, rule);
-        let region = match &gs.clip {
-            Some(clip) => Arc::new(Mask::intersected(&path_mask, clip)),
+        let region = match effective_mask(&gs) {
+            Some(cov) => Arc::new(Mask::intersected(&path_mask, &cov)),
             None => path_mask,
         };
         let region = match shading.bbox {
@@ -1550,19 +1551,14 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             }
             None => region,
         };
-        if let Some(bg) = shading.background {
-            fill_path(
-                &mut self.pix,
-                &mut self.raster,
-                polys,
-                rule,
-                rgba8(bg),
-                gs.fill_alpha,
-                gs.clip.as_deref(),
-                gs.blend_mode,
-            );
-        }
-        shading.paint(&mut self.pix, Some(&region), gs.fill_alpha, to_device);
+        shading.paint_background(&mut self.pix, &region, gs.fill_alpha, gs.blend_mode);
+        shading.paint(
+            &mut self.pix,
+            Some(&region),
+            gs.fill_alpha,
+            to_device,
+            gs.blend_mode,
+        );
     }
 
     /// Rasterizes `polys` under `rule` into a clip [`Mask`], reusing a
@@ -2766,20 +2762,22 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             region.as_deref(),
             frame.gs.fill_alpha,
             frame.gs.ctm,
+            frame.gs.blend_mode,
         );
     }
 
-    /// The coverage region a shading paints under: the active clip,
-    /// intersected with the shading's `/BBox` (rasterized under the same
-    /// matrix the shading paints with) when it declares one.
+    /// The coverage region a shading paints under: the active clip and
+    /// group soft mask, intersected with the shading's `/BBox` (rasterized
+    /// under the same matrix the shading paints with) when it declares one.
     fn shading_region(
         &mut self,
         shading: &Shading,
         gs: &GState,
         to_device: Matrix,
     ) -> Option<Arc<Mask>> {
-        match (&shading.bbox, &gs.clip) {
-            (Some(b), clip) => {
+        let coverage = effective_mask(gs);
+        match (&shading.bbox, coverage) {
+            (Some(b), coverage) => {
                 let mut pb = PathBuilder::new(to_device);
                 pb.rect(
                     b[0].min(b[2]),
@@ -2788,13 +2786,12 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                     (b[3] - b[1]).abs(),
                 );
                 let bbox_mask = self.rasterize_clip(&pb.finish(), FillRule::NonZero);
-                Some(match clip {
-                    Some(clip) => Arc::new(Mask::intersected(&bbox_mask, clip)),
+                Some(match coverage {
+                    Some(cov) => Arc::new(Mask::intersected(&bbox_mask, &cov)),
                     None => bbox_mask,
                 })
             }
-            (None, Some(clip)) => Some(Arc::clone(clip)),
-            (None, None) => None,
+            (None, coverage) => coverage,
         }
     }
 
@@ -4959,6 +4956,154 @@ mod tests {
         assert!(report.is_empty(), "painted: {:?}", report.warnings());
         assert_near(px(&pix, 60, 50), [102, 0, 153, 255], 4, "page-anchored t");
         assert_eq!(px(&pix, 40, 50), WHITE, "the path itself did move");
+    }
+
+    /// A constant-green shading (C0 = C1, extended both ways) so blend and
+    /// mask probes read one exact color everywhere the shading paints.
+    const GREEN_SHADING: &str = "<< /ShadingType 2 /ColorSpace /DeviceRGB /Coords [0 0 100 0] \
+         /Extend [true true] /Function << /FunctionType 2 /Domain [0 1] \
+         /C0 [0 1 0] /C1 [0 1 0] /N 1 >> >>";
+
+    #[test]
+    fn sh_honors_the_blend_mode() {
+        // Multiply over a mid-gray backdrop keeps half of each source
+        // channel (§11.3.5.2): 0.5 × green = (0, 128, 0) exactly.
+        let resources = "/Shading << /Sh0 5 0 R >> /ExtGState << /GS0 << /BM /Multiply >> >>";
+        let content = b"0.5 0.5 0.5 rg 0 0 100 100 re f /GS0 gs /Sh0 sh";
+        let bytes = small_doc(resources, content, |b| {
+            b.object(5, GREEN_SHADING);
+        });
+        let (pix, report) = render_reporting(bytes);
+        assert!(report.is_empty(), "painted: {:?}", report.warnings());
+        assert_eq!(px(&pix, 50, 50), [0, 128, 0, 255], "multiply with backdrop");
+    }
+
+    #[test]
+    fn sh_composites_through_the_group_soft_mask() {
+        // The group paints white over the left half: the shading may only
+        // reach those pixels, exactly like any other paint under the mask.
+        let resources = "/Shading << /Sh0 6 0 R >> \
+             /ExtGState << /GS0 << /SMask << /S /Luminosity /G 5 0 R >> >> >>";
+        let bytes = small_doc(resources, b"/GS0 gs /Sh0 sh", |b| {
+            b.stream(
+                5,
+                "/Type /XObject /Subtype /Form /BBox [0 0 100 100]",
+                b"1 1 1 rg 0 0 50 100 re f",
+            );
+            b.object(6, GREEN_SHADING);
+        });
+        let (pix, report) = render_reporting(bytes);
+        assert!(report.is_empty(), "painted: {:?}", report.warnings());
+        assert_eq!(px(&pix, 25, 50), [0, 255, 0, 255], "unmasked half paints");
+        assert_eq!(px(&pix, 75, 50), WHITE, "masked half shows the page");
+    }
+
+    #[test]
+    fn shading_pattern_fill_honors_the_blend_mode() {
+        let resources = "/Pattern << /P0 << /PatternType 2 /Shading 5 0 R >> >> \
+             /ExtGState << /GS0 << /BM /Multiply >> >>";
+        let content = b"0.5 0.5 0.5 rg 0 0 100 100 re f \
+                        /GS0 gs /Pattern cs /P0 scn 20 20 60 60 re f";
+        let bytes = small_doc(resources, content, |b| {
+            b.object(5, GREEN_SHADING);
+        });
+        let (pix, report) = render_reporting(bytes);
+        assert!(report.is_empty(), "painted: {:?}", report.warnings());
+        assert_eq!(px(&pix, 50, 50), [0, 128, 0, 255], "multiply inside path");
+        assert_eq!(px(&pix, 10, 50), [128, 128, 128, 255], "outside untouched");
+    }
+
+    #[test]
+    fn shading_pattern_fill_composites_through_the_group_soft_mask() {
+        let resources = "/Pattern << /P0 << /PatternType 2 /Shading 6 0 R >> >> \
+             /ExtGState << /GS0 << /SMask << /S /Luminosity /G 5 0 R >> >> >>";
+        let content = b"/GS0 gs /Pattern cs /P0 scn 0 0 100 100 re f";
+        let bytes = small_doc(resources, content, |b| {
+            b.stream(
+                5,
+                "/Type /XObject /Subtype /Form /BBox [0 0 100 100]",
+                b"1 1 1 rg 0 0 50 100 re f",
+            );
+            b.object(6, GREEN_SHADING);
+        });
+        let (pix, report) = render_reporting(bytes);
+        assert!(report.is_empty(), "painted: {:?}", report.warnings());
+        assert_eq!(px(&pix, 25, 50), [0, 255, 0, 255], "unmasked half paints");
+        assert_eq!(px(&pix, 75, 50), WHITE, "masked half shows the page");
+    }
+
+    #[test]
+    fn pattern_background_respects_the_shading_bbox() {
+        // /Background obeys /BBox exactly as the gradient does — both are
+        // painting the shading (ISO 32000-1 Table 78, temporary clipping
+        // boundary). The axis spans x 30..50 with no extension, so inside
+        // the BBox the strips beside the gradient show the background and
+        // everything outside the BBox stays untouched even though the
+        // filled path covers the whole page.
+        let resources = "/Pattern << /P0 << /PatternType 2 /Shading 5 0 R >> >>";
+        let content = b"/Pattern cs /P0 scn 0 0 100 100 re f";
+        let bytes = small_doc(resources, content, |b| {
+            b.object(
+                5,
+                "<< /ShadingType 2 /ColorSpace /DeviceRGB /Coords [30 0 50 0] \
+                 /BBox [20 20 60 60] /Background [0 1 0] \
+                 /Function << /FunctionType 2 /Domain [0 1] \
+                 /C0 [1 0 0] /C1 [0 0 1] /N 1 >> >>",
+            );
+        });
+        let (pix, report) = render_reporting(bytes);
+        assert!(report.is_empty(), "painted: {:?}", report.warnings());
+        assert_eq!(px(&pix, 10, 50), WHITE, "left of the BBox");
+        assert_eq!(px(&pix, 25, 50), [0, 255, 0, 255], "background strip");
+        assert_near(px(&pix, 40, 50), [121, 0, 134, 255], 2, "gradient");
+        assert_eq!(px(&pix, 55, 50), [0, 255, 0, 255], "background strip");
+        assert_eq!(px(&pix, 70, 50), WHITE, "right of the BBox");
+        assert_eq!(px(&pix, 40, 10), WHITE, "above the BBox");
+    }
+
+    #[test]
+    fn tiles_inherit_the_blend_mode() {
+        // The Multiply set before the pattern fill must reach the tile
+        // frames: green cells over the mid-gray backdrop keep half the
+        // green channel instead of reverting to Normal inside each tile.
+        let resources = "/Pattern << /P0 5 0 R >> /ExtGState << /GS0 << /BM /Multiply >> >>";
+        let content = b"0.5 0.5 0.5 rg 0 0 100 100 re f \
+                        /GS0 gs /Pattern cs /P0 scn 0 0 100 100 re f";
+        let bytes = small_doc(resources, content, |b| {
+            b.stream(
+                5,
+                "/PatternType 1 /PaintType 1 /TilingType 1 /BBox [0 0 10 10] \
+                 /XStep 10 /YStep 10 /Resources << >>",
+                b"0 1 0 rg 0 0 10 10 re f",
+            );
+        });
+        let (pix, report) = render_reporting(bytes);
+        assert!(report.is_empty(), "painted: {:?}", report.warnings());
+        assert_eq!(px(&pix, 50, 50), [0, 128, 0, 255], "tile multiplies");
+    }
+
+    #[test]
+    fn tiles_inherit_the_group_soft_mask() {
+        let resources = "/Pattern << /P0 6 0 R >> \
+             /ExtGState << /GS0 << /SMask << /S /Luminosity /G 5 0 R >> >> >>";
+        let content = b"/GS0 gs /Pattern cs /P0 scn 0 0 100 100 re f";
+        let bytes = small_doc(resources, content, |b| {
+            b.stream(
+                5,
+                "/Type /XObject /Subtype /Form /BBox [0 0 100 100]",
+                b"1 1 1 rg 0 0 50 100 re f",
+            );
+            b.stream(
+                6,
+                "/PatternType 1 /PaintType 1 /TilingType 1 /BBox [0 0 10 10] \
+                 /XStep 10 /YStep 10 /Resources << >>",
+                b"1 0 0 rg 0 0 10 10 re f",
+            );
+        });
+        let (pix, report) = render_reporting(bytes);
+        assert!(report.is_empty(), "painted: {:?}", report.warnings());
+        assert_eq!(px(&pix, 25, 50), RED, "unmasked half tiles");
+        assert_eq!(px(&pix, 75, 50), WHITE, "masked half shows the page");
     }
 
     #[test]

--- a/crates/pdfboss-render/src/lib.rs
+++ b/crates/pdfboss-render/src/lib.rs
@@ -284,7 +284,9 @@ pub enum SkippedKind {
     /// A `Do` whose XObject resource is missing, is not a stream, or has no
     /// subtype this renderer knows how to draw.
     XObject,
-    /// A shading (`sh`), which this renderer does not paint.
+    /// A shading (`sh` or a shading pattern) this renderer could not
+    /// paint: an unsupported kind, a missing resource, or a structural
+    /// failure. Axial and radial gradients paint.
     Shading,
     /// A pattern fill or stroke, painted as flat mid-gray instead of the
     /// pattern's own content.
@@ -292,7 +294,8 @@ pub enum SkippedKind {
     /// A mask that was ignored, so content the author masked out painted
     /// solid: an image `/SMask` or `/Mask`, or an `/ExtGState` `/SMask`.
     SoftMask,
-    /// A blend mode other than `Normal`, painted as `Normal`.
+    /// A non-separable blend mode (Hue, Saturation, Color, Luminosity),
+    /// painted as `Normal`; the separable modes paint.
     BlendMode,
     /// An annotation appearance stream that was declared but could not be
     /// painted: unreadable, unparsable, or with no selectable state.

--- a/crates/pdfboss-render/src/raster.rs
+++ b/crates/pdfboss-render/src/raster.rs
@@ -682,7 +682,7 @@ fn fill_run(dst: &mut [u8], px: [u8; 4]) {
 
 /// Source-over paints one pixel at alpha `a`, honoring the blend mode.
 #[inline(always)]
-fn paint_pixel<const NORMAL: bool>(
+pub(crate) fn paint_pixel<const NORMAL: bool>(
     dst: &mut [u8],
     a: f32,
     rgb: [u8; 3],

--- a/crates/pdfboss-render/src/shading.rs
+++ b/crates/pdfboss-render/src/shading.rs
@@ -9,7 +9,7 @@ use pdfboss_core::geom::{Matrix, Point};
 use pdfboss_core::{decoded_stream_data_with, AsyncObjectSource, Dict, Error, Object};
 
 use crate::color::ColorSpace;
-use crate::raster::{composite_over, Mask};
+use crate::raster::{paint_pixel, BlendMode, Mask};
 use crate::Pixmap;
 
 /// Most components any color space here carries (CMYK is 4; `Other` caps at
@@ -1131,36 +1131,25 @@ impl Shading {
     }
 
     /// Paints the shading over every pixel `region` covers (the whole page
-    /// when `None`), compositing at `alpha` × coverage. `to_device` maps the
-    /// shading's target space to device pixels; a singular matrix paints
-    /// nothing (the caller reports it).
+    /// when `None`), compositing at `alpha` × coverage under `blend`.
+    /// `to_device` maps the shading's target space to device pixels; a
+    /// singular matrix paints nothing (the caller reports it).
     pub(crate) fn paint(
         &self,
         pix: &mut Pixmap,
         region: Option<&Mask>,
         alpha: f32,
         to_device: Matrix,
+        blend: BlendMode,
     ) {
         let Some(inv) = to_device.invert() else {
             return;
         };
-        let alpha = if alpha.is_finite() {
-            alpha.clamp(0.0, 1.0)
-        } else {
-            1.0
-        };
-        if alpha <= 0.0 {
+        let Some(alpha) = clamped_alpha(alpha) else {
             return;
-        }
-        let (x_lo, x_hi, y_lo, y_hi) = match region {
-            Some(m) => (
-                m.x0,
-                (m.x0 + m.bbox_w).min(pix.width),
-                m.y0,
-                (m.y0 + m.bbox_h).min(pix.height),
-            ),
-            None => (0, pix.width, 0, pix.height),
         };
+        let (x_lo, x_hi, y_lo, y_hi) = region_bounds(pix, region);
+        let normal = blend == BlendMode::Normal;
         let mut comps = [0f32; MAX_COMPS];
         for y in y_lo..y_hi {
             for x in x_lo..x_hi {
@@ -1177,19 +1166,95 @@ impl Shading {
                 };
                 let t = self.domain[0] + (self.domain[1] - self.domain[0]) * s;
                 let n = self.functions.eval(&[t], &mut comps);
-                let rgb = self.cs.to_rgb(&comps[..n]);
-                let q = |v: f32| (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
-                let rgb8 = [q(rgb[0]), q(rgb[1]), q(rgb[2])];
+                let rgb8 = quantize_rgb(self.cs.to_rgb(&comps[..n]));
                 let a = alpha * cov as f32 / 255.0;
-                let off = ((y * pix.width + x) * 4) as usize;
-                if a >= 1.0 {
-                    let opaque = [rgb8[0], rgb8[1], rgb8[2], 255];
-                    pix.data[off..off + 4].copy_from_slice(&opaque);
-                } else {
-                    composite_over(&mut pix.data[off..off + 4], rgb8, a);
-                }
+                shade_pixel(pix, x, y, a, rgb8, normal, blend);
             }
         }
+    }
+
+    /// Composites `/Background` over every pixel `region` covers, at
+    /// `alpha` × coverage under `blend` — the first half of the spec's
+    /// paint-twice model (Table 78: background first, then the shading
+    /// over it), sharing the shading's own clipping including `/BBox`.
+    pub(crate) fn paint_background(
+        &self,
+        pix: &mut Pixmap,
+        region: &Mask,
+        alpha: f32,
+        blend: BlendMode,
+    ) {
+        let Some(bg) = self.background else {
+            return;
+        };
+        let Some(alpha) = clamped_alpha(alpha) else {
+            return;
+        };
+        let (x_lo, x_hi, y_lo, y_hi) = region_bounds(pix, Some(region));
+        let normal = blend == BlendMode::Normal;
+        let rgb8 = quantize_rgb(bg);
+        for y in y_lo..y_hi {
+            for x in x_lo..x_hi {
+                let cov = region.coverage(x, y);
+                if cov == 0 {
+                    continue;
+                }
+                let a = alpha * cov as f32 / 255.0;
+                shade_pixel(pix, x, y, a, rgb8, normal, blend);
+            }
+        }
+    }
+}
+
+/// A constant alpha normalized for painting: clamped to 0..=1 (non-finite
+/// reads as opaque), `None` when nothing would paint.
+fn clamped_alpha(alpha: f32) -> Option<f32> {
+    let alpha = if alpha.is_finite() {
+        alpha.clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+    (alpha > 0.0).then_some(alpha)
+}
+
+/// The device-pixel rectangle a paint loop walks: the region's bbox clamped
+/// to the page, or the whole page without a region.
+fn region_bounds(pix: &Pixmap, region: Option<&Mask>) -> (u32, u32, u32, u32) {
+    match region {
+        Some(m) => (
+            m.x0,
+            (m.x0 + m.bbox_w).min(pix.width),
+            m.y0,
+            (m.y0 + m.bbox_h).min(pix.height),
+        ),
+        None => (0, pix.width, 0, pix.height),
+    }
+}
+
+/// Unit-range RGB to RGB8.
+fn quantize_rgb(rgb: [f32; 3]) -> [u8; 3] {
+    let q = |v: f32| (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+    [q(rgb[0]), q(rgb[1]), q(rgb[2])]
+}
+
+/// Composites one shading pixel through the raster blend seam.
+#[inline]
+fn shade_pixel(
+    pix: &mut Pixmap,
+    x: u32,
+    y: u32,
+    a: f32,
+    rgb8: [u8; 3],
+    normal: bool,
+    blend: BlendMode,
+) {
+    let opaque = [rgb8[0], rgb8[1], rgb8[2], 255];
+    let off = ((y * pix.width + x) * 4) as usize;
+    let dst = &mut pix.data[off..off + 4];
+    if normal {
+        paint_pixel::<true>(dst, a, rgb8, opaque, blend);
+    } else {
+        paint_pixel::<false>(dst, a, rgb8, opaque, blend);
     }
 }
 


### PR DESCRIPTION
STACKED on #66 (base = feat/type4-functions) — merge #66 first; this retargets to main automatically. Do not squash into the base branch.

Closes the two recorded follow-ups: every shading paint (sh operator + shading patterns) now composites through gs.blend_mode and effective_mask (clip ∩ group soft mask) via the shared paint_pixel seam; tiling-pattern cells inherit blend_mode and soft_mask (they previously reverted to Normal/none while forms inherited both). /Background moved under path∩clip∩mask∩/BBox (Table 78: BBox is a clipping boundary for the whole shading paint — the old pre-fill leaked outside BBox and double-multiplied path AA; stated in the commit body). Stale executor/lib docs from the pre-gradient era fixed. Known deviation kept and documented: stroke shading-patterns composite at fill_alpha.

Verification: +7 hand-computed fixture tests (Multiply + luminosity-mask over sh and pattern paints, Background-in-BBox, tile inheritance x2); the 6 corpus files carrying ShadingType 2 render byte-identical (18 pages); controller-verified 505/505 baseline shas at the stack tip; 118 pytest.