### PR TITLE
feat(core): expose the bleed, trim and art boxes on every page

### DIFF
--- a/crates/pdfboss-aio/src/document.rs
+++ b/crates/pdfboss-aio/src/document.rs
@@ -235,6 +235,13 @@ pub(crate) struct PageRecord {
     pub(crate) media_box: Option<pdfboss_core::Rect>,
     /// Inherited `/CropBox`, raw as above.
     pub(crate) crop_box: Option<pdfboss_core::Rect>,
+    /// Leaf `/BleedBox`, raw as above. Not inheritable (ISO 32000
+    /// §7.7.3.3, Table 30), so read from the leaf dictionary only.
+    pub(crate) bleed_box: Option<pdfboss_core::Rect>,
+    /// Leaf `/TrimBox`, raw as above.
+    pub(crate) trim_box: Option<pdfboss_core::Rect>,
+    /// Leaf `/ArtBox`, raw as above.
+    pub(crate) art_box: Option<pdfboss_core::Rect>,
     /// Inherited `/Rotate`, raw as above.
     pub(crate) rotate: Option<i32>,
 }
@@ -1401,6 +1408,9 @@ impl AsyncDocument {
             Some(record.resources),
             record.media_box,
             record.crop_box,
+            record.bleed_box,
+            record.trim_box,
+            record.art_box,
             record.rotate,
             record.dict,
             record.r,
@@ -1482,14 +1492,25 @@ impl AsyncDocument {
                         stack.push((kid.clone(), inherited.clone(), depth + 1));
                     }
                 }
-                None => pages.push(PageRecord {
-                    r: node_ref,
-                    dict: dict.clone(),
-                    resources: inherited.resources.clone(),
-                    media_box: inherited.media_box,
-                    crop_box: inherited.crop_box,
-                    rotate: inherited.rotate,
-                }),
+                None => {
+                    // BleedBox, TrimBox and ArtBox are not inheritable
+                    // (ISO 32000 §7.7.3.3, Table 30): read them from the
+                    // leaf dictionary only, mirroring the synchronous walk.
+                    let bleed_box = self.rect_value(dict, "BleedBox", &mut chain).await;
+                    let trim_box = self.rect_value(dict, "TrimBox", &mut chain).await;
+                    let art_box = self.rect_value(dict, "ArtBox", &mut chain).await;
+                    pages.push(PageRecord {
+                        r: node_ref,
+                        dict: dict.clone(),
+                        resources: inherited.resources.clone(),
+                        media_box: inherited.media_box,
+                        crop_box: inherited.crop_box,
+                        bleed_box,
+                        trim_box,
+                        art_box,
+                        rotate: inherited.rotate,
+                    });
+                }
             }
         }
         pages

--- a/crates/pdfboss-aio/tests/parity.rs
+++ b/crates/pdfboss-aio/tests/parity.rs
@@ -265,15 +265,40 @@ fn inherited_attrs_doc() -> Vec<u8> {
     b.build(1)
 }
 
+/// One page declaring `/BleedBox`, `/TrimBox` and `/ArtBox` on the leaf
+/// (with an indirect coordinate), one declaring none, and a `/TrimBox` on
+/// the `/Pages` node that must NOT leak down: the boxes are not in ISO
+/// 32000-1 Table 30's inheritable set, so both walks must read them from
+/// the leaf dictionary only.
+fn page_boxes_doc() -> Vec<u8> {
+    let mut b = PdfBuilder::new();
+    b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+    b.object(
+        2,
+        "<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 \
+         /MediaBox [0 0 600 800] /TrimBox [1 1 2 2] >>",
+    );
+    b.object(
+        3,
+        "<< /Type /Page /Parent 2 0 R /CropBox [50 50 550 750] \
+         /BleedBox [40 40 560 760] /TrimBox [60 70 540 5 0 R] \
+         /ArtBox [100 100 700 700] >>",
+    );
+    b.object(4, "<< /Type /Page /Parent 2 0 R >>");
+    b.object(5, "730");
+    b.build(1)
+}
+
 /// Every page attribute the two APIs hand out must be identical: media box,
-/// crop box, rotation, size, object reference and dictionary. The fixture
-/// declares everything on `/Pages` nodes, so a traversal that fails to
-/// inherit reports US Letter for an A4 page — silently, which is why this
-/// compares every field rather than probing one.
+/// crop box, bleed/trim/art boxes, rotation, size, object reference and
+/// dictionary. The fixture declares everything on `/Pages` nodes, so a
+/// traversal that fails to inherit reports US Letter for an A4 page —
+/// silently, which is why this compares every field rather than probing one.
 #[tokio::test]
 async fn pages_agree_with_the_sync_document() {
     let mut cases = fixtures();
     cases.push(("inherited_attrs", inherited_attrs_doc()));
+    cases.push(("page_boxes", page_boxes_doc()));
     for (name, bytes) in cases {
         let sync_doc = Document::load(bytes.clone()).expect("sync load");
         let async_doc = AsyncDocument::from_bytes(bytes).await.expect("async open");
@@ -287,6 +312,9 @@ async fn pages_agree_with_the_sync_document() {
             let a = async_doc.page(i).expect("async page");
             assert_eq!(s.media_box, a.media_box, "{name} page {i}: media box");
             assert_eq!(s.crop_box, a.crop_box, "{name} page {i}: crop box");
+            assert_eq!(s.bleed_box, a.bleed_box, "{name} page {i}: bleed box");
+            assert_eq!(s.trim_box, a.trim_box, "{name} page {i}: trim box");
+            assert_eq!(s.art_box, a.art_box, "{name} page {i}: art box");
             assert_eq!(s.rotate, a.rotate, "{name} page {i}: rotation");
             assert_eq!(s.size(), a.size(), "{name} page {i}: size");
             assert_eq!(

--- a/crates/pdfboss-core/src/document.rs
+++ b/crates/pdfboss-core/src/document.rs
@@ -79,6 +79,9 @@ struct PageRec {
     obj_ref: Option<ObjRef>,
     media_box: Rect,
     crop_box: Rect,
+    bleed_box: Rect,
+    trim_box: Rect,
+    art_box: Rect,
     rotate: i32,
     resources: Dict,
     dict: Dict,
@@ -447,6 +450,9 @@ impl Document {
             index,
             media_box: rec.media_box,
             crop_box: rec.crop_box,
+            bleed_box: rec.bleed_box,
+            trim_box: rec.trim_box,
+            art_box: rec.art_box,
             rotate: rec.rotate,
             resources: rec.resources.clone(),
             dict: rec.dict.clone(),
@@ -558,7 +564,22 @@ impl Document {
                         stack.push((kid.clone(), inherited.clone(), depth + 1));
                     }
                 }
-                None => pages.push(make_page_rec(node_ref, dict.clone(), &inherited)),
+                None => {
+                    // BleedBox, TrimBox and ArtBox are not inheritable
+                    // (ISO 32000 §7.7.3.3, Table 30): read them from the
+                    // leaf dictionary only.
+                    let bleed = self.rect_value(dict, "BleedBox");
+                    let trim = self.rect_value(dict, "TrimBox");
+                    let art = self.rect_value(dict, "ArtBox");
+                    pages.push(make_page_rec(
+                        node_ref,
+                        dict.clone(),
+                        &inherited,
+                        bleed,
+                        trim,
+                        art,
+                    ));
+                }
             }
         }
         pages
@@ -684,12 +705,22 @@ where
 /// attributes. The defaults live in [`Page::from_tree_attrs`] — the one
 /// implementation of page defaulting, shared with the asynchronous API —
 /// and this only reshapes its output into the index-less cache record.
-fn make_page_rec(obj_ref: Option<ObjRef>, dict: Dict, inherited: &Inherited) -> PageRec {
+fn make_page_rec(
+    obj_ref: Option<ObjRef>,
+    dict: Dict,
+    inherited: &Inherited,
+    bleed_box: Option<Rect>,
+    trim_box: Option<Rect>,
+    art_box: Option<Rect>,
+) -> PageRec {
     let page = Page::from_tree_attrs(
         0,
         inherited.resources.clone(),
         inherited.media_box,
         inherited.crop_box,
+        bleed_box,
+        trim_box,
+        art_box,
         inherited.rotate,
         dict,
         obj_ref,
@@ -698,6 +729,9 @@ fn make_page_rec(obj_ref: Option<ObjRef>, dict: Dict, inherited: &Inherited) -> 
         obj_ref: page.obj_ref,
         media_box: page.media_box,
         crop_box: page.crop_box,
+        bleed_box: page.bleed_box,
+        trim_box: page.trim_box,
+        art_box: page.art_box,
         rotate: page.rotate,
         resources: page.resources,
         dict: page.dict,
@@ -765,17 +799,25 @@ pub struct Metadata {
 ///
 /// Defaults: `media_box` falls back to US Letter (612x792) when absent or
 /// invalid, `crop_box` falls back to (and is intersected with) `media_box`,
-/// and `rotate` is normalized to one of {0, 90, 180, 270}. Every construction
-/// path normalizes `rotate` — [`Document::page`] and [`Page::from_parts`]
-/// alike — so the invariant holds however a `Page` was built. `rotate` is a
-/// public field, so a caller may still overwrite it afterwards; [`Page::size`]
+/// `bleed_box`, `trim_box` and `art_box` fall back to `crop_box` (and are
+/// clipped to `media_box`) per ISO 32000 §14.11.2, and `rotate` is
+/// normalized to one of {0, 90, 180, 270}. Every construction path
+/// normalizes `rotate` — [`Document::page`] and [`Page::from_parts`] alike —
+/// so the invariant holds however a `Page` was built. `rotate` is a public
+/// field, so a caller may still overwrite it afterwards; [`Page::size`]
 /// reads it modulo a full turn and so stays correct if they do.
+///
+/// All five boxes are in unrotated PDF user space: [`Page::size`] swaps
+/// width and height under a quarter-turn `/Rotate`, the boxes never do.
 #[derive(Clone)]
 pub struct Page {
     /// 0-based page index.
     pub index: usize,
     pub media_box: Rect,
     pub crop_box: Rect,
+    pub bleed_box: Rect,
+    pub trim_box: Rect,
+    pub art_box: Rect,
     pub rotate: i32,
     /// The page's (inherited) `/Resources` dictionary.
     pub resources: Dict,
@@ -797,6 +839,10 @@ impl Page {
     /// reduced, and a value that is not a multiple of 90 falls back to 0
     /// (lenient). The caller does not have to pre-normalize, and the [`Page`]
     /// invariant holds whichever constructor built it.
+    ///
+    /// `bleed_box`, `trim_box` and `art_box` are set to `crop_box` — their
+    /// ISO 32000 §14.11.2 default. A caller that resolved real values
+    /// overwrites the public fields afterwards.
     pub fn from_parts(
         index: usize,
         media_box: Rect,
@@ -810,6 +856,9 @@ impl Page {
             index,
             media_box,
             crop_box,
+            bleed_box: crop_box,
+            trim_box: crop_box,
+            art_box: crop_box,
             rotate: normalize_rotation(rotate),
             resources,
             dict,
@@ -825,10 +874,11 @@ impl Page {
 
     /// Builds a page from raw, possibly missing page-tree attributes,
     /// applying the same defaults [`Document::page`] applies (ISO 32000
-    /// §7.7.3.3): a missing or degenerate `/MediaBox` reads as
+    /// §7.7.3.3, §14.11.2): a missing or degenerate `/MediaBox` reads as
     /// [`Page::US_LETTER`], `/CropBox` clips to the media box and falls back
-    /// to it, a missing `/Rotate` reads as 0 and is normalized, and missing
-    /// `/Resources` read as empty.
+    /// to it, `/BleedBox`, `/TrimBox` and `/ArtBox` clip to the media box
+    /// and fall back to the crop box, a missing `/Rotate` reads as 0 and is
+    /// normalized, and missing `/Resources` read as empty.
     ///
     /// This is the one implementation of page defaulting. The synchronous
     /// tree walk routes through it, and a caller that resolved inheritance
@@ -836,11 +886,15 @@ impl Page {
     /// page tree while reading it — gets the identical `Page` back, so the
     /// two APIs cannot disagree about what an attribute-less page looks
     /// like.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_tree_attrs(
         index: usize,
         resources: Option<Dict>,
         media_box: Option<Rect>,
         crop_box: Option<Rect>,
+        bleed_box: Option<Rect>,
+        trim_box: Option<Rect>,
+        art_box: Option<Rect>,
         rotate: Option<i32>,
         dict: Dict,
         obj_ref: Option<ObjRef>,
@@ -852,10 +906,19 @@ impl Page {
             .and_then(|c| c.intersect(media_box))
             .filter(|r| r.width() > 0.0 && r.height() > 0.0)
             .unwrap_or(media_box);
+        let clip = |declared: Option<Rect>| {
+            declared
+                .and_then(|b| b.intersect(media_box))
+                .filter(|r| r.width() > 0.0 && r.height() > 0.0)
+                .unwrap_or(crop_box)
+        };
         Page {
             index,
             media_box,
             crop_box,
+            bleed_box: clip(bleed_box),
+            trim_box: clip(trim_box),
+            art_box: clip(art_box),
             rotate: normalize_rotation(rotate.unwrap_or(0)),
             resources: resources.unwrap_or_default(),
             dict,
@@ -1404,6 +1467,92 @@ mod tests {
     }
 
     #[test]
+    fn page_boxes_declared_and_defaulted() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 800] \
+             /CropBox [50 50 550 750] /BleedBox [40 40 560 760] \
+             /TrimBox [5 0 R 6 0 R 7 0 R 8 0 R] >>",
+        );
+        b.object(4, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 800] >>");
+        b.object(5, "60");
+        b.object(6, "70");
+        b.object(7, "540");
+        b.object(8, "730");
+        let doc = Document::load(b.build(1)).unwrap();
+
+        let page = doc.page(0).unwrap();
+        assert_eq!(page.bleed_box, Rect::new(40.0, 40.0, 560.0, 760.0));
+        assert_eq!(
+            page.trim_box,
+            Rect::new(60.0, 70.0, 540.0, 730.0),
+            "indirect array elements resolve"
+        );
+        assert_eq!(
+            page.art_box, page.crop_box,
+            "undeclared box is the crop box"
+        );
+
+        let bare = doc.page(1).unwrap();
+        assert_eq!(bare.bleed_box, bare.crop_box);
+        assert_eq!(bare.trim_box, bare.crop_box);
+        assert_eq!(bare.art_box, bare.crop_box);
+    }
+
+    #[test]
+    fn page_boxes_clip_to_media_and_fall_back() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+             /CropBox [10 10 190 190] /TrimBox [100 100 400 400] \
+             /BleedBox [0 0 0 0] /ArtBox [300 300 400 400] >>",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+
+        let page = doc.page(0).unwrap();
+        assert_eq!(
+            page.trim_box,
+            Rect::new(100.0, 100.0, 200.0, 200.0),
+            "a trim box past the media box clips to it"
+        );
+        assert_eq!(
+            page.bleed_box, page.crop_box,
+            "a degenerate bleed box falls back to the crop box"
+        );
+        assert_eq!(
+            page.art_box, page.crop_box,
+            "an art box disjoint from the media box falls back to the crop box"
+        );
+    }
+
+    /// `/BleedBox`, `/TrimBox` and `/ArtBox` are not in ISO 32000 Table 30's
+    /// inheritable set: a value on a `/Pages` node must not leak into its
+    /// leaves, which read their spec default (the crop box) instead.
+    #[test]
+    fn page_boxes_are_not_inherited() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(
+            2,
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 \
+             /TrimBox [10 10 90 90] /BleedBox [5 5 95 95] /ArtBox [20 20 80 80] >>",
+        );
+        b.object(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] >>");
+        let doc = Document::load(b.build(1)).unwrap();
+
+        let page = doc.page(0).unwrap();
+        assert_eq!(page.trim_box, page.crop_box);
+        assert_eq!(page.bleed_box, page.crop_box);
+        assert_eq!(page.art_box, page.crop_box);
+    }
+
+    #[test]
     fn kids_cycle_truncates_without_hanging() {
         let mut b = PdfBuilder::new();
         b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
@@ -1830,6 +1979,10 @@ mod tests {
         assert_eq!(page.dict(), &dict);
         // /Rotate 90 swaps the reported page size.
         assert_eq!(page.size(), (400.0, 200.0));
+        // The boxes from_parts does not take read as their spec default.
+        assert_eq!(page.bleed_box, page.crop_box);
+        assert_eq!(page.trim_box, page.crop_box);
+        assert_eq!(page.art_box, page.crop_box);
     }
 
     /// `from_parts` normalizes `/Rotate` just as the page tree does, so an

--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -110,6 +110,12 @@ fn version_string(version: (u8, u8)) -> String {
     format!("{}.{}", version.0, version.1)
 }
 
+/// Flattens a core [`Rect`](pdfboss_core::Rect) to the `(x0, y0, x1, y1)`
+/// tuple the page-box getters return.
+fn rect_tuple(r: pdfboss_core::Rect) -> (f32, f32, f32, f32) {
+    (r.x0, r.y0, r.x1, r.y1)
+}
+
 /// Converts a core [`Object`] to plain Python data: dict/list/str/bytes/
 /// int/float/bool/None. Names become `str`; strings decode as UTF-8 where
 /// valid, else stay `bytes`; streams become `{"dict": ..., "length": n}`
@@ -546,6 +552,37 @@ impl Page {
     #[getter]
     fn rotation(&self) -> i32 {
         self.page.rotate
+    }
+
+    /// The media box `(x0, y0, x1, y1)` in unrotated PDF user space;
+    /// US Letter (0, 0, 612, 792) when the file declares none.
+    #[getter]
+    fn media_box(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.page.media_box)
+    }
+
+    /// The crop box, clipped to the media box; defaults to the media box.
+    #[getter]
+    fn crop_box(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.page.crop_box)
+    }
+
+    /// The bleed box, clipped to the media box; defaults to the crop box.
+    #[getter]
+    fn bleed_box(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.page.bleed_box)
+    }
+
+    /// The trim box, clipped to the media box; defaults to the crop box.
+    #[getter]
+    fn trim_box(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.page.trim_box)
+    }
+
+    /// The art box, clipped to the media box; defaults to the crop box.
+    #[getter]
+    fn art_box(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.page.art_box)
     }
 
     /// Extracts the page's text. Releases the GIL and runs on a private
@@ -1154,6 +1191,37 @@ impl AsyncPage {
     #[getter]
     fn rotation(&self) -> i32 {
         self.page.rotate
+    }
+
+    /// The media box `(x0, y0, x1, y1)` in unrotated PDF user space;
+    /// US Letter (0, 0, 612, 792) when the file declares none.
+    #[getter]
+    fn media_box(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.page.media_box)
+    }
+
+    /// The crop box, clipped to the media box; defaults to the media box.
+    #[getter]
+    fn crop_box(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.page.crop_box)
+    }
+
+    /// The bleed box, clipped to the media box; defaults to the crop box.
+    #[getter]
+    fn bleed_box(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.page.bleed_box)
+    }
+
+    /// The trim box, clipped to the media box; defaults to the crop box.
+    #[getter]
+    fn trim_box(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.page.trim_box)
+    }
+
+    /// The art box, clipped to the media box; defaults to the crop box.
+    #[getter]
+    fn art_box(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.page.art_box)
     }
 
     /// Extracts the page's text. Coroutine resolving to str.

--- a/python/pdfboss/_pdfboss.pyi
+++ b/python/pdfboss/_pdfboss.pyi
@@ -144,6 +144,32 @@ class Page:
     def rotation(self) -> int:
         """Page rotation in degrees: 0, 90, 180 or 270."""
 
+    @property
+    def media_box(self) -> tuple[float, float, float, float]:
+        """The media box ``(x0, y0, x1, y1)`` in unrotated PDF user space
+        — ``width``/``height`` swap under ``rotation``, the boxes never do.
+        US Letter ``(0, 0, 612, 792)`` when the file declares none."""
+
+    @property
+    def crop_box(self) -> tuple[float, float, float, float]:
+        """The crop box, clipped to the media box; defaults to the media
+        box."""
+
+    @property
+    def bleed_box(self) -> tuple[float, float, float, float]:
+        """The bleed box, clipped to the media box; defaults to the crop
+        box."""
+
+    @property
+    def trim_box(self) -> tuple[float, float, float, float]:
+        """The trim box, clipped to the media box; defaults to the crop
+        box."""
+
+    @property
+    def art_box(self) -> tuple[float, float, float, float]:
+        """The art box, clipped to the media box; defaults to the crop
+        box."""
+
     def extract_text(self) -> str:
         """Extracts the page's text."""
 
@@ -265,6 +291,32 @@ class AsyncPage:
     def height(self) -> float: ...
     @property
     def rotation(self) -> int: ...
+    @property
+    def media_box(self) -> tuple[float, float, float, float]:
+        """The media box ``(x0, y0, x1, y1)`` in unrotated PDF user space
+        — ``width``/``height`` swap under ``rotation``, the boxes never do.
+        US Letter ``(0, 0, 612, 792)`` when the file declares none."""
+
+    @property
+    def crop_box(self) -> tuple[float, float, float, float]:
+        """The crop box, clipped to the media box; defaults to the media
+        box."""
+
+    @property
+    def bleed_box(self) -> tuple[float, float, float, float]:
+        """The bleed box, clipped to the media box; defaults to the crop
+        box."""
+
+    @property
+    def trim_box(self) -> tuple[float, float, float, float]:
+        """The trim box, clipped to the media box; defaults to the crop
+        box."""
+
+    @property
+    def art_box(self) -> tuple[float, float, float, float]:
+        """The art box, clipped to the media box; defaults to the crop
+        box."""
+
     async def extract_text(self) -> str: ...
     async def extract_markdown(self) -> str: ...
     async def render(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,3 +31,33 @@ def shapes_pdf(fixtures_dir: Path) -> Path:
 @pytest.fixture
 def xref_stream_pdf(fixtures_dir: Path) -> Path:
     return fixtures_dir / "xref-stream.pdf"
+
+
+@pytest.fixture
+def boxed_pdf() -> bytes:
+    """A one-page PDF declaring /CropBox, /BleedBox and /TrimBox but no
+    /ArtBox, built in memory with a correct classic xref table."""
+    objects = {
+        1: b"<< /Type /Catalog /Pages 2 0 R >>",
+        2: b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        3: (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 800] "
+            b"/CropBox [50 50 550 750] /BleedBox [40 40 560 760] "
+            b"/TrimBox [60 70 540 730] >>"
+        ),
+    }
+    out = bytearray(b"%PDF-1.7\n")
+    offsets = {}
+    for num, body in sorted(objects.items()):
+        offsets[num] = len(out)
+        out += b"%d 0 obj\n%s\nendobj\n" % (num, body)
+    xref_at = len(out)
+    out += b"xref\n0 %d\n" % (len(objects) + 1)
+    out += b"0000000000 65535 f \n"
+    for num in sorted(objects):
+        out += b"%010d 00000 n \n" % offsets[num]
+    out += b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n" % (
+        len(objects) + 1,
+        xref_at,
+    )
+    return bytes(out)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -97,6 +97,18 @@ class TestAsyncDocumentQueries:
         )
         assert [d.page_count for d in docs] == [1, 3]
 
+    @pytest.mark.asyncio
+    async def test_page_boxes_match_sync(self, boxed_pdf: bytes) -> None:
+        sync_page = Document(data=boxed_pdf)[0]
+        page = (await AsyncDocument.from_bytes(boxed_pdf))[0]
+        assert page.media_box == sync_page.media_box
+        assert page.crop_box == sync_page.crop_box
+        assert page.bleed_box == sync_page.bleed_box
+        assert page.trim_box == sync_page.trim_box
+        assert page.art_box == sync_page.art_box
+        assert page.trim_box == pytest.approx((60.0, 70.0, 540.0, 730.0))
+        assert page.art_box == page.crop_box, "undeclared art box is the crop box"
+
 
 def element_key(element: Element) -> tuple[object, ...]:
     """A comparable identity for an element (everything but value())."""

--- a/tests/test_pdfboss.py
+++ b/tests/test_pdfboss.py
@@ -217,6 +217,24 @@ class TestPageGeometry:
         assert page.rotation in (0, 90, 180, 270)
 
 
+class TestPageBoxes:
+    def test_undeclared_boxes_fall_back_per_spec(self, hello_pdf: Path) -> None:
+        page = Document(str(hello_pdf))[0]
+        assert page.media_box == pytest.approx((0.0, 0.0, 612.0, 792.0))
+        assert page.crop_box == page.media_box
+        assert page.bleed_box == page.crop_box
+        assert page.trim_box == page.crop_box
+        assert page.art_box == page.crop_box
+
+    def test_declared_boxes_are_reported(self, boxed_pdf: bytes) -> None:
+        page = Document(data=boxed_pdf)[0]
+        assert page.media_box == pytest.approx((0.0, 0.0, 600.0, 800.0))
+        assert page.crop_box == pytest.approx((50.0, 50.0, 550.0, 750.0))
+        assert page.bleed_box == pytest.approx((40.0, 40.0, 560.0, 760.0))
+        assert page.trim_box == pytest.approx((60.0, 70.0, 540.0, 730.0))
+        assert page.art_box == page.crop_box, "undeclared art box is the crop box"
+
+
 class TestRender:
     def test_render_returns_png_bytes(self, hello_pdf: Path) -> None:
         png = Document(str(hello_pdf))[0].render()


### PR DESCRIPTION
`Page` gains `bleed_box`, `trim_box` and `art_box` as effective public fields next to `media_box` and `crop_box`, defaulted in `Page::from_tree_attrs` — the one implementation of page defaulting — per ISO 32000 §14.11.2: clipped to the media box, falling back to the crop box. The boxes are not inheritable (§7.7.3.3 Table 30), so both tree walks read them from the leaf dictionary only; the async document threads them through `PageRecord` into the same constructor, so the sync and async APIs cannot disagree. The Python bindings expose all five boxes as `(x0, y0, x1, y1)` getters on both `Page` and `AsyncPage`, with matching stubs. All boxes are in unrotated user space — `width`/`height` swap under `/Rotate`, the boxes never do.

`from_parts` keeps its signature: the three boxes it does not take read as their spec default (the crop box), and the public fields are the escape hatch for callers that resolved real values. Nothing on the render or extraction path changes.

Verification (controller-run): `cargo test --workspace` 1895 passed / 0 failed (42 suites) and `cargo fmt --check` clean on the final tree; clippy (default and `substitute-fonts`) and `RUSTDOCFLAGS="-D warnings" cargo doc` clean on the pre-reflow tree (the reflow was whitespace in one test; CI re-runs the full set). New tests confirmed by name: `page_boxes_declared_and_defaulted`, `page_boxes_clip_to_media_and_fall_back`, `page_boxes_are_not_inherited` (core), box assertions + a non-inheritance fixture in `pages_agree_with_the_sync_document` (aio parity). pytest 121/121 against a provenance-checked wheel built from this tree, including declared/defaulted sync tests and an async-vs-sync box parity test.