### PR TITLE
feat(text): expose styled spans with bbox, decorations, color and page

### DIFF
--- a/crates/pdfboss-aio/tests/parity.rs
+++ b/crates/pdfboss-aio/tests/parity.rs
@@ -355,7 +355,8 @@ async fn shared_algorithms_run_over_the_async_document() {
         let doc = async_doc.clone();
         let handle = tokio::spawn(async move {
             let page = doc.page(i).expect("async page");
-            let text = pdfboss_output::extract_text_with(doc.clone(), &page)
+            let oc = doc.oc_state().await;
+            let text = pdfboss_output::extract_text_with(doc.clone(), &page, oc.as_ref())
                 .await
                 .expect("async text");
             let opts = pdfboss_render::RenderOptions {
@@ -468,7 +469,8 @@ async fn encrypted_documents_decrypt_identically() {
     let sync_page = sync_doc.page(0).expect("sync page");
     let async_page = async_doc.page(0).expect("async page");
     let sync_text = pdfboss_output::extract_text(&sync_doc, &sync_page).expect("sync text");
-    let async_text = pdfboss_output::extract_text_with(async_doc.clone(), &async_page)
+    let oc = async_doc.oc_state().await;
+    let async_text = pdfboss_output::extract_text_with(async_doc.clone(), &async_page, oc.as_ref())
         .await
         .expect("async text");
     assert_eq!(sync_text, "Top secret message");
@@ -479,8 +481,9 @@ async fn encrypted_documents_decrypt_identically() {
 
     // Markdown extraction over the same encrypted content agrees too.
     let sync_md = pdfboss_output::extract_page_markdown(&sync_doc, &sync_page).expect("sync md");
-    let async_md = pdfboss_output::extract_page_markdown_with(async_doc.clone(), &async_page)
-        .await
-        .expect("async md");
+    let async_md =
+        pdfboss_output::extract_page_markdown_with(async_doc.clone(), &async_page, oc.as_ref())
+            .await
+            .expect("async md");
     assert_eq!(sync_md, async_md, "markdown agrees on encrypted files");
 }

--- a/crates/pdfboss-cli/src/input.rs
+++ b/crates/pdfboss-cli/src/input.rs
@@ -118,10 +118,15 @@ impl Input {
             Input::Remote { rt, doc } => {
                 let page = doc.page(index).map_err(|e| e.to_string())?;
                 let (spans, rulings, _) = rt
-                    .block_on(pdfboss_text::extract_spans_and_rulings_reporting_with(
-                        doc.clone(),
-                        &page,
-                    ))
+                    .block_on(async {
+                        let oc = doc.oc_state().await;
+                        pdfboss_text::extract_spans_and_rulings_reporting_with(
+                            doc.clone(),
+                            &page,
+                            oc.as_ref(),
+                        )
+                        .await
+                    })
                     .map_err(|e| e.to_string())?;
                 Ok((spans, rulings))
             }

--- a/crates/pdfboss-output/src/lib.rs
+++ b/crates/pdfboss-output/src/lib.rs
@@ -6,7 +6,7 @@ mod markdown;
 mod output;
 mod structure;
 
-use pdfboss_core::{AsyncObjectSource, Document, Page, Result};
+use pdfboss_core::{AsyncObjectSource, Document, OcState, Page, Result};
 
 pub use ir::{BBox, Block, Cell, Inline, Line, ListItem, Marker, PageLayout, Role};
 pub use markdown::Markdown;
@@ -37,17 +37,21 @@ pub fn extract_text(doc: &Document, page: &Page) -> Result<String> {
 }
 
 /// [`extract_text`] against any object source, awaiting whatever I/O the
-/// source needs to read the page — the same span extraction and layout,
-/// minus the document's optional-content configuration, which a bare
-/// source cannot supply: every layer extracts here.
+/// source needs to read the page — the same span extraction and layout.
+/// `oc` is the document's optional-content visibility (the async document's
+/// `oc_state()`); `None` extracts every layer.
 ///
 /// The source is taken by value and the page by reference. That combination is
 /// what a consumer needs to spawn the result: the future is `Send` over a source
 /// that is `Send + Sync`, and `'static` as long as the borrow of `page` is
 /// created inside the consumer's own `async move` block, which owns the page.
 /// See `pdfboss_core::source`'s "Signing a shared algorithm".
-pub async fn extract_text_with<S: AsyncObjectSource>(src: S, page: &Page) -> Result<String> {
-    let (text, _) = extract_text_reporting_with(src, page).await?;
+pub async fn extract_text_with<S: AsyncObjectSource>(
+    src: S,
+    page: &Page,
+    oc: Option<&OcState>,
+) -> Result<String> {
+    let (text, _) = extract_text_reporting_with(src, page, oc).await?;
     Ok(text)
 }
 
@@ -62,13 +66,13 @@ pub fn extract_text_reporting(doc: &Document, page: &Page) -> Result<(String, Ex
 }
 
 /// [`extract_text_reporting`] against any object source. Signed like
-/// [`extract_text_with`], for the same reasons — every optional-content
-/// layer included.
+/// [`extract_text_with`], for the same reasons — `oc` gating included.
 pub async fn extract_text_reporting_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
+    oc: Option<&OcState>,
 ) -> Result<(String, ExtractReport)> {
-    let (spans, report) = pdfboss_text::extract_spans_reporting_with(src, page).await?;
+    let (spans, report) = pdfboss_text::extract_spans_reporting_with(src, page, oc).await?;
     Ok((Text.render(&[page_layout(&spans)]), report))
 }
 
@@ -135,8 +139,7 @@ pub fn extract_page_markdown(doc: &Document, page: &Page) -> Result<String> {
 }
 
 /// [`extract_page_markdown`] against any object source. Signed like
-/// [`extract_text_with`], for the same reasons — every optional-content
-/// layer included.
+/// [`extract_text_with`], for the same reasons — `oc` gating included.
 ///
 /// There is no document-level `_with`: an asynchronous caller collects each
 /// page's spans and rulings with
@@ -146,9 +149,10 @@ pub fn extract_page_markdown(doc: &Document, page: &Page) -> Result<String> {
 pub async fn extract_page_markdown_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
+    oc: Option<&OcState>,
 ) -> Result<String> {
     let (spans, rulings, _) =
-        pdfboss_text::extract_spans_and_rulings_reporting_with(src, page).await?;
+        pdfboss_text::extract_spans_and_rulings_reporting_with(src, page, oc).await?;
     Ok(Markdown.render(&[page_layout_with_rulings(&spans, &rulings)]))
 }
 
@@ -1185,6 +1189,7 @@ mod tests {
                     payload: Vec::new(),
                 },
                 &text_page,
+                None,
             )
             .await
         };

--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -23,8 +23,9 @@ use pdfboss_core::elements::{Element as CoreElement, ElementOpts, Elements, Xref
 use pdfboss_core::Document as CoreDocument;
 use pdfboss_core::Metadata as CoreMetadata;
 use pdfboss_core::Page as CorePage;
-use pdfboss_core::{Dict, DocumentSeed, ObjRef, Object};
+use pdfboss_core::{Dict, DocumentSeed, ObjRef, Object, OcState};
 use pdfboss_output::Output;
+use pdfboss_text::{FontCache, TextSpan};
 
 create_exception!(
     pdfboss,
@@ -516,6 +517,28 @@ impl Document {
         };
         ElementIter { doc, iter }
     }
+
+    /// Lazily iterates the document's styled text spans, page by page:
+    /// every page's, or the 0-based `pages` given, in the order given.
+    /// Each step releases the GIL, runs on a private materialization of
+    /// the document, and shares one font cache across the walk, so a font
+    /// loads once for the document.
+    #[pyo3(signature = (pages=None))]
+    fn spans(&self, pages: Option<Vec<usize>>) -> SpanIter {
+        let (seed, count) = {
+            let doc = self.inner.lock();
+            (doc.seed(), doc.page_count())
+        };
+        let pages = pages.unwrap_or_else(|| (0..count).collect());
+        SpanIter {
+            state: Mutex::new(SpanIterState {
+                seed,
+                fonts: FontCache::default(),
+                pages: pages.into_iter(),
+                buffer: Vec::new().into_iter(),
+            }),
+        }
+    }
 }
 
 /// A single page of a document.
@@ -605,6 +628,18 @@ impl Page {
         })
     }
 
+    /// The page's styled text spans, in emission order. Releases the GIL
+    /// and runs on a private materialization of the document, like
+    /// `extract_text`. Lenient the same way: unreadable content yields no
+    /// spans rather than raising.
+    fn spans(&self, py: Python<'_>) -> PyResult<Vec<Span>> {
+        py.allow_threads(|| {
+            let doc = CoreDocument::from_seed(self.seed.clone());
+            let spans = pdfboss_text::extract_spans(&doc, &self.page).map_err(pdf_err)?;
+            Ok(spans.into_iter().map(|inner| Span { inner }).collect())
+        })
+    }
+
     /// Renders the page and returns PNG bytes. Releases the GIL while the
     /// rasterization and PNG encoding run, on a private materialization of
     /// the document — no lock is held, so renders called from multiple
@@ -666,6 +701,192 @@ impl Page {
             ))
         })?;
         Ok((PyBytes::new(py, &png), warnings))
+    }
+}
+
+/// One styled text span: a positioned run of text with everything the
+/// file states about how it is shown — font, size, weight and slant,
+/// drawn underline/strikethrough, fill color, visibility, writing mode.
+#[pyclass(frozen)]
+struct Span {
+    inner: TextSpan,
+}
+
+#[pymethods]
+impl Span {
+    /// The decoded text.
+    #[getter]
+    fn text(&self) -> &str {
+        &self.inner.text
+    }
+
+    /// Device-space x coordinate of the span origin.
+    #[getter]
+    fn x(&self) -> f32 {
+        self.inner.x
+    }
+
+    /// Device-space y coordinate of the span baseline.
+    #[getter]
+    fn y(&self) -> f32 {
+        self.inner.y
+    }
+
+    /// Device-space x after the last glyph's advance.
+    #[getter]
+    fn end_x(&self) -> f32 {
+        self.inner.end_x
+    }
+
+    /// Effective font size.
+    #[getter]
+    fn size(&self) -> f32 {
+        self.inner.size
+    }
+
+    /// Font resource name (e.g. "F1").
+    #[getter]
+    fn font(&self) -> &str {
+        &self.inner.font
+    }
+
+    /// The font's /BaseFont name verbatim — subset prefix included —
+    /// falling back to the FontDescriptor's /FontName; empty when the
+    /// file names the font nowhere.
+    #[getter]
+    fn font_name(&self) -> &str {
+        &self.inner.font_name
+    }
+
+    /// 0-based index of the page the span came from.
+    #[getter]
+    fn page(&self) -> usize {
+        self.inner.page
+    }
+
+    /// Device-space box `(x0, y0, x1, y1)`, y-up: origin to advance
+    /// horizontally, the font's descent..ascent vertically.
+    #[getter]
+    fn bbox(&self) -> (f32, f32, f32, f32) {
+        rect_tuple(self.inner.bbox)
+    }
+
+    /// Bold, from FontDescriptor evidence with BaseFont-name fallback.
+    #[getter]
+    fn bold(&self) -> bool {
+        self.inner.bold
+    }
+
+    /// Italic, from FontDescriptor evidence with BaseFont-name fallback.
+    #[getter]
+    fn italic(&self) -> bool {
+        self.inner.italic
+    }
+
+    /// FontDescriptor /Flags FixedPitch.
+    #[getter]
+    fn monospace(&self) -> bool {
+        self.inner.monospace
+    }
+
+    /// FontDescriptor /Flags Serif.
+    #[getter]
+    fn serif(&self) -> bool {
+        self.inner.serif
+    }
+
+    /// A drawn ruling sits just below the baseline covering most of the
+    /// span. Read from the page's geometry — PDF has no underline
+    /// attribute — so a table border hugging a cell's text can read as
+    /// one.
+    #[getter]
+    fn underline(&self) -> bool {
+        self.inner.underline
+    }
+
+    /// A drawn ruling crosses the span's x-height band — geometry-read,
+    /// like `underline`.
+    #[getter]
+    fn strikethrough(&self) -> bool {
+        self.inner.strikethrough
+    }
+
+    /// The text rise (Ts) the span was shown under: positive above the
+    /// baseline — a superscript/subscript signal.
+    #[getter]
+    fn rise(&self) -> f32 {
+        self.inner.rise
+    }
+
+    /// Writing mode 1: the text advances downward.
+    #[getter]
+    fn vertical(&self) -> bool {
+        self.inner.vertical
+    }
+
+    /// Shown under render mode 3 or 7, which paint nothing — the shape of
+    /// an OCR text layer under a scanned image.
+    #[getter]
+    fn invisible(&self) -> bool {
+        self.inner.invisible
+    }
+
+    /// Fill color as RGB in [0, 1]; None for pattern fills, which have no
+    /// single color.
+    #[getter]
+    fn color(&self) -> Option<(f32, f32, f32)> {
+        self.inner.color
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Span(page={}, text={:?}, font_name={:?})",
+            self.inner.page, self.inner.text, self.inner.font_name
+        )
+    }
+}
+
+/// Lazy sync iterator over a document's styled spans, returned by
+/// `Document.spans()`. Buffers one page's spans at a time; each page is
+/// extracted with the GIL released on a private materialization of the
+/// document, with one font cache shared across the walk.
+#[pyclass(frozen)]
+struct SpanIter {
+    state: Mutex<SpanIterState>,
+}
+
+struct SpanIterState {
+    seed: DocumentSeed,
+    fonts: FontCache,
+    pages: std::vec::IntoIter<usize>,
+    buffer: std::vec::IntoIter<TextSpan>,
+}
+
+#[pymethods]
+impl SpanIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(&self, py: Python<'_>) -> PyResult<Option<Span>> {
+        let state = &self.state;
+        py.allow_threads(|| {
+            let mut state = state.lock().unwrap_or_else(PoisonError::into_inner);
+            loop {
+                if let Some(span) = state.buffer.next() {
+                    return Ok(Some(Span { inner: span }));
+                }
+                let Some(index) = state.pages.next() else {
+                    return Ok(None);
+                };
+                let doc = CoreDocument::from_seed(state.seed.clone());
+                let page = doc.page(index).map_err(pdf_err)?;
+                let (spans, _) =
+                    pdfboss_text::extract_spans_reporting_cached(&doc, &page, &state.fonts)
+                        .map_err(pdf_err)?;
+                state.buffer = spans.into_iter();
+            }
+        })
     }
 }
 
@@ -978,13 +1199,14 @@ impl AsyncDocument {
     fn extract_text<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let oc = inner.oc_state().await;
             let mut out = String::new();
             for i in 0..inner.page_count() {
                 if i > 0 {
                     out.push('\u{c}');
                 }
                 let page = inner.page(i).map_err(aio_err)?;
-                let text = pdfboss_output::extract_text_with(inner.clone(), &page)
+                let text = pdfboss_output::extract_text_with(inner.clone(), &page, oc.as_ref())
                     .await
                     .map_err(pdf_err)?;
                 out.push_str(&text);
@@ -1000,13 +1222,17 @@ impl AsyncDocument {
     fn extract_markdown<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let oc = inner.oc_state().await;
             let mut pages = Vec::new();
             for i in 0..inner.page_count() {
                 let page = inner.page(i).map_err(aio_err)?;
-                let (spans, rulings, _) =
-                    pdfboss_text::extract_spans_and_rulings_reporting_with(inner.clone(), &page)
-                        .await
-                        .map_err(pdf_err)?;
+                let (spans, rulings, _) = pdfboss_text::extract_spans_and_rulings_reporting_with(
+                    inner.clone(),
+                    &page,
+                    oc.as_ref(),
+                )
+                .await
+                .map_err(pdf_err)?;
                 pages.push((spans, rulings));
             }
             Ok(pdfboss_output::Markdown
@@ -1154,6 +1380,26 @@ impl AsyncDocument {
             stream: Arc::new(tokio::sync::Mutex::new(self.inner.elements(opts))),
         }
     }
+
+    /// Streams the document's styled text spans page by page — the async
+    /// twin of `Document.spans`, over range-fetching reads; use with
+    /// `async for`. Every page's, or the 0-based `pages` given, in the
+    /// order given, with one font cache shared across the walk.
+    #[pyo3(signature = (pages=None))]
+    fn spans(&self, pages: Option<Vec<usize>>) -> AsyncSpanIter {
+        let doc = self.inner.clone();
+        let pages = pages.unwrap_or_else(|| (0..doc.page_count()).collect());
+        AsyncSpanIter {
+            state: Arc::new(tokio::sync::Mutex::new(AsyncSpanIterState {
+                doc,
+                fonts: FontCache::default(),
+                oc: None,
+                oc_loaded: false,
+                pages: pages.into_iter(),
+                buffer: Vec::new().into_iter(),
+            })),
+        }
+    }
 }
 
 /// A single page of an async document. Attributes are synchronous — the
@@ -1229,7 +1475,8 @@ impl AsyncPage {
         let doc = self.doc.clone();
         let page = self.page.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            pdfboss_output::extract_text_with(doc, &page)
+            let oc = doc.oc_state().await;
+            pdfboss_output::extract_text_with(&doc, &page, oc.as_ref())
                 .await
                 .map_err(pdf_err)
         })
@@ -1241,9 +1488,27 @@ impl AsyncPage {
         let doc = self.doc.clone();
         let page = self.page.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            pdfboss_output::extract_page_markdown_with(doc, &page)
+            let oc = doc.oc_state().await;
+            pdfboss_output::extract_page_markdown_with(&doc, &page, oc.as_ref())
                 .await
                 .map_err(pdf_err)
+        })
+    }
+
+    /// The page's styled text spans — the async twin of `Page.spans`.
+    /// Coroutine resolving to a list of `Span`.
+    fn spans<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let doc = self.doc.clone();
+        let page = self.page.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let oc = doc.oc_state().await;
+            let spans = pdfboss_text::extract_spans_with(&doc, &page, oc.as_ref())
+                .await
+                .map_err(pdf_err)?;
+            Ok(spans
+                .into_iter()
+                .map(|inner| Span { inner })
+                .collect::<Vec<Span>>())
         })
     }
 
@@ -1341,6 +1606,64 @@ impl AsyncElementIter {
     }
 }
 
+/// Async iterator over a document's styled spans, returned by
+/// `AsyncDocument.spans()`. Buffers one page's spans at a time; each
+/// `__anext__` is a coroutine driving the shared extraction over the
+/// async document's range-fetching reads, with one font cache — and the
+/// document's optional-content state, loaded once — shared across the
+/// walk.
+#[pyclass(frozen)]
+struct AsyncSpanIter {
+    state: Arc<tokio::sync::Mutex<AsyncSpanIterState>>,
+}
+
+struct AsyncSpanIterState {
+    doc: AioDocument,
+    fonts: FontCache,
+    oc: Option<OcState>,
+    oc_loaded: bool,
+    pages: std::vec::IntoIter<usize>,
+    buffer: std::vec::IntoIter<TextSpan>,
+}
+
+#[pymethods]
+impl AsyncSpanIter {
+    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// Coroutine resolving to the next Span; raises StopAsyncIteration
+    /// when the walk is exhausted.
+    fn __anext__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut state = state.lock().await;
+            if !state.oc_loaded {
+                state.oc = state.doc.oc_state().await;
+                state.oc_loaded = true;
+            }
+            loop {
+                if let Some(span) = state.buffer.next() {
+                    return Ok(Span { inner: span });
+                }
+                let Some(index) = state.pages.next() else {
+                    return Err(PyStopAsyncIteration::new_err("span walk exhausted"));
+                };
+                let page = state.doc.page(index).map_err(aio_err)?;
+                let (spans, _) = pdfboss_text::extract_spans_reporting_cached_with(
+                    state.doc.clone(),
+                    &page,
+                    &state.fonts,
+                    state.oc.as_ref(),
+                )
+                .await
+                .map_err(pdf_err)?;
+                state.buffer = spans.into_iter();
+            }
+        })
+    }
+}
+
 #[pymodule]
 fn _pdfboss(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
@@ -1352,6 +1675,9 @@ fn _pdfboss(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ElementIter>()?;
     m.add_class::<AsyncDocument>()?;
     m.add_class::<AsyncElementIter>()?;
+    m.add_class::<Span>()?;
+    m.add_class::<SpanIter>()?;
+    m.add_class::<AsyncSpanIter>()?;
     Ok(())
 }
 
@@ -1409,6 +1735,9 @@ mod tests {
         assert_send_sync::<super::ElementIter>();
         assert_send_sync::<super::AsyncDocument>();
         assert_send_sync::<super::AsyncElementIter>();
+        assert_send_sync::<super::Span>();
+        assert_send_sync::<super::SpanIter>();
+        assert_send_sync::<super::AsyncSpanIter>();
     }
 
     #[test]

--- a/crates/pdfboss-text/src/extract.rs
+++ b/crates/pdfboss-text/src/extract.rs
@@ -6,7 +6,7 @@ use crate::{Ruling, TextSpan};
 use pdfboss_core::content::{parse_content, Op, TextItem};
 use pdfboss_core::{
     content_stream_data_with, page_content_with, AsyncObjectSource, Dict, Matrix, Name, ObjRef,
-    Object, OcState, Page, Point,
+    Object, OcState, Page, Point, Rect,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -221,7 +221,58 @@ pub async fn page_spans_and_rulings_with<S: AsyncObjectSource>(
         0,
     );
     exec.run(root).await;
-    (exec.spans, exec.rulings, exec.report)
+    let mut spans = exec.spans;
+    for span in &mut spans {
+        span.page = page.index;
+        mark_underline_and_strikethrough(span, &exec.rulings);
+    }
+    (spans, exec.rulings, exec.report)
+}
+
+/// How far below the baseline (in fractions of the effective size) an
+/// underline may sit, and the slack above it for lines drawn exactly on
+/// the baseline.
+const UNDERLINE_BELOW: f32 = 0.3;
+const UNDERLINE_ABOVE: f32 = 0.05;
+
+/// The x-height band (in fractions of the effective size above the
+/// baseline) a strikethrough crosses.
+const STRIKETHROUGH_LOW: f32 = 0.15;
+const STRIKETHROUGH_HIGH: f32 = 0.6;
+
+/// The fraction of a span's width a ruling must cover to decorate it: a
+/// neighbour's underline running past a word boundary is not this span's.
+const DECORATED_MIN_OVERLAP: f32 = 0.6;
+
+/// Sets `underline`/`strikethrough` from the page's horizontal rulings:
+/// underline when one sits just below the baseline covering most of the
+/// span, strikethrough when one crosses the x-height band. Vertical
+/// writing is left unmarked — its decorations are vertical lines beside
+/// the text, which are indistinguishable from column rules here.
+fn mark_underline_and_strikethrough(span: &mut TextSpan, rulings: &[Ruling]) {
+    if span.vertical || span.size <= 0.0 {
+        return;
+    }
+    let width = span.bbox.x1 - span.bbox.x0;
+    if width <= 0.0 {
+        return;
+    }
+    for r in rulings {
+        if r.start.y != r.end.y {
+            continue;
+        }
+        let overlap = r.end.x.min(span.bbox.x1) - r.start.x.max(span.bbox.x0);
+        if overlap < DECORATED_MIN_OVERLAP * width {
+            continue;
+        }
+        let above = r.start.y - span.y;
+        if above >= -UNDERLINE_BELOW * span.size && above <= UNDERLINE_ABOVE * span.size {
+            span.underline = true;
+        }
+        if above >= STRIKETHROUGH_LOW * span.size && above <= STRIKETHROUGH_HIGH * span.size {
+            span.strikethrough = true;
+        }
+    }
 }
 
 /// The graphics-state parameters text extraction cares about. Saved and
@@ -238,6 +289,10 @@ struct GState {
     font: Option<Arc<Font>>,
     font_name: String,
     size: f32,
+    /// `Tr` (ISO 32000-1 Table 106); modes 3 and 7 paint nothing.
+    render_mode: i32,
+    /// Fill color as RGB; `None` inside a pattern fill.
+    fill_color: Option<(f32, f32, f32)>,
     /// `w` and ExtGState `/LW`; scales rulings' stroke width.
     line_width: f32,
 }
@@ -254,8 +309,33 @@ impl GState {
             font: None,
             font_name: String::new(),
             size: 0.0,
+            render_mode: 0,
+            fill_color: Some((0.0, 0.0, 0.0)),
             line_width: 1.0,
         }
+    }
+}
+
+/// Reads color components by count — 1 gray, 3 RGB, 4 CMYK, clamped to
+/// `[0, 1]` — the approximation span colors carry for spaces whose
+/// transform extraction does not run. Any other count is no color.
+fn components_color(comps: &[f32]) -> Option<(f32, f32, f32)> {
+    let c = |v: f32| {
+        if v.is_finite() {
+            v.clamp(0.0, 1.0)
+        } else {
+            0.0
+        }
+    };
+    match comps {
+        [v] => Some((c(*v), c(*v), c(*v))),
+        [r, g, b] => Some((c(*r), c(*g), c(*b))),
+        [cy, m, y, k] => Some((
+            (1.0 - c(*cy)) * (1.0 - c(*k)),
+            (1.0 - c(*m)) * (1.0 - c(*k)),
+            (1.0 - c(*y)) * (1.0 - c(*k)),
+        )),
+        _ => None,
     }
 }
 
@@ -728,6 +808,26 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             Op::SetHorizScaling(v) => frame.gs.horiz_scale = v / 100.0,
             Op::SetLeading(v) => frame.gs.leading = *v,
             Op::SetTextRise(v) => frame.gs.rise = *v,
+            Op::SetTextRender(mode) => frame.gs.render_mode = *mode,
+            Op::SetFillGray(v) => frame.gs.fill_color = components_color(&[*v]),
+            Op::SetFillRGB(r, g, b) => frame.gs.fill_color = components_color(&[*r, *g, *b]),
+            Op::SetFillCMYK(c, m, y, k) => {
+                frame.gs.fill_color = components_color(&[*c, *m, *y, *k])
+            }
+            // Selecting a fill space resets the fill color to the space's
+            // initial color (ISO 32000-1 §8.6.8): black everywhere but
+            // Pattern, which has no single color.
+            Op::SetFillColorSpace(name) => {
+                frame.gs.fill_color = (name.0 != "Pattern").then_some((0.0, 0.0, 0.0));
+            }
+            Op::SetFillColor(comps) => frame.gs.fill_color = components_color(comps),
+            Op::SetFillColorN(comps, pattern) => {
+                frame.gs.fill_color = if pattern.is_some() {
+                    None
+                } else {
+                    components_color(comps)
+                };
+            }
             Op::TextMove(tx, ty) => {
                 frame.tlm = Matrix::translate(*tx, *ty).concat(frame.tlm);
                 frame.tm = frame.tlm;
@@ -924,15 +1024,42 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             }
         }
         let end = tm.concat(gs.ctm).apply(Point { x: 0.0, y: gs.rise });
+        let size = if size.is_finite() { size } else { 0.0 };
+        let bbox = if font.vertical {
+            Rect {
+                x0: origin.x - size / 2.0,
+                y0: origin.y.min(end.y),
+                x1: origin.x + size / 2.0,
+                y1: origin.y.max(end.y),
+            }
+        } else {
+            Rect {
+                x0: origin.x.min(end.x),
+                y0: origin.y + font.descent / 1000.0 * size,
+                x1: origin.x.max(end.x),
+                y1: origin.y + font.ascent / 1000.0 * size,
+            }
+        };
         (!text.is_empty() && origin.x.is_finite() && origin.y.is_finite()).then(|| TextSpan {
             text,
             x: origin.x,
             y: origin.y,
             end_x: end.x,
-            size: if size.is_finite() { size } else { 0.0 },
+            size,
+            bbox,
             font: gs.font_name.clone(),
+            font_name: font.base_name.clone(),
+            page: 0,
             bold: font.bold,
             italic: font.italic,
+            monospace: font.monospace,
+            serif: font.serif,
+            rise: gs.rise,
+            vertical: font.vertical,
+            invisible: matches!(gs.render_mode, 3 | 7),
+            color: gs.fill_color,
+            underline: false,
+            strikethrough: false,
         })
     }
 

--- a/crates/pdfboss-text/src/font.rs
+++ b/crates/pdfboss-text/src/font.rs
@@ -73,6 +73,32 @@ pub struct Font {
     /// BaseFont-name substrings as fallback.
     pub bold: bool,
     pub italic: bool,
+    /// `/BaseFont` verbatim — subset prefix included — falling back to the
+    /// FontDescriptor's `/FontName`; empty when the file states neither.
+    pub base_name: String,
+    /// Upper edge of the em box in per-mille units: `/Ascent`, else
+    /// `/CapHeight`, else 800.
+    pub ascent: f32,
+    /// Lower edge of the em box in per-mille units, never positive:
+    /// `/Descent`, else -200.
+    pub descent: f32,
+    /// FontDescriptor `/Flags` FixedPitch (ISO 32000-1 Table 123 bit 1).
+    pub monospace: bool,
+    /// FontDescriptor `/Flags` Serif (ISO 32000-1 Table 123 bit 2).
+    pub serif: bool,
+}
+
+/// Everything [`Font::style`] reads in one descriptor pass: the font's
+/// stated name, the weight/slant evidence, and the vertical metrics
+/// extraction turns into span boxes.
+struct Style {
+    name: String,
+    bold: bool,
+    italic: bool,
+    ascent: f32,
+    descent: f32,
+    monospace: bool,
+    serif: bool,
 }
 
 /// One `/Encoding` table cell. Base-table entries and most `/Differences`
@@ -127,6 +153,11 @@ impl Font {
             winansi_high_codes: false,
             bold: false,
             italic: false,
+            base_name: String::new(),
+            ascent: 800.0,
+            descent: -200.0,
+            monospace: false,
+            serif: false,
         }
     }
 
@@ -400,26 +431,61 @@ impl Font {
     /// already-resolved descendant dict for Type0 — refining the guess with
     /// `/Flags`, `/FontWeight`, and `/ItalicAngle` (ISO 32000-1 §9.8.1,
     /// Table 123).
-    async fn style<S: AsyncObjectSource>(
-        src: &S,
-        dict: &Dict,
-        descriptor_holder: &Dict,
-    ) -> (bool, bool) {
+    async fn style<S: AsyncObjectSource>(src: &S, dict: &Dict, descriptor_holder: &Dict) -> Style {
         let name = rv(src, dict, "BaseFont")
             .await
             .and_then(|o| o.as_name().map(|n| n.0.clone()))
             .unwrap_or_default();
-        let mut bold = name.contains("Bold");
-        let mut italic = name.contains("Italic") || name.contains("Oblique");
+        let mut style = Style {
+            bold: name.contains("Bold"),
+            italic: name.contains("Italic") || name.contains("Oblique"),
+            name,
+            ascent: 800.0,
+            descent: -200.0,
+            monospace: false,
+            serif: false,
+        };
         let Some(descriptor) = rv(src, descriptor_holder, "FontDescriptor")
             .await
             .and_then(|o| o.as_dict().cloned())
         else {
-            return (bold, italic);
+            return style;
         };
+        if style.name.is_empty() {
+            style.name = rv(src, &descriptor, "FontName")
+                .await
+                .and_then(|o| o.as_name().map(|n| n.0.clone()))
+                .unwrap_or_default();
+        }
+        let ascent = match rv(src, &descriptor, "Ascent")
+            .await
+            .and_then(|o| o.as_f64())
+        {
+            Some(a) if a != 0.0 => Some(a),
+            _ => rv(src, &descriptor, "CapHeight")
+                .await
+                .and_then(|o| o.as_f64())
+                .filter(|c| *c != 0.0),
+        };
+        if let Some(a) = ascent {
+            style.ascent = a as f32;
+        }
+        if let Some(d) = rv(src, &descriptor, "Descent")
+            .await
+            .and_then(|o| o.as_f64())
+            .filter(|d| *d != 0.0)
+        {
+            // Stated as negative (ISO 32000-1 Table 122); some producers
+            // write the magnitude.
+            style.descent = -(d as f32).abs();
+        }
+        let mut bold = style.bold;
+        let mut italic = style.italic;
         if let Some(flags) = rv(src, &descriptor, "Flags").await.and_then(|o| o.as_int()) {
             italic = italic || flags & (1 << 6) != 0; // Table 123 bit 7: Italic
             bold = bold || flags & (1 << 18) != 0; // Table 123 bit 19: ForceBold
+            style.monospace = flags & 1 != 0; // Table 123 bit 1: FixedPitch
+            style.serif = flags & 2 != 0; // Table 123 bit 2: Serif
         }
         if let Some(weight) = rv(src, &descriptor, "FontWeight")
             .await
@@ -440,7 +506,9 @@ impl Font {
         {
             italic = italic || angle != 0.0;
         }
-        (bold, italic)
+        style.bold = bold;
+        style.italic = italic;
+        style
     }
 
     /// Loads a Type1/TrueType/Type3 font: 1-byte codes, `/Encoding` base
@@ -482,7 +550,7 @@ impl Font {
         // Only a font that states no `/Encoding` has anything to gain here, and
         // only then is the embedded program worth inflating.
         let winansi_high_codes = encoding.is_none() && Font::built_for_windows(src, dict).await;
-        let (bold, italic) = Font::style(src, dict, dict).await;
+        let style = Font::style(src, dict, dict).await;
 
         Font {
             simple: true,
@@ -498,8 +566,13 @@ impl Font {
             default_vwidth: -1000.0,
             space_code: Some(32),
             winansi_high_codes,
-            bold,
-            italic,
+            bold: style.bold,
+            italic: style.italic,
+            base_name: style.name,
+            ascent: style.ascent,
+            descent: style.descent,
+            monospace: style.monospace,
+            serif: style.serif,
         }
     }
 
@@ -659,7 +732,7 @@ impl Font {
         // (ISO 32000-1 §9.7.4); reuse the dict just resolved above rather
         // than resolving /DescendantFonts a second time.
         let descriptor_holder = descendant.as_ref().unwrap_or(dict);
-        let (bold, italic) = Font::style(src, dict, descriptor_holder).await;
+        let style = Font::style(src, dict, descriptor_holder).await;
 
         let space_code = encoding
             .cmap
@@ -684,8 +757,13 @@ impl Font {
             space_code,
             // Composite codes never reach the single-byte fallbacks.
             winansi_high_codes: false,
-            bold,
-            italic,
+            bold: style.bold,
+            italic: style.italic,
+            base_name: style.name,
+            ascent: style.ascent,
+            descent: style.descent,
+            monospace: style.monospace,
+            serif: style.serif,
         }
     }
 

--- a/crates/pdfboss-text/src/lib.rs
+++ b/crates/pdfboss-text/src/lib.rs
@@ -6,10 +6,10 @@ mod extract;
 mod font;
 mod sfnt;
 
-use pdfboss_core::{block_on, AsyncObjectSource, Document, Immediate, Page, Result};
+use pdfboss_core::{block_on, AsyncObjectSource, Document, Immediate, OcState, Page, Result};
 
 pub use extract::{ExtractReport, FontCache, SkipCause, SkippedText, SkippedTextKind};
-pub use pdfboss_core::Point;
+pub use pdfboss_core::{Point, Rect};
 
 /// A positioned run of extracted text.
 #[derive(Debug, Clone, PartialEq)]
@@ -26,6 +26,18 @@ pub struct TextSpan {
     pub size: f32,
     /// Font resource name.
     pub font: String,
+    /// The font's `/BaseFont` name verbatim — subset prefix included —
+    /// falling back to the FontDescriptor's `/FontName`; empty when the
+    /// file names the font nowhere (a missing font resource included).
+    pub font_name: String,
+    /// 0-based index of the page the span came from.
+    pub page: usize,
+    /// Device-space box: origin to advance horizontally, the font's
+    /// `/Descent`..`/Ascent` (per-mille of the effective size) vertically.
+    /// Exact for unrotated horizontal text, an approximation under rotated
+    /// matrices; vertical writing takes the advance as its vertical extent
+    /// and half the size to each side of the baseline.
+    pub bbox: Rect,
     /// Whether the font that produced this span is bold: FontDescriptor
     /// `/FontWeight` >= 600, `/Flags` ForceBold, or a `/StemV` in bold
     /// stem-width territory, else a `Bold` substring
@@ -35,6 +47,32 @@ pub struct TextSpan {
     /// `/Flags` Italic or a nonzero `/ItalicAngle`, else an `Italic` or
     /// `Oblique` substring in `/BaseFont` (ISO 32000-1 Table 123).
     pub italic: bool,
+    /// FontDescriptor `/Flags` FixedPitch (ISO 32000-1 Table 123 bit 1).
+    pub monospace: bool,
+    /// FontDescriptor `/Flags` Serif (ISO 32000-1 Table 123 bit 2).
+    pub serif: bool,
+    /// The text rise (`Ts`) the span was shown under, in unscaled text
+    /// space: positive above the baseline — a superscript/subscript
+    /// signal. The origin already includes the shift.
+    pub rise: f32,
+    /// Writing mode 1: the text advances downward and `bbox` takes the
+    /// advance as its vertical extent.
+    pub vertical: bool,
+    /// Shown under render mode 3 or 7 (ISO 32000-1 Table 106), which paint
+    /// nothing — the shape of an OCR text layer under a scanned image.
+    pub invisible: bool,
+    /// The fill color the span was shown with, as RGB in `[0, 1]`. Device
+    /// gray/RGB/CMYK convert exactly; other spaces' components are read by
+    /// count (1 gray, 3 RGB, 4 CMYK) without running the space's
+    /// transform. `None` for pattern fills, which have no single color.
+    pub color: Option<(f32, f32, f32)>,
+    /// A drawn ruling sits just below the baseline and covers most of the
+    /// span. PDF has no underline attribute — this is read from the page's
+    /// geometry, so a table border hugging a cell's text can read as one.
+    pub underline: bool,
+    /// A drawn ruling crosses the span's x-height band — geometry-read,
+    /// like `underline`.
+    pub strikethrough: bool,
 }
 
 /// An axis-aligned line segment a page draws, in the same y-up user space as
@@ -63,8 +101,8 @@ pub struct Ruling {
 /// Content in optional-content layers the document's default configuration
 /// turns off (ISO 32000-1 §8.11) is excluded, counted in
 /// [`ExtractReport::hidden`]. The document-level entry points here read
-/// that configuration themselves; the source-generic `_with` twins have no
-/// document to read it from and extract every layer.
+/// that configuration themselves; the source-generic `_with` twins take it
+/// as their `oc` parameter (`None` extracts every layer).
 pub fn extract_spans(doc: &Document, page: &Page) -> Result<Vec<TextSpan>> {
     let oc = doc.oc_state();
     let (spans, _, _) = block_on(extract::page_spans_and_rulings_with(
@@ -80,9 +118,11 @@ pub fn extract_spans(doc: &Document, page: &Page) -> Result<Vec<TextSpan>> {
 /// source needs to read the page.
 ///
 /// This is the shared implementation [`extract_spans`] drives over
-/// [`Immediate`] on the calling thread; the one thing the document-level
-/// entry adds is the document's optional-content configuration, which a
-/// bare source cannot supply — this function extracts every layer.
+/// [`Immediate`] on the calling thread. `oc` is the document's
+/// optional-content visibility — `Document::oc_state` sync, the async
+/// document's `oc_state()` over a range-fetching source — and gates hidden
+/// layers exactly as the document-level entry does; `None` extracts every
+/// layer.
 ///
 /// The source is taken by value and the page by reference. That combination is
 /// what a consumer needs to spawn the result: the future is `Send` over a source
@@ -92,8 +132,9 @@ pub fn extract_spans(doc: &Document, page: &Page) -> Result<Vec<TextSpan>> {
 pub async fn extract_spans_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
+    oc: Option<&OcState>,
 ) -> Result<Vec<TextSpan>> {
-    let (spans, _, _) = extract::page_spans_and_rulings_with(src, page, None, None).await;
+    let (spans, _, _) = extract::page_spans_and_rulings_with(src, page, None, oc).await;
     Ok(spans)
 }
 
@@ -117,13 +158,13 @@ pub fn extract_spans_reporting(
 }
 
 /// [`extract_spans_reporting`] against any object source. Signed like
-/// [`extract_spans_with`], for the same reasons — including extracting
-/// every optional-content layer, which a bare source cannot gate.
+/// [`extract_spans_with`], for the same reasons — `oc` gating included.
 pub async fn extract_spans_reporting_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
+    oc: Option<&OcState>,
 ) -> Result<(Vec<TextSpan>, ExtractReport)> {
-    let (spans, _, report) = extract::page_spans_and_rulings_with(src, page, None, None).await;
+    let (spans, _, report) = extract::page_spans_and_rulings_with(src, page, None, oc).await;
     Ok((spans, report))
 }
 
@@ -153,15 +194,14 @@ pub fn extract_spans_reporting_cached(
 }
 
 /// [`extract_spans_reporting_cached`] against any object source. Signed like
-/// [`extract_spans_with`], for the same reasons — including extracting
-/// every optional-content layer, which a bare source cannot gate.
+/// [`extract_spans_with`], for the same reasons — `oc` gating included.
 pub async fn extract_spans_reporting_cached_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
     fonts: &FontCache,
+    oc: Option<&OcState>,
 ) -> Result<(Vec<TextSpan>, ExtractReport)> {
-    let (spans, _, report) =
-        extract::page_spans_and_rulings_with(src, page, Some(fonts), None).await;
+    let (spans, _, report) = extract::page_spans_and_rulings_with(src, page, Some(fonts), oc).await;
     Ok((spans, report))
 }
 
@@ -184,14 +224,13 @@ pub fn extract_spans_and_rulings_reporting(
 }
 
 /// [`extract_spans_and_rulings_reporting`] against any object source. Signed
-/// like [`extract_spans_with`], for the same reasons — including extracting
-/// every optional-content layer, which a bare source cannot gate.
+/// like [`extract_spans_with`], for the same reasons — `oc` gating included.
 pub async fn extract_spans_and_rulings_reporting_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
+    oc: Option<&OcState>,
 ) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
-    let (spans, rulings, report) =
-        extract::page_spans_and_rulings_with(src, page, None, None).await;
+    let (spans, rulings, report) = extract::page_spans_and_rulings_with(src, page, None, oc).await;
     Ok((spans, rulings, report))
 }
 
@@ -217,15 +256,16 @@ pub fn extract_spans_and_rulings_reporting_cached(
 }
 
 /// [`extract_spans_and_rulings_reporting_cached`] against any object source.
-/// Signed like [`extract_spans_with`], for the same reasons — including
-/// extracting every optional-content layer, which a bare source cannot gate.
+/// Signed like [`extract_spans_with`], for the same reasons — `oc` gating
+/// included.
 pub async fn extract_spans_and_rulings_reporting_cached_with<S: AsyncObjectSource>(
     src: S,
     page: &Page,
     fonts: &FontCache,
+    oc: Option<&OcState>,
 ) -> Result<(Vec<TextSpan>, Vec<Ruling>, ExtractReport)> {
     let (spans, rulings, report) =
-        extract::page_spans_and_rulings_with(src, page, Some(fonts), None).await;
+        extract::page_spans_and_rulings_with(src, page, Some(fonts), oc).await;
     Ok((spans, rulings, report))
 }
 
@@ -315,6 +355,419 @@ mod tests {
         assert_eq!(spans[0].text, "top");
         assert_eq!(spans[1].text, "bottom");
         assert!(spans.iter().all(|s| s.size > 0.0 && s.x >= 0.0));
+    }
+
+    /// `font_name` carries the file's `/BaseFont` verbatim — subset prefix
+    /// included — while `font` stays the resource name.
+    #[test]
+    fn span_font_name_is_the_base_font_verbatim() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td (x) Tj ET");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /ABCDEF+Times-Roman \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert_eq!(spans[0].font_name, "ABCDEF+Times-Roman");
+        assert_eq!(spans[0].font, "F1");
+    }
+
+    /// A font dictionary with no `/BaseFont` falls back to the descriptor's
+    /// `/FontName`; a missing or unloadable font resource yields an empty
+    /// name.
+    #[test]
+    fn span_font_name_falls_back_to_descriptor_font_name() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R /F2 7 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td (a) Tj /F2 12 Tf (b) Tj ET");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /Encoding /WinAnsiEncoding \
+             /FontDescriptor 6 0 R >>",
+        );
+        b.object(6, "<< /Type /FontDescriptor /FontName /Nameless-Face >>");
+        b.object(
+            7,
+            "<< /Type /Font /Subtype /Type1 /Encoding /WinAnsiEncoding >>",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert_eq!(spans[0].font_name, "Nameless-Face");
+        assert_eq!(spans[1].font_name, "");
+    }
+
+    /// Every span names the 0-based page it came from.
+    #[test]
+    fn span_carries_its_page_index() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 7 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td (one) Tj ET");
+        b.object(
+            5,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 7 0 R >> >> /Contents 6 0 R >>",
+        );
+        b.stream(6, "", b"BT /F1 12 Tf 72 720 Td (two) Tj ET");
+        b.object(
+            7,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        for index in 0..2 {
+            let page = doc.page(index).unwrap();
+            let spans = extract_spans(&doc, &page).unwrap();
+            assert_eq!(spans[0].page, index, "page {index}");
+        }
+    }
+
+    /// The bbox spans origin to advance horizontally and the descriptor's
+    /// `/Descent`..`/Ascent` vertically, both scaled by the effective size.
+    #[test]
+    fn span_bbox_uses_descriptor_metrics() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td (Hi) Tj ET");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding /FontDescriptor 6 0 R >>",
+        );
+        b.object(
+            6,
+            "<< /Type /FontDescriptor /FontName /Helvetica \
+             /Ascent 718 /Descent -207 >>",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        let s = &spans[0];
+        assert!((s.bbox.x0 - s.x).abs() < 1e-3);
+        assert!((s.bbox.x1 - s.end_x).abs() < 1e-3);
+        assert!((s.bbox.y0 - (720.0 - 0.207 * 12.0)).abs() < 1e-3);
+        assert!((s.bbox.y1 - (720.0 + 0.718 * 12.0)).abs() < 1e-3);
+    }
+
+    /// Without a descriptor the vertical extent falls back to 0.8 em above
+    /// and 0.2 em below the baseline.
+    #[test]
+    fn span_bbox_defaults_to_em_fractions() {
+        let doc = Document::load(simple_doc("Hi")).unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        let s = &spans[0];
+        assert!((s.bbox.y0 - (720.0 - 0.2 * 12.0)).abs() < 1e-3);
+        assert!((s.bbox.y1 - (720.0 + 0.8 * 12.0)).abs() < 1e-3);
+    }
+
+    /// A descriptor stating `/CapHeight` but no `/Ascent` uses it for the
+    /// upper edge.
+    #[test]
+    fn span_bbox_falls_back_to_cap_height() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td (Hi) Tj ET");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding /FontDescriptor 6 0 R >>",
+        );
+        b.object(
+            6,
+            "<< /Type /FontDescriptor /FontName /Helvetica /CapHeight 700 >>",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert!((spans[0].bbox.y1 - (720.0 + 0.7 * 12.0)).abs() < 1e-3);
+        assert!((spans[0].bbox.y0 - (720.0 - 0.2 * 12.0)).abs() < 1e-3);
+    }
+
+    /// Table 123 bit 1 (FixedPitch) surfaces as `monospace`.
+    #[test]
+    fn fixed_pitch_flag_marks_monospace() {
+        let spans = flag_spans(1);
+        assert!(spans[0].monospace);
+        assert!(!spans[0].serif);
+    }
+
+    /// Table 123 bit 2 (Serif) surfaces as `serif`.
+    #[test]
+    fn serif_flag_marks_serif() {
+        let spans = flag_spans(2);
+        assert!(spans[0].serif);
+        assert!(!spans[0].monospace);
+    }
+
+    /// One page shown with a font whose descriptor states `/Flags flags`.
+    fn flag_spans(flags: u32) -> Vec<TextSpan> {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td (x) Tj ET");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Custom \
+             /Encoding /WinAnsiEncoding /FontDescriptor 6 0 R >>",
+        );
+        b.object(
+            6,
+            &format!("<< /Type /FontDescriptor /FontName /Custom /Flags {flags} >>"),
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        extract_spans(&doc, &page).unwrap()
+    }
+
+    /// The span records the text rise (`Ts`) it was shown under.
+    #[test]
+    fn span_carries_text_rise() {
+        let doc = Document::load(pdfboss_testkit::doc_with_graphics(
+            "BT /F1 12 Tf 72 720 Td (flat) Tj 5 Ts (up) Tj ET",
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert_eq!(spans[0].rise, 0.0);
+        assert_eq!(spans[1].rise, 5.0);
+    }
+
+    /// A writing-mode-1 (`Identity-V`) font marks its spans vertical.
+    #[test]
+    fn span_marks_vertical_writing() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F1 12 Tf 72 720 Td <0001> Tj ET");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type0 /BaseFont /X /Encoding /Identity-V \
+             /DescendantFonts [6 0 R] /ToUnicode 7 0 R >>",
+        );
+        b.object(
+            6,
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /X /DW 600 >>",
+        );
+        b.stream(
+            7,
+            "",
+            b"1 begincodespacerange <0000> <FFFF> endcodespacerange\n\
+              1 beginbfchar <0001> <0041> endbfchar",
+        );
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert!(spans[0].vertical);
+    }
+
+    /// Render modes 3 and 7 paint nothing (ISO 32000-1 Table 106) — the
+    /// shape of an OCR text layer — and mark the span invisible; a later
+    /// `Tr` back to a painting mode clears the mark.
+    #[test]
+    fn invisible_render_modes_mark_the_span() {
+        let doc = Document::load(pdfboss_testkit::doc_with_graphics(
+            "BT /F1 12 Tf 72 720 Td (seen) Tj 3 Tr (ocr) Tj 7 Tr (clip) Tj 0 Tr (back) Tj ET",
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        let invisible: Vec<bool> = spans.iter().map(|s| s.invisible).collect();
+        assert_eq!(invisible, [false, true, true, false]);
+    }
+
+    /// The fill color defaults to black (ISO 32000-1 §8.6.8).
+    #[test]
+    fn span_color_defaults_to_black() {
+        let doc = Document::load(simple_doc("Hi")).unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert_eq!(spans[0].color, Some((0.0, 0.0, 0.0)));
+    }
+
+    /// `rg`, `g` and `k` set the span color, CMYK and gray converted to RGB.
+    #[test]
+    fn device_fill_colors_set_the_span_color() {
+        let doc = Document::load(pdfboss_testkit::doc_with_graphics(
+            "BT /F1 12 Tf 72 720 Td 1 0 0 rg (red) Tj 0.5 g (gray) Tj \
+             1 0 0 0 k (cyan) Tj ET",
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert_eq!(spans[0].color, Some((1.0, 0.0, 0.0)));
+        assert_eq!(spans[1].color, Some((0.5, 0.5, 0.5)));
+        assert_eq!(spans[2].color, Some((0.0, 1.0, 1.0)));
+    }
+
+    /// `sc`/`scn` components are read by count — 1 gray, 3 RGB, 4 CMYK —
+    /// whatever the named space, the same approximation every extractor
+    /// makes without running the space's transform.
+    #[test]
+    fn sc_components_set_the_span_color_by_count() {
+        let doc = Document::load(pdfboss_testkit::doc_with_graphics(
+            "BT /F1 12 Tf 72 720 Td /DeviceRGB cs 0 1 0 sc (green) Tj \
+             0.25 sc (dark) Tj ET",
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert_eq!(spans[0].color, Some((0.0, 1.0, 0.0)));
+        assert_eq!(spans[1].color, Some((0.25, 0.25, 0.25)));
+    }
+
+    /// A pattern fill has no single color: the span says so with `None`
+    /// rather than guessing.
+    #[test]
+    fn pattern_fill_leaves_color_unknown() {
+        let doc = Document::load(pdfboss_testkit::doc_with_graphics(
+            "BT /F1 12 Tf 72 720 Td /Pattern cs /P1 scn (patterned) Tj ET",
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert_eq!(spans[0].color, None);
+    }
+
+    /// A ruling drawn just below the baseline, covering the span, reads as
+    /// an underline.
+    #[test]
+    fn an_underline_ruling_marks_the_span() {
+        let doc = Document::load(pdfboss_testkit::doc_with_graphics(
+            "BT /F1 12 Tf 72 720 Td (Hello) Tj ET 72 718.5 m 105 718.5 l S",
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert!(spans[0].underline);
+        assert!(!spans[0].strikethrough);
+    }
+
+    /// A ruling crossing the x-height band reads as a strikethrough.
+    #[test]
+    fn a_strikethrough_ruling_marks_the_span() {
+        let doc = Document::load(pdfboss_testkit::doc_with_graphics(
+            "BT /F1 12 Tf 72 720 Td (Hello) Tj ET 72 723.6 m 105 723.6 l S",
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert!(spans[0].strikethrough);
+        assert!(!spans[0].underline);
+    }
+
+    /// A ruling far from the baseline — a table border, a separator —
+    /// decorates nothing.
+    #[test]
+    fn a_distant_ruling_marks_nothing() {
+        let doc = Document::load(pdfboss_testkit::doc_with_graphics(
+            "BT /F1 12 Tf 72 720 Td (Hello) Tj ET 72 700 m 105 700 l S",
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert!(!spans[0].underline);
+        assert!(!spans[0].strikethrough);
+    }
+
+    /// A ruling at underline height that barely overlaps the span — a
+    /// neighbour's underline continuing past a word boundary does not
+    /// count; the mark needs most of the span covered.
+    #[test]
+    fn an_underline_needs_most_of_the_span_covered() {
+        let doc = Document::load(pdfboss_testkit::doc_with_graphics(
+            "BT /F1 12 Tf 72 720 Td (Hello) Tj ET 100 718.5 m 130 718.5 l S",
+        ))
+        .unwrap();
+        let page = doc.page(0).unwrap();
+        let spans = extract_spans(&doc, &page).unwrap();
+        assert!(!spans[0].underline);
+    }
+
+    /// The source-generic entry points take the optional-content state a
+    /// document-owning caller can read (`Document::oc_state`, or the async
+    /// document's `oc_state()`), so a hidden layer is excluded over any
+    /// source exactly as the document-level entries exclude it; `None`
+    /// still extracts every layer.
+    #[test]
+    fn the_source_generic_entry_points_honor_optional_content() {
+        let mut b = PdfBuilder::new();
+        b.object(
+            1,
+            "<< /Type /Catalog /Pages 2 0 R /OCProperties \
+             << /OCGs [6 0 R] /D << /OFF [6 0 R] >> >> >>",
+        );
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> \
+             /Properties << /H 6 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(
+            4,
+            "",
+            b"BT /F1 12 Tf 72 720 Td /OC /H BDC (hidden) Tj EMC (kept) Tj ET",
+        );
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding >>",
+        );
+        b.object(6, "<< /Type /OCG /Name (hidden) >>");
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let oc = doc.oc_state();
+        let gated = block_on(extract_spans_with(Immediate(&doc), &page, oc.as_ref())).unwrap();
+        let texts: Vec<&str> = gated.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(texts, ["kept"]);
+        let all = block_on(extract_spans_with(Immediate(&doc), &page, None)).unwrap();
+        let texts: Vec<&str> = all.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(texts, ["hidden", "kept"]);
     }
 
     /// FontDescriptor evidence: /Flags italic bit and /FontWeight.
@@ -528,7 +981,8 @@ mod tests {
         let doc = Document::load(b.build(1)).unwrap();
         let page = doc.page(0).unwrap();
         let counting = Counting::new(&doc);
-        let (spans, report) = block_on(extract_spans_reporting_with(&counting, &page)).unwrap();
+        let (spans, report) =
+            block_on(extract_spans_reporting_with(&counting, &page, None)).unwrap();
         assert!(report.is_complete(), "unexpected skips: {report:?}");
         assert_eq!(spans.len(), 2, "both form invocations must show text");
         assert_eq!(
@@ -570,7 +1024,7 @@ mod tests {
         for index in 0..2 {
             let page = doc.page(index).unwrap();
             let (spans, report) = block_on(extract_spans_reporting_cached_with(
-                &counting, &page, &fonts,
+                &counting, &page, &fonts, None,
             ))
             .unwrap();
             assert!(report.is_complete(), "unexpected skips: {report:?}");
@@ -696,6 +1150,7 @@ mod tests {
                     payload: Vec::new(),
                 },
                 &spans_page,
+                None,
             )
             .await
         };

--- a/crates/pdfboss-tui/src/lib.rs
+++ b/crates/pdfboss-tui/src/lib.rs
@@ -481,9 +481,12 @@ async fn extract_markdown(
     page: usize,
 ) {
     let result = match doc.page(page) {
-        Ok(page_object) => pdfboss_output::extract_page_markdown_with(doc, &page_object)
-            .await
-            .map_err(|error| error.to_string()),
+        Ok(page_object) => {
+            let oc = doc.oc_state().await;
+            pdfboss_output::extract_page_markdown_with(&doc, &page_object, oc.as_ref())
+                .await
+                .map_err(|error| error.to_string())
+        }
         Err(error) => Err(error.to_string()),
     };
     tx.send(Msg::MarkdownReady { generation, result }).ok();

--- a/python/pdfboss/__init__.py
+++ b/python/pdfboss/__init__.py
@@ -4,11 +4,14 @@ from pdfboss._pdfboss import (
     AsyncDocument,
     AsyncElementIter,
     AsyncPage,
+    AsyncSpanIter,
     Document,
     Element,
     ElementIter,
     Page,
     PdfError,
+    Span,
+    SpanIter,
     __version__,
 )
 
@@ -16,10 +19,13 @@ __all__ = [
     "AsyncDocument",
     "AsyncElementIter",
     "AsyncPage",
+    "AsyncSpanIter",
     "Document",
     "Element",
     "ElementIter",
     "Page",
     "PdfError",
+    "Span",
+    "SpanIter",
     "__version__",
 ]

--- a/python/pdfboss/_pdfboss.pyi
+++ b/python/pdfboss/_pdfboss.pyi
@@ -1,7 +1,14 @@
+"""Type stubs for the compiled extension module ``pdfboss._pdfboss``.
+
+The ``pdfboss`` package re-exports everything here; these stubs are the
+typed surface editors and type checkers see.
+"""
+
 import os
 from collections.abc import AsyncIterator, Iterator
 
 __version__: str
+"""The installed pdfboss version, e.g. ``"0.18.0"``."""
 
 class PdfError(Exception):
     """Raised for any PDF processing error.
@@ -18,13 +25,20 @@ class Element:
     or logical document structure.
     """
 
-    kind: str                      # "header" | "object" | "xref" | "trailer" |
-                                   # "startxref" | "eof" | "page" | "font" |
-                                   # "image" | "annotation" | "content_op"
-    span: tuple[int, int] | None   # physical byte range; for "content_op" the
-                                   # range within the page's decoded content stream
-    ref: tuple[int, int] | None    # (num, gen) where applicable
-    page: int | None               # logical elements
+    kind: str
+    """What the element is: ``"header"``, ``"object"``, ``"xref"``,
+    ``"trailer"``, ``"startxref"``, ``"eof"``, ``"page"``, ``"font"``,
+    ``"image"``, ``"annotation"`` or ``"content_op"``."""
+
+    span: tuple[int, int] | None
+    """Physical byte range in the file; for ``"content_op"`` the range
+    within the page's decoded content stream."""
+
+    ref: tuple[int, int] | None
+    """The element's ``(num, gen)`` object reference, where applicable."""
+
+    page: int | None
+    """The 0-based page index for logical elements, ``None`` otherwise."""
     def value(self) -> object:
         """Lazy conversion to plain Python data:
         dict/list/str/bytes/int/float/bool/None. PDF names -> str,
@@ -36,15 +50,139 @@ class ElementIter:
     """Lazy sync iterator over elements; each ``__next__`` releases the
     GIL while the next element is located and parsed."""
 
-    def __iter__(self) -> "ElementIter": ...
-    def __next__(self) -> Element: ...
+    def __iter__(self) -> "ElementIter":
+        """Returns the iterator itself."""
+
+    def __next__(self) -> Element:
+        """The next element; raises ``StopIteration`` when exhausted. A
+        per-item failure raises ``PdfError`` for that item and iteration
+        may be continued (salvage semantics)."""
 
 class AsyncElementIter:
     """Async iterator over elements; each ``__anext__`` is a coroutine
     driving the underlying stream, so the event loop is never blocked."""
 
-    def __aiter__(self) -> "AsyncElementIter": ...
-    async def __anext__(self) -> Element: ...
+    def __aiter__(self) -> "AsyncElementIter":
+        """Returns the iterator itself."""
+
+    async def __anext__(self) -> Element:
+        """The next element; raises ``StopAsyncIteration`` when exhausted.
+        A per-item failure raises ``PdfError`` for that item and iteration
+        may be continued (salvage semantics)."""
+
+class Span:
+    """One styled text span, yielded by ``Page.spans``/``Document.spans``
+    and their async twins: a positioned run of text with everything the
+    file states about how it is shown."""
+
+    @property
+    def text(self) -> str:
+        """The decoded text."""
+
+    @property
+    def x(self) -> float:
+        """Device-space x coordinate of the span origin."""
+
+    @property
+    def y(self) -> float:
+        """Device-space y coordinate of the span baseline."""
+
+    @property
+    def end_x(self) -> float:
+        """Device-space x after the last glyph's advance."""
+
+    @property
+    def size(self) -> float:
+        """Effective font size."""
+
+    @property
+    def font(self) -> str:
+        """Font resource name (e.g. ``"F1"``)."""
+
+    @property
+    def font_name(self) -> str:
+        """The font's ``/BaseFont`` name verbatim — subset prefix included
+        — falling back to the FontDescriptor's ``/FontName``; empty when
+        the file names the font nowhere."""
+
+    @property
+    def page(self) -> int:
+        """0-based index of the page the span came from."""
+
+    @property
+    def bbox(self) -> tuple[float, float, float, float]:
+        """Device-space box ``(x0, y0, x1, y1)``, y-up: origin to advance
+        horizontally, the font's descent..ascent vertically."""
+
+    @property
+    def bold(self) -> bool:
+        """Bold, from FontDescriptor evidence with BaseFont-name fallback."""
+
+    @property
+    def italic(self) -> bool:
+        """Italic, from FontDescriptor evidence with BaseFont-name
+        fallback."""
+
+    @property
+    def monospace(self) -> bool:
+        """FontDescriptor ``/Flags`` FixedPitch."""
+
+    @property
+    def serif(self) -> bool:
+        """FontDescriptor ``/Flags`` Serif."""
+
+    @property
+    def underline(self) -> bool:
+        """A drawn ruling sits just below the baseline covering most of
+        the span. Read from the page's geometry — PDF has no underline
+        attribute — so a table border hugging a cell's text can read as
+        one."""
+
+    @property
+    def strikethrough(self) -> bool:
+        """A drawn ruling crosses the span's x-height band —
+        geometry-read, like ``underline``."""
+
+    @property
+    def rise(self) -> float:
+        """The text rise (``Ts``) the span was shown under: positive above
+        the baseline — a superscript/subscript signal."""
+
+    @property
+    def vertical(self) -> bool:
+        """Writing mode 1: the text advances downward."""
+
+    @property
+    def invisible(self) -> bool:
+        """Shown under render mode 3 or 7, which paint nothing — the shape
+        of an OCR text layer under a scanned image."""
+
+    @property
+    def color(self) -> tuple[float, float, float] | None:
+        """Fill color as RGB in ``[0, 1]``; ``None`` for pattern fills,
+        which have no single color."""
+
+class SpanIter:
+    """Lazy sync iterator over a document's styled spans; buffers one
+    page's spans at a time, extracting each page with the GIL released."""
+
+    def __iter__(self) -> "SpanIter":
+        """Returns the iterator itself."""
+
+    def __next__(self) -> Span:
+        """The next span; raises ``StopIteration`` when the walk is
+        exhausted, ``PdfError`` when a page cannot be materialized."""
+
+class AsyncSpanIter:
+    """Async iterator over a document's styled spans; each ``__anext__``
+    is a coroutine, so the event loop is never blocked."""
+
+    def __aiter__(self) -> "AsyncSpanIter":
+        """Returns the iterator itself."""
+
+    async def __anext__(self) -> Span:
+        """The next span; raises ``StopAsyncIteration`` when the walk is
+        exhausted, ``PdfError`` when a page cannot be materialized."""
 
 class Document:
     """A loaded PDF document.
@@ -67,7 +205,11 @@ class Document:
         *,
         data: bytes | None = None,
         password: str = "",
-    ) -> None: ...
+    ) -> None:
+        """Opens a PDF from exactly one of ``path`` or ``data``; passing
+        neither or both raises ``ValueError``. ``password`` opens an
+        encrypted file, as either the user or the owner password."""
+
     @property
     def page_count(self) -> int:
         """Number of pages in the document."""
@@ -84,7 +226,9 @@ class Document:
         ``creator``, ``producer``, ``creation_date``, ``mod_date``.
         """
 
-    def __len__(self) -> int: ...
+    def __len__(self) -> int:
+        """Number of pages, so ``len(doc)`` mirrors ``doc.page_count``."""
+
     def __getitem__(self, index: int) -> Page:
         """The page at ``index`` (0-based; negative indexes count from the
         end). Raises ``IndexError`` when out of range."""
@@ -120,6 +264,12 @@ class Document:
         document order. Nothing is parsed or decoded before it is
         yielded; each step releases the GIL while parsing.
         """
+
+    def spans(self, pages: list[int] | None = None) -> Iterator[Span]:
+        """Lazily iterates the document's styled text spans, page by
+        page: every page's, or the 0-based ``pages`` given, in the order
+        given. Each step releases the GIL and shares one font cache
+        across the walk."""
 
 class Page:
     """A single page of a document.
@@ -178,6 +328,11 @@ class Page:
         ``Document.extract_markdown`` is the better answer whenever the
         whole document is at hand."""
 
+    def spans(self) -> list[Span]:
+        """The page's styled text spans, in emission order. Releases the
+        GIL like ``extract_text``, and is lenient the same way:
+        unreadable content yields no spans rather than raising."""
+
     def render(
         self,
         scale: float = 1.0,
@@ -233,20 +388,58 @@ class AsyncDocument:
     """
 
     @staticmethod
-    async def open(path: str | os.PathLike, *, password: str = "") -> "AsyncDocument": ...
+    async def open(path: str | os.PathLike, *, password: str = "") -> "AsyncDocument":
+        """Opens a PDF file for async access. The whole file is never read
+        eagerly. ``password`` opens an encrypted file, as either the user
+        or the owner password."""
+
     @staticmethod
-    async def open_url(url: str, *, password: str = "") -> "AsyncDocument": ...
+    async def open_url(url: str, *, password: str = "") -> "AsyncDocument":
+        """Opens a PDF over HTTP using range requests; the whole file is
+        never downloaded. The server must honor ``Range`` (a server that
+        ignores it raises ``PdfError`` with an ``"http:"`` message).
+        ``password`` opens an encrypted file, as either the user or the
+        owner password."""
+
     @staticmethod
-    async def from_bytes(data: bytes, *, password: str = "") -> "AsyncDocument": ...
+    async def from_bytes(data: bytes, *, password: str = "") -> "AsyncDocument":
+        """Loads a PDF from bytes already in memory. ``password`` opens an
+        encrypted file, as either the user or the owner password."""
+
     @property
-    def page_count(self) -> int: ...
+    def page_count(self) -> int:
+        """Number of pages in the document. A property, exactly like the
+        sync ``Document.page_count``: the open flow already parsed the
+        page tree, so nothing here awaits."""
+
     @property
-    def version(self) -> str: ...
-    def __len__(self) -> int: ...
-    def __getitem__(self, index: int) -> "AsyncPage": ...
-    def page(self, index: int) -> "AsyncPage": ...
-    async def extract_text(self) -> str: ...
-    async def extract_markdown(self) -> str: ...
+    def version(self) -> str:
+        """PDF version from the file header, e.g. ``"1.7"``. A property,
+        like the sync ``Document.version``."""
+
+    def __len__(self) -> int:
+        """Number of pages, so ``len(doc)`` mirrors ``doc.page_count``."""
+
+    def __getitem__(self, index: int) -> "AsyncPage":
+        """The page at ``index`` (0-based; negative indexes count from the
+        end). Raises ``IndexError`` when out of range."""
+
+    def page(self, index: int) -> "AsyncPage":
+        """The page at 0-based ``index``. Synchronous — the page tree and
+        its inherited attributes were resolved at open — and negative
+        indexes are NOT accepted here (use subscription, ``doc[-1]``, for
+        that), mirroring the sync ``Document`` split."""
+
+    async def extract_text(self) -> str:
+        """Extracts text from all pages, joined by form feed (``"\\f"``) —
+        the async twin of ``Document.extract_text``. Per-page lenient: a
+        page whose content will not read contributes an empty string, and
+        an error means the document itself could not be read."""
+
+    async def extract_markdown(self) -> str:
+        """Whole-document markdown — the async twin of
+        ``Document.extract_markdown``: headings, lists and tables inferred
+        from layout, heading sizes judged across the document."""
     async def render_pages(
         self,
         pages: list[int] | None = None,
@@ -260,8 +453,15 @@ class AsyncDocument:
         fanned out across the cores as tokio tasks so the asyncio loop
         stays free. Works over any source, including ``open_url``."""
 
-    async def metadata(self) -> dict[str, str]: ...
-    async def get_object(self, num: int, gen: int = 0) -> object: ...
+    async def metadata(self) -> dict[str, str]:
+        """Document metadata; only keys present in the file are included.
+        Same keys as ``Document.metadata``. A coroutine, unlike the sync
+        property: the info dictionary is fetched on demand."""
+
+    async def get_object(self, num: int, gen: int = 0) -> object:
+        """Fetches and parses the indirect object ``num gen``, returning
+        its value converted to plain Python data (the same conversion as
+        ``Element.value``)."""
     def elements(
         self,
         *,
@@ -274,6 +474,11 @@ class AsyncDocument:
         ordering and salvage semantics as ``Document.elements``.
         """
 
+    def spans(self, pages: list[int] | None = None) -> AsyncIterator[Span]:
+        """Streams the document's styled text spans page by page — the
+        async twin of ``Document.spans``, over range-fetching reads; use
+        with ``async for``."""
+
 class AsyncPage:
     """A single page of an async document.
 
@@ -284,13 +489,21 @@ class AsyncPage:
     """
 
     @property
-    def number(self) -> int: ...
+    def number(self) -> int:
+        """0-based page index."""
+
     @property
-    def width(self) -> float: ...
+    def width(self) -> float:
+        """Page width in points (after rotation)."""
+
     @property
-    def height(self) -> float: ...
+    def height(self) -> float:
+        """Page height in points (after rotation)."""
+
     @property
-    def rotation(self) -> int: ...
+    def rotation(self) -> int:
+        """Page rotation in degrees: 0, 90, 180 or 270."""
+
     @property
     def media_box(self) -> tuple[float, float, float, float]:
         """The media box ``(x0, y0, x1, y1)`` in unrotated PDF user space
@@ -317,19 +530,38 @@ class AsyncPage:
         """The art box, clipped to the media box; defaults to the crop
         box."""
 
-    async def extract_text(self) -> str: ...
-    async def extract_markdown(self) -> str: ...
+    async def extract_text(self) -> str:
+        """Extracts the page's text — the async twin of
+        ``Page.extract_text``."""
+
+    async def extract_markdown(self) -> str:
+        """Page markdown, ranking heading sizes against that page alone —
+        the async twin of ``Page.extract_markdown``.
+        ``AsyncDocument.extract_markdown`` is the better answer whenever
+        the whole document is at hand."""
+
+    async def spans(self) -> list[Span]:
+        """The page's styled text spans — the async twin of
+        ``Page.spans``."""
+
     async def render(
         self,
         scale: float = 1.0,
         fonts: str = "all-embedded",
         font_dir: str | None = None,
         compression: str = "default",
-    ) -> bytes: ...
+    ) -> bytes:
+        """Renders the page at ``scale`` and resolves to PNG bytes — the
+        async twin of ``Page.render``, with the same arguments and the
+        same leniency."""
+
     async def render_reporting(
         self,
         scale: float = 1.0,
         fonts: str = "all-embedded",
         font_dir: str | None = None,
         compression: str = "default",
-    ) -> tuple[bytes, list[str]]: ...
+    ) -> tuple[bytes, list[str]]:
+        """Renders the page like ``render``, resolving to
+        ``(png, warnings)`` — the async twin of ``Page.render_reporting``,
+        with the same warning semantics."""

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -1,0 +1,199 @@
+"""Tests for styled span iteration: ``Page.spans``, ``Document.spans`` and
+their async twins.
+
+Runs against the committed fixture PDFs in ``tests/fixtures/`` plus small
+in-memory documents built here. Requires the extension module to be built
+and installed (e.g. via maturin).
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from pdfboss import AsyncDocument, Document, Span
+
+
+def build_pdf(objects: dict[int, bytes]) -> bytes:
+    """A classic-xref PDF from numbered object bodies (streams included)."""
+    out = bytearray(b"%PDF-1.7\n")
+    offsets = {}
+    for num, body in sorted(objects.items()):
+        offsets[num] = len(out)
+        out += b"%d 0 obj\n%s\nendobj\n" % (num, body)
+    xref_at = len(out)
+    out += b"xref\n0 %d\n" % (len(objects) + 1)
+    out += b"0000000000 65535 f \n"
+    for num in sorted(objects):
+        out += b"%010d 00000 n \n" % offsets[num]
+    out += b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n" % (
+        len(objects) + 1,
+        xref_at,
+    )
+    return bytes(out)
+
+
+def stream(dict_body: bytes, data: bytes) -> bytes:
+    return b"<< %s /Length %d >>\nstream\n%s\nendstream" % (
+        dict_body,
+        len(data),
+        data,
+    )
+
+
+@pytest.fixture
+def styled_pdf() -> bytes:
+    """One page exercising every style channel: a bold-italic descriptor
+    font, a red fill, an underline ruling, and an invisible (``3 Tr``)
+    run."""
+    content = (
+        b"BT /F1 12 Tf 72 720 Td (plain) Tj ET "
+        b"BT /F2 12 Tf 72 690 Td 1 0 0 rg (styled) Tj 3 Tr ( ocr) Tj ET "
+        b"72 688.5 m 110 688.5 l S"
+    )
+    return build_pdf(
+        {
+            1: b"<< /Type /Catalog /Pages 2 0 R >>",
+            2: b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            3: (
+                b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+                b"/Resources << /Font << /F1 5 0 R /F2 6 0 R >> >> "
+                b"/Contents 4 0 R >>"
+            ),
+            4: stream(b"", content),
+            5: (
+                b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica "
+                b"/Encoding /WinAnsiEncoding >>"
+            ),
+            6: (
+                b"<< /Type /Font /Subtype /Type1 /BaseFont /Custom-Face "
+                b"/Encoding /WinAnsiEncoding /FontDescriptor 7 0 R >>"
+            ),
+            7: (
+                b"<< /Type /FontDescriptor /FontName /Custom-Face "
+                b"/Flags 66 /FontWeight 700 /Ascent 718 /Descent -207 >>"
+            ),
+        }
+    )
+
+
+class TestPageSpans:
+    def test_returns_span_list(self, hello_pdf: Path) -> None:
+        doc = Document(str(hello_pdf))
+        spans = doc[0].spans()
+        assert isinstance(spans, list)
+        assert all(isinstance(s, Span) for s in spans)
+        assert spans[0].text == "Hello, world!"
+
+    def test_geometry_and_identity(self, hello_pdf: Path) -> None:
+        (span,) = Document(str(hello_pdf))[0].spans()
+        x0, y0, x1, y1 = span.bbox
+        assert x0 < x1 and y0 < y1
+        assert x0 == pytest.approx(span.x)
+        assert y0 < span.y < y1
+        assert span.size > 0.0
+        assert span.page == 0
+        assert span.font == "F1"
+        assert span.font_name != ""
+
+    def test_style_attributes(self, styled_pdf: bytes) -> None:
+        doc = Document(data=styled_pdf)
+        plain, styled, ocr = doc[0].spans()
+        assert plain.text == "plain"
+        assert not plain.bold and not plain.italic
+        assert not plain.underline and not plain.strikethrough
+        assert plain.color == pytest.approx((0.0, 0.0, 0.0))
+        assert not plain.invisible
+
+        assert styled.text == "styled"
+        assert styled.font_name == "Custom-Face"
+        assert styled.bold and styled.italic
+        assert styled.serif and not styled.monospace
+        assert styled.underline and not styled.strikethrough
+        assert styled.color == pytest.approx((1.0, 0.0, 0.0))
+        assert not styled.vertical
+        assert styled.rise == 0.0
+
+        assert ocr.invisible
+
+    def test_hidden_layers_are_excluded(self) -> None:
+        data = build_pdf(
+            {
+                1: (
+                    b"<< /Type /Catalog /Pages 2 0 R /OCProperties "
+                    b"<< /OCGs [6 0 R] /D << /OFF [6 0 R] >> >> >>"
+                ),
+                2: b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+                3: (
+                    b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+                    b"/Resources << /Font << /F1 5 0 R >> "
+                    b"/Properties << /H 6 0 R >> >> /Contents 4 0 R >>"
+                ),
+                4: stream(
+                    b"",
+                    b"BT /F1 12 Tf 72 720 Td /OC /H BDC (hidden) Tj EMC (kept) Tj ET",
+                ),
+                5: (
+                    b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica "
+                    b"/Encoding /WinAnsiEncoding >>"
+                ),
+                6: b"<< /Type /OCG /Name (hidden) >>",
+            }
+        )
+        doc = Document(data=data)
+        assert [s.text for s in doc[0].spans()] == ["kept"]
+
+
+class TestDocumentSpans:
+    def test_lazy_iterator_in_page_order(self, three_pages_pdf: Path) -> None:
+        doc = Document(str(three_pages_pdf))
+        spans = doc.spans()
+        assert isinstance(spans, Iterator)
+        pages = [s.page for s in spans]
+        assert pages == sorted(pages)
+        assert set(pages) == {0, 1, 2}
+
+    def test_pages_filter_in_given_order(self, three_pages_pdf: Path) -> None:
+        doc = Document(str(three_pages_pdf))
+        pages = [s.page for s in doc.spans(pages=[2, 0])]
+        assert pages == [2, 0]
+
+    def test_matches_per_page_extraction(self, three_pages_pdf: Path) -> None:
+        doc = Document(str(three_pages_pdf))
+        walked = [s.text for s in doc.spans()]
+        per_page = [s.text for i in range(len(doc)) for s in doc[i].spans()]
+        assert walked == per_page
+
+
+class TestAsyncSpans:
+    @pytest.mark.asyncio
+    async def test_page_spans_match_sync(self, hello_pdf: Path) -> None:
+        doc = await AsyncDocument.open(hello_pdf)
+        spans = await doc[0].spans()
+        sync_spans = Document(str(hello_pdf))[0].spans()
+        assert [s.text for s in spans] == [s.text for s in sync_spans]
+        assert spans[0].bbox == sync_spans[0].bbox
+        assert spans[0].font_name == sync_spans[0].font_name
+
+    @pytest.mark.asyncio
+    async def test_document_spans_is_async_iterator(
+        self, three_pages_pdf: Path
+    ) -> None:
+        doc = await AsyncDocument.open(three_pages_pdf)
+        pages = [s.page async for s in doc.spans()]
+        assert set(pages) == {0, 1, 2}
+
+    @pytest.mark.asyncio
+    async def test_document_spans_pages_filter(self, three_pages_pdf: Path) -> None:
+        doc = await AsyncDocument.open(three_pages_pdf)
+        pages = [s.page async for s in doc.spans(pages=[1])]
+        assert pages == [1]
+
+    @pytest.mark.asyncio
+    async def test_hidden_layers_match_sync(self, styled_pdf: bytes) -> None:
+        doc = await AsyncDocument.from_bytes(styled_pdf)
+        spans = await doc[0].spans()
+        sync_spans = Document(data=styled_pdf)[0].spans()
+        assert [s.text for s in spans] == [s.text for s in sync_spans]
+        assert [s.underline for s in spans] == [s.underline for s in sync_spans]
+        assert [s.color for s in spans] == [s.color for s in sync_spans]


### PR DESCRIPTION
## What

Iteration over **styled spans**, not just elements — every span now tells the full story of how its text is shown, in both the sync and async APIs.

`TextSpan` (pdfboss-text) grows:

| field | source |
|---|---|
| `font_name` | `/BaseFont` verbatim (subset prefix kept), descriptor `/FontName` fallback |
| `page` | 0-based page index, stamped by extraction |
| `bbox` | origin→advance × `/Descent`..`/Ascent` (`/CapHeight`, then 0.8/−0.2 em fallbacks) |
| `bold`, `italic` | existing evidence, unchanged |
| `monospace`, `serif` | descriptor `/Flags` bits 1/2 |
| `underline`, `strikethrough` | geometry-read from the page's rulings: a line just below the baseline / through the x-height band, covering ≥60% of the span |
| `color` | fill color as RGB; device spaces exact, others by component count; patterns → `None` |
| `invisible` | render modes 3 and 7 (OCR text layers) |
| `rise`, `vertical` | `Ts` value; writing mode 1 |

**Async OC parity:** the `_with` extractors (pdfboss-text, pdfboss-output) now take `oc: Option<&OcState>` — a document-owning async caller passes `AsyncDocument::oc_state()`, so hidden optional-content layers are gated identically sync and async. The Python async bindings, the TUI markdown pane and the remote CLI all pass it now; this also fixes the pre-existing divergence where async `extract_text` included hidden layers the sync path excluded.

**Python surface** (the dedicated method, sync + async):

```python
for span in doc.spans():                 # lazy, page by page, one FontCache
    span.text, span.bbox, span.font_name, span.bold, span.underline, ...

doc[0].spans()                           # list[Span] for one page
await adoc[0].spans()                    # async twin
async for span in adoc.spans(pages=[2]): # async lazy walk
```

## Verification

- `cargo test --workspace`: **1916 passed** (aio sync/async parity suite included); clippy `-D warnings` clean
- `pytest tests/`: **132 passed** (new `tests/test_spans.py`: style attributes, OC gating, page filters, async parity)
- **pdf_oxide's corpus** (veraPDF 2,907 + Mozilla pdf.js 977 + SafeDocs 26 = 3,910 PDFs): **zero span-iteration exceptions**, 20.9s; the 19 load failures are encrypted/intentionally-broken fixtures at the `Document()` constructor
- 259-file corpus: 1.96M spans — 0.84% underline, 0.10% strikethrough, 0.63% invisible; top outliers spot-checked against renders (forms with genuine underlines, a magazine masthead rule) — the documented table-border caveat, no surprises

Underline/strikethrough are geometry heuristics by nature (PDF has no such text attributes); the field docs carry the caveat.