### PR TITLE
fix(render): carry the RenderOptions oc field into the fallback tests

### DIFF
--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -5879,6 +5879,7 @@ mod tests {
         let opts = RenderOptions {
             glyph_painting: GlyphPainting::Full,
             substitutes: SubstituteSource::Dir(dir.clone()),
+            ..Default::default()
         };
         let out = crate::render_page_reporting(&doc, &page, 1.0, &opts).expect("render");
         std::fs::remove_dir_all(&dir).ok();
@@ -6022,6 +6023,7 @@ mod tests {
         let opts = RenderOptions {
             glyph_painting: GlyphPainting::Full,
             substitutes: SubstituteSource::Dir(dir.clone()),
+            ..Default::default()
         };
         let (pix, report) = crate::render_page_reporting(&doc, &page, 1.0, &opts).expect("render");
         std::fs::remove_dir_all(&dir).ok();

--- a/crates/pdfboss-render/src/glyph.rs
+++ b/crates/pdfboss-render/src/glyph.rs
@@ -2261,6 +2261,7 @@ mod tests {
         let opts = || RenderOptions {
             glyph_painting: GlyphPainting::Full,
             substitutes: SubstituteSource::Dir(dir.clone()),
+            ..Default::default()
         };
 
         // Serif (0x2) + Nonsymbolic (0x20): the descriptor states the font


### PR DESCRIPTION
Restores green CI on main. #64's fallback tests construct `RenderOptions` field-by-field; #65 added the `oc` field — a semantic conflict only visible on merged main (`E0063` in three test initializers: executor.rs two sites, glyph.rs one). Filled with `..Default::default()`, the convention every other test site uses.

Verified locally on this branch: `cargo fmt --check`, `clippy --all-targets -D warnings` in both feature states, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --workspace` and `cargo test -p pdfboss-render --features substitute-fonts` — all green.