### PR TITLE
docs(core): describe membership visibility instead of linking a private item

### DIFF
--- a/crates/pdfboss-core/src/oc.rs
+++ b/crates/pdfboss-core/src/oc.rs
@@ -73,7 +73,8 @@ impl OcState {
     /// Whether content gated by `value` — the operand of a stream or
     /// annotation dictionary's `/OC` entry — is visible: a group reference
     /// is visible unless the group is off; a membership dictionary follows
-    /// [`OcState::ocmd_visible`]. A direct group dictionary has no
+    /// its `/VE` visibility expression, else its `/P` policy over `/OCGs`.
+    /// A direct group dictionary has no
     /// reference identity to be turned off by, and anything malformed is
     /// left visible.
     pub async fn visible_with<S: AsyncObjectSource>(&self, src: &S, value: &Object) -> bool {


### PR DESCRIPTION
The workspace doc gate (RUSTDOCFLAGS=-D warnings) fails on main since #65: visible_with's public doc links the private OcState::ocmd_visible. Replaced the link with the semantics in prose. Verified: cargo doc --workspace --no-deps clean under -D warnings on current main + this fix; fmt clean. My pre-merge gate list had fmt/clippy/test but not the doc build — the doc gate is now part of every remaining pre-merge verification in this campaign.