### PR TITLE
docs: apply the PR-claim audit's citation corrections

### DIFF
--- a/benchmarks/parsebench/README.md
+++ b/benchmarks/parsebench/README.md
@@ -76,6 +76,7 @@ leaderboard's "Open Source - Local" bracket (numbers from the repo's
 
 | Engine | Overall |
 |---|--:|
+| PyMuPDF4LLM | 53.49 |
 | Warp Ingest | 40.18 |
 | LiteParse (no OCR) | 32.80 |
 | OpenDataLoader | 29.40 |
@@ -94,9 +95,10 @@ leaderboard's "Open Source - Local" bracket (numbers from the repo's
   436 need a per-page layout payload (`ParseLayoutPageIR` items with
   normalized bboxes) that this provider does not emit, plus the 42 image
   inputs. The zeroing is identical for the pypdf/PyMuPDF baselines
-  (verified in-harness). Follow-up: expose block geometry from pdfboss's
-  layout IR through the Python bindings and emit the payload — no non-ML
-  local engine on the public leaderboard does.
+  (verified in-harness). PyMuPDF4LLM shows the payload is within reach of a
+  text-layer engine — it builds one from native page boxes and scores
+  61.89 on the dimension. Follow-up: expose block geometry from pdfboss's
+  layout IR through the Python bindings and emit the payload.
 - **Content Faithfulness** is dragged by two by-design choices: pdfboss
   markdown drops page headers/footers (the is_header/is_footer rules score
   zero) and scan-only pages have no text layer to extract.

--- a/crates/pdfboss-render/src/glyph.rs
+++ b/crates/pdfboss-render/src/glyph.rs
@@ -909,7 +909,7 @@ impl SubstituteInputs {
         // StandardEncoding (ISO 32000-1 9.6.6's built-in encoding for the
         // standard 14); and a descriptor whose `/Flags` declare Nonsymbolic
         // states outright that the font uses the Adobe standard Latin
-        // character set (Table 121), whose built-in encoding is the standard
+        // character set (Table 123), whose built-in encoding is the standard
         // one (Annex D) -- without the font program the built-in table itself
         // is unreadable, and StandardEncoding is its defined shape. A
         // symbolic font's built-in encoding is unknowable here, so it is

--- a/crates/pdfboss-render/src/substitute.rs
+++ b/crates/pdfboss-render/src/substitute.rs
@@ -1,5 +1,5 @@
 //! Non-embedded font substitution: deriving a face request from a PDF font
-//! dictionary (ISO 32000-1 Table 121, `/FontDescriptor /Flags`) and mapping
+//! dictionary (ISO 32000-1 Table 123, `/FontDescriptor /Flags`) and mapping
 //! that request onto a replacement face, either compiled in or read from a
 //! directory at render time.
 //!
@@ -69,7 +69,7 @@ pub(crate) trait SubstituteProvider: Send + Sync {
     fn face(&self, req: &FaceRequest) -> Option<Vec<u8>>;
 }
 
-/// `/FontDescriptor /Flags` bits consulted here (ISO 32000-1 Table 121).
+/// `/FontDescriptor /Flags` bits consulted here (ISO 32000-1 Table 123).
 const FLAG_FIXED_PITCH: i64 = 0x1;
 const FLAG_SERIF: i64 = 0x2;
 const FLAG_NONSYMBOLIC: i64 = 0x20;
@@ -77,7 +77,7 @@ const FLAG_ITALIC: i64 = 0x40;
 const FLAG_FORCE_BOLD: i64 = 0x40000;
 
 /// Whether `font`'s descriptor declares the Nonsymbolic flag (ISO 32000-1
-/// Table 121): the font uses the Adobe standard Latin character set. An
+/// Table 123): the font uses the Adobe standard Latin character set. An
 /// absent descriptor or absent `/Flags` reads as `false` -- unknown is
 /// never nonsymbolic.
 pub(crate) async fn nonsymbolic<S: AsyncObjectSource>(src: &S, font: &Dict) -> bool {


### PR DESCRIPTION
Two accounting corrections from the adversarial claim audit: the `/FontDescriptor /Flags` citation is ISO 32000-1 **Table 123** (was 121, four comment sites in substitute.rs/glyph.rs), and the ParseBench "Open Source - Local" bracket table gains the **PyMuPDF4LLM 53.49** row it omitted — the bracket's top member, whose native-box layout payload (VG 61.89) also refutes the old 'no non-ML local engine emits one' sentence; the Visual Grounding bullet now cites it as prior art. Comment/markdown-only; fmt + clippy (substitute-fonts) + doc -D warnings clean.