### PR TITLE
perf(core): take the token and font hot paths off the allocator

### DIFF
--- a/crates/pdfboss-core/src/cmap/mod.rs
+++ b/crates/pdfboss-core/src/cmap/mod.rs
@@ -11,7 +11,7 @@ pub use predefined::{cid_to_unicode, predefined, CidToUnicode};
 
 use crate::document::decoded_stream_data_with;
 use crate::hash::FastMap;
-use crate::lexer::{Lexer, Token};
+use crate::lexer::{decode_hex, decode_hex_fixed, Lexer, RawToken, Token};
 use crate::object::{Dict, Object, Stream};
 use crate::source::AsyncObjectSource;
 use std::sync::Arc;
@@ -128,8 +128,8 @@ impl CidCmap {
         loop {
             match next_or_skip(&mut lx, data.len()) {
                 None => break,
-                Some(Token::Keyword(kw)) => {
-                    match kw.as_slice() {
+                Some(RawToken::Keyword(kw)) => {
+                    match kw {
                         b"begincodespacerange" => out.parse_codespaces(&mut lx, data.len()),
                         b"begincidchar" => out.parse_cidchars(&mut lx, data.len(), false),
                         b"begincidrange" => out.parse_cidranges(&mut lx, data.len(), false),
@@ -145,11 +145,11 @@ impl CidCmap {
                     pending_name = None;
                     wmode_pending = false;
                 }
-                Some(Token::Name(n)) => {
+                Some(RawToken::Owned(Token::Name(n))) => {
                     wmode_pending = n.0 == "WMode";
                     pending_name = (!wmode_pending).then_some(n.0);
                 }
-                Some(Token::Int(i)) => {
+                Some(RawToken::Owned(Token::Int(i))) => {
                     if wmode_pending {
                         out.wmode = u8::from(i == 1);
                     }
@@ -295,23 +295,27 @@ impl CidCmap {
     fn parse_codespaces(&mut self, lx: &mut Lexer<'_>, len: usize) {
         loop {
             let lo = match next_or_skip(lx, len) {
-                Some(Token::HexString(h)) => h,
+                Some(RawToken::Hex(span)) => span,
                 Some(_) | None => return, // `endcodespacerange` or junk
             };
-            let Some(Token::HexString(hi)) = next_or_skip(lx, len) else {
+            let Some(RawToken::Hex(hi)) = next_or_skip(lx, len) else {
                 return;
             };
-            if lo.is_empty() || lo.len() > 4 || hi.len() != lo.len() {
+            // Over-long or empty codes are skipped, exactly like the
+            // over-long check the owned form made after decoding.
+            let (Some((lo, lo_len)), Some((hi, hi_len))) =
+                (decode_hex_fixed::<4>(lo), decode_hex_fixed::<4>(hi))
+            else {
+                continue;
+            };
+            if lo_len == 0 || hi_len != lo_len {
                 continue;
             }
-            let mut space = Codespace {
-                len: lo.len() as u8,
-                lo: [0; 4],
-                hi: [0; 4],
-            };
-            space.lo[..lo.len()].copy_from_slice(&lo);
-            space.hi[..hi.len()].copy_from_slice(&hi);
-            self.codespaces.push(space);
+            self.codespaces.push(Codespace {
+                len: lo_len as u8,
+                lo,
+                hi,
+            });
         }
     }
 
@@ -319,16 +323,19 @@ impl CidCmap {
     fn parse_cidchars(&mut self, lx: &mut Lexer<'_>, len: usize, notdef: bool) {
         loop {
             let code = match next_or_skip(lx, len) {
-                Some(Token::HexString(h)) => h,
+                Some(RawToken::Hex(span)) => span,
                 Some(_) | None => return,
             };
-            let Some(Token::Int(cid)) = next_or_skip(lx, len) else {
+            let Some(RawToken::Owned(Token::Int(cid))) = next_or_skip(lx, len) else {
                 return;
             };
-            if code.is_empty() || code.len() > 4 {
+            let Some((code, code_len)) = decode_hex_fixed::<4>(code) else {
+                continue;
+            };
+            if code_len == 0 {
                 continue;
             }
-            let (value, width) = (code_value(&code), code.len() as u8);
+            let (value, width) = (code_value(&code[..code_len]), code_len as u8);
             let cid = cid.max(0) as u32;
             if notdef {
                 self.notdefs.push(CidRange {
@@ -347,24 +354,33 @@ impl CidCmap {
     fn parse_cidranges(&mut self, lx: &mut Lexer<'_>, len: usize, notdef: bool) {
         loop {
             let lo = match next_or_skip(lx, len) {
-                Some(Token::HexString(h)) => h,
+                Some(RawToken::Hex(span)) => span,
                 Some(_) | None => return,
             };
-            let Some(Token::HexString(hi)) = next_or_skip(lx, len) else {
+            let Some(RawToken::Hex(hi)) = next_or_skip(lx, len) else {
                 return;
             };
-            let Some(Token::Int(cid)) = next_or_skip(lx, len) else {
+            let Some(RawToken::Owned(Token::Int(cid))) = next_or_skip(lx, len) else {
                 return;
             };
-            if lo.is_empty() || lo.len() > 4 {
+            let Some((lo, lo_len)) = decode_hex_fixed::<4>(lo) else {
+                continue;
+            };
+            if lo_len == 0 {
                 continue;
             }
-            let (lo_v, hi_v) = (code_value(&lo), code_value(&hi));
+            // An over-long `hi` still folds through all its bytes, exactly
+            // as the owned form's fold did (the low 32 bits win).
+            let hi_v = match decode_hex_fixed::<4>(hi) {
+                Some((hi, hi_len)) => code_value(&hi[..hi_len]),
+                None => code_value(&decode_hex(hi)),
+            };
+            let lo_v = code_value(&lo[..lo_len]);
             if hi_v < lo_v {
                 continue;
             }
             let range = CidRange {
-                len: lo.len() as u8,
+                len: lo_len as u8,
                 lo: lo_v,
                 hi: hi_v,
                 cid: cid.max(0) as u32,
@@ -475,11 +491,11 @@ async fn embedded_cmap<S: AsyncObjectSource>(src: &S, stream: &Stream) -> Option
 
 /// Fetches the next token, force-advancing past unlexable bytes; `None` at
 /// end of input.
-fn next_or_skip(lx: &mut Lexer<'_>, len: usize) -> Option<Token> {
+fn next_or_skip<'a>(lx: &mut Lexer<'a>, len: usize) -> Option<RawToken<'a>> {
     loop {
         let before = lx.pos();
-        match lx.next_token() {
-            Ok(Token::Eof) => return None,
+        match lx.next_raw_token() {
+            Ok(RawToken::Owned(Token::Eof)) => return None,
             Ok(t) => return Some(t),
             Err(_) => {
                 if lx.pos() <= before {

--- a/crates/pdfboss-core/src/content.rs
+++ b/crates/pdfboss-core/src/content.rs
@@ -5,7 +5,7 @@
 use crate::elements::Span;
 use crate::error::{Error, Result};
 use crate::geom::Matrix;
-use crate::lexer::{is_whitespace, Lexer, RawToken, Token};
+use crate::lexer::{decode_hex, is_whitespace, Lexer, RawToken, Token};
 use crate::object::{Dict, Name, Object};
 
 /// Maximum operand container (array/dictionary) nesting depth. Composing
@@ -248,6 +248,13 @@ fn parse_content_ops(data: &[u8], mut emit: impl FnMut(Op, Span)) -> Result<()> 
                     run_start = Some(token_start);
                 }
                 kw
+            }
+            RawToken::Hex(span) => {
+                if run_start.is_none() {
+                    run_start = Some(token_start);
+                }
+                stack.push(Object::String(decode_hex(span)));
+                continue;
             }
             RawToken::Owned(token) => {
                 if !matches!(token, Token::Eof) && run_start.is_none() {

--- a/crates/pdfboss-core/src/lexer.rs
+++ b/crates/pdfboss-core/src/lexer.rs
@@ -34,12 +34,12 @@ pub enum Token {
 }
 
 /// Whether `b` is PDF whitespace (ISO 32000 §7.2.2, Table 1).
-pub(crate) fn is_whitespace(b: u8) -> bool {
+pub(crate) const fn is_whitespace(b: u8) -> bool {
     matches!(b, b'\0' | b'\t' | b'\n' | b'\x0C' | b'\r' | b' ')
 }
 
 /// Whether `b` is a PDF delimiter character (ISO 32000 §7.2.2, Table 2).
-pub(crate) fn is_delimiter(b: u8) -> bool {
+pub(crate) const fn is_delimiter(b: u8) -> bool {
     matches!(
         b,
         b'(' | b')' | b'<' | b'>' | b'[' | b']' | b'{' | b'}' | b'/' | b'%'
@@ -48,8 +48,20 @@ pub(crate) fn is_delimiter(b: u8) -> bool {
 
 /// Whether `b` is a regular character (neither whitespace nor delimiter).
 pub(crate) fn is_regular(b: u8) -> bool {
-    !is_whitespace(b) && !is_delimiter(b)
+    REGULAR[b as usize]
 }
+
+/// [`is_regular`] as a table: the token scanners classify every byte of
+/// every content stream and CMap, and one load beats two match chains.
+const REGULAR: [bool; 256] = {
+    let mut table = [false; 256];
+    let mut b = 0usize;
+    while b < 256 {
+        table[b] = !is_whitespace(b as u8) && !is_delimiter(b as u8);
+        b += 1;
+    }
+    table
+};
 
 /// Value of an ASCII hex digit, if `b` is one.
 fn hex_val(b: u8) -> Option<u8> {
@@ -134,13 +146,19 @@ fn parse_number_fast(run: &[u8]) -> Option<Token> {
 /// to match on it and drop it dominated content-parse allocation.
 /// [`Lexer::next_token`] wraps this, copying keyword bytes into the public
 /// [`Token`], so the two forms cannot lex differently.
-pub(crate) enum RawToken<'a> {
-    /// Any non-keyword token, carried as the public type. Never
+pub enum RawToken<'a> {
+    /// Any non-keyword, non-hex token, carried as the public type. Never
     /// [`Token::Keyword`]: keywords always come out borrowed.
     Owned(Token),
     /// A bare regular-character run — or a lenient stray delimiter —
     /// borrowed from the input.
     Keyword(&'a [u8]),
+    /// A hex string's raw span (the bytes between `<` and `>`, undecoded),
+    /// borrowed from the input. CMaps are almost nothing but short hex
+    /// strings, and decoding each into a [`Token::HexString`] allocation
+    /// just to read a code out dominated CMap parsing; [`decode_hex`] and
+    /// [`decode_hex_fixed`] turn a span into bytes when they are wanted.
+    Hex(&'a [u8]),
 }
 
 /// Tokenizer over a byte slice.
@@ -175,13 +193,14 @@ impl<'a> Lexer<'a> {
         Ok(match self.next_raw_token()? {
             RawToken::Owned(token) => token,
             RawToken::Keyword(kw) => Token::Keyword(kw.to_vec()),
+            RawToken::Hex(span) => Token::HexString(decode_hex(span)),
         })
     }
 
-    /// [`Lexer::next_token`] with keyword bytes borrowed instead of copied.
-    /// This is the one lexing implementation; `next_token` merely copies the
-    /// borrow out.
-    pub(crate) fn next_raw_token(&mut self) -> Result<RawToken<'a>> {
+    /// [`Lexer::next_token`] with keyword and hex-string bytes borrowed
+    /// instead of copied. This is the one lexing implementation;
+    /// `next_token` merely copies the borrows out.
+    pub fn next_raw_token(&mut self) -> Result<RawToken<'a>> {
         self.skip_whitespace_and_comments();
         let Some(&b) = self.data.get(self.pos) else {
             return Ok(RawToken::Owned(Token::Eof));
@@ -201,7 +220,7 @@ impl<'a> Lexer<'a> {
                     Ok(RawToken::Owned(Token::DictOpen))
                 } else {
                     self.pos += 1;
-                    Ok(RawToken::Owned(self.lex_hex_string()))
+                    Ok(RawToken::Hex(self.hex_span()))
                 }
             }
             b'>' => {
@@ -243,20 +262,13 @@ impl<'a> Lexer<'a> {
     /// Advances past whitespace and `%` comments.
     pub fn skip_whitespace_and_comments(&mut self) {
         loop {
-            while self.data.get(self.pos).is_some_and(|&b| is_whitespace(b)) {
-                self.pos += 1;
-            }
-            if self.data.get(self.pos) == Some(&b'%') {
-                while self
-                    .data
-                    .get(self.pos)
-                    .is_some_and(|&b| b != b'\r' && b != b'\n')
-                {
-                    self.pos += 1;
-                }
-            } else {
+            let rest = &self.data[self.pos.min(self.data.len())..];
+            self.pos += rest.iter().take_while(|&&b| is_whitespace(b)).count();
+            if self.data.get(self.pos) != Some(&b'%') {
                 return;
             }
+            let rest = &self.data[self.pos..];
+            self.pos += memchr::memchr2(b'\r', b'\n', rest).unwrap_or(rest.len());
         }
     }
 
@@ -267,11 +279,11 @@ impl<'a> Lexer<'a> {
 
     /// Consumes the run of regular characters starting at the cursor.
     fn take_regular_run(&mut self) -> &'a [u8] {
-        let start = self.pos;
-        while self.data.get(self.pos).is_some_and(|&b| is_regular(b)) {
-            self.pos += 1;
-        }
-        &self.data[start..self.pos]
+        let start = self.pos.min(self.data.len());
+        let rest = &self.data[start..];
+        let run = rest.iter().take_while(|&&b| is_regular(b)).count();
+        self.pos = start + run;
+        &rest[..run]
     }
 
     /// Lexes a run starting with a digit, sign, or period: a number when the
@@ -480,29 +492,75 @@ impl<'a> Lexer<'a> {
     /// Lexes a hex string after the opening `<`: whitespace is ignored, a
     /// trailing odd digit is padded with `0`, non-hex bytes are skipped
     /// (lenient), and a missing `>` terminates at end of input.
-    fn lex_hex_string(&mut self) -> Token {
-        let rest = &self.data[self.pos..];
-        let digits = memchr::memchr(b'>', rest).unwrap_or(rest.len());
-        let mut out = Vec::with_capacity(digits.div_ceil(2).min(HEX_STRING_PREALLOC_CAP));
-        let mut pending: Option<u8> = None;
-        while let Some(&b) = self.data.get(self.pos) {
-            self.pos += 1;
-            if b == b'>' {
-                break;
+    /// Consumes a hex string's raw span: everything up to (and past) the
+    /// closing `>`, returned undecoded.
+    fn hex_span(&mut self) -> &'a [u8] {
+        let start = self.pos;
+        let rest = &self.data[start..];
+        match memchr::memchr(b'>', rest) {
+            Some(end) => {
+                self.pos = start + end + 1;
+                &rest[..end]
             }
-            let Some(v) = hex_val(b) else {
-                continue; // whitespace and invalid bytes are skipped
-            };
-            match pending.take() {
-                Some(hi) => out.push((hi << 4) | v),
-                None => pending = Some(v),
+            None => {
+                self.pos = self.data.len();
+                rest
             }
         }
-        if let Some(hi) = pending {
-            out.push(hi << 4);
-        }
-        Token::HexString(out)
     }
+}
+
+/// Decodes a hex string's raw span: hex digit pairs to bytes, whitespace
+/// and invalid bytes skipped, an odd trailing digit read as the high
+/// nibble (ISO 32000-1 §7.3.4.3).
+pub fn decode_hex(span: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(span.len().div_ceil(2).min(HEX_STRING_PREALLOC_CAP));
+    let mut pending: Option<u8> = None;
+    for &b in span {
+        let Some(v) = hex_val(b) else {
+            continue;
+        };
+        match pending.take() {
+            Some(hi) => out.push((hi << 4) | v),
+            None => pending = Some(v),
+        }
+    }
+    if let Some(hi) = pending {
+        out.push(hi << 4);
+    }
+    out
+}
+
+/// [`decode_hex`] into a stack buffer: `Some((bytes, len))`, or `None`
+/// when the span decodes to more than `N` bytes — the caller's cue that
+/// the value is not the short code it expected.
+pub fn decode_hex_fixed<const N: usize>(span: &[u8]) -> Option<([u8; N], usize)> {
+    let mut out = [0u8; N];
+    let mut len = 0usize;
+    let mut pending: Option<u8> = None;
+    for &b in span {
+        let Some(v) = hex_val(b) else {
+            continue;
+        };
+        match pending.take() {
+            Some(hi) => {
+                if len == N {
+                    return None;
+                }
+                out[len] = (hi << 4) | v;
+                len += 1;
+            }
+            None => pending = Some(v),
+        }
+    }
+    if let Some(hi) = pending {
+        if len == N {
+            return None;
+        }
+        out[len] = hi << 4;
+        len += 1;
+    }
+    Some((out, len))
 }
 
 #[cfg(test)]

--- a/crates/pdfboss-text/src/cmap.rs
+++ b/crates/pdfboss-text/src/cmap.rs
@@ -1,7 +1,7 @@
 //! ToUnicode CMap parsing: `begincodespacerange`, `beginbfchar`, and both
 //! `beginbfrange` forms; destination hex is UTF-16BE and may be multi-char.
 
-use pdfboss_core::lexer::{Lexer, Token};
+use pdfboss_core::lexer::{decode_hex, decode_hex_fixed, Lexer, RawToken, Token};
 use pdfboss_core::FastMap;
 
 /// A parsed ToUnicode CMap mapping character codes to Unicode strings.
@@ -22,6 +22,19 @@ pub struct ToUnicode {
 /// Folds up to the last 4 bytes of a hex-string source code, big-endian.
 fn code_value(bytes: &[u8]) -> u32 {
     bytes.iter().fold(0u32, |acc, &b| (acc << 8) | u32::from(b))
+}
+
+/// Decodes a source code's raw hex span without allocating: its folded
+/// value and byte length. An over-long code (past 4 bytes) still folds
+/// through all its bytes, exactly as the owned form's fold did.
+fn hex_code(span: &[u8]) -> (u32, usize) {
+    match decode_hex_fixed::<4>(span) {
+        Some((bytes, len)) => (code_value(&bytes[..len]), len),
+        None => {
+            let bytes = decode_hex(span);
+            (code_value(&bytes), bytes.len())
+        }
+    }
 }
 
 /// Splits destination hex bytes into UTF-16BE code units; a trailing odd
@@ -55,7 +68,7 @@ impl ToUnicode {
         loop {
             match next_or_skip(&mut lx, data.len()) {
                 None => break,
-                Some(Token::Keyword(kw)) => match kw.as_slice() {
+                Some(RawToken::Keyword(kw)) => match kw {
                     b"begincodespacerange" => out.parse_codespaces(&mut lx, data.len()),
                     b"beginbfchar" => out.parse_bfchars(&mut lx, data.len()),
                     b"beginbfrange" => out.parse_bfranges(&mut lx, data.len()),
@@ -116,17 +129,17 @@ impl ToUnicode {
     fn parse_codespaces(&mut self, lx: &mut Lexer<'_>, len: usize) {
         loop {
             let lo = match next_or_skip(lx, len) {
-                Some(Token::HexString(h)) => h,
+                Some(RawToken::Hex(span)) => span,
                 Some(_) | None => return, // `endcodespacerange` or junk
             };
-            let Some(Token::HexString(hi)) = next_or_skip(lx, len) else {
+            let Some(RawToken::Hex(hi)) = next_or_skip(lx, len) else {
                 return;
             };
-            if lo.is_empty() {
+            let (lo_v, lo_len) = hex_code(lo);
+            if lo_len == 0 {
                 continue;
             }
-            self.codespaces
-                .push((lo.len(), code_value(&lo), code_value(&hi)));
+            self.codespaces.push((lo_len, lo_v, hex_code(hi).0));
         }
     }
 
@@ -134,15 +147,15 @@ impl ToUnicode {
     fn parse_bfchars(&mut self, lx: &mut Lexer<'_>, len: usize) {
         loop {
             let src = match next_or_skip(lx, len) {
-                Some(Token::HexString(h)) => h,
+                Some(RawToken::Hex(span)) => span,
                 Some(_) | None => return,
             };
             match next_or_skip(lx, len) {
-                Some(Token::HexString(dst)) => {
-                    let units = utf16_units(&dst);
+                Some(RawToken::Hex(dst)) => {
+                    let units = utf16_units(&decode_hex(dst));
                     if !units.is_empty() && !is_replacement(&units) {
                         self.singles
-                            .insert(code_value(&src), String::from_utf16_lossy(&units));
+                            .insert(hex_code(src).0, String::from_utf16_lossy(&units));
                     }
                 }
                 // A name destination (base-font form) or junk: skip entry.
@@ -156,32 +169,32 @@ impl ToUnicode {
     fn parse_bfranges(&mut self, lx: &mut Lexer<'_>, len: usize) {
         loop {
             let lo = match next_or_skip(lx, len) {
-                Some(Token::HexString(h)) => code_value(&h),
+                Some(RawToken::Hex(span)) => hex_code(span).0,
                 Some(_) | None => return,
             };
             let hi = match next_or_skip(lx, len) {
-                Some(Token::HexString(h)) => code_value(&h),
+                Some(RawToken::Hex(span)) => hex_code(span).0,
                 Some(_) | None => return,
             };
             match next_or_skip(lx, len) {
-                Some(Token::HexString(dst)) => {
-                    let units = utf16_units(&dst);
+                Some(RawToken::Hex(dst)) => {
+                    let units = utf16_units(&decode_hex(dst));
                     if !units.is_empty() && !is_replacement(&units) && lo <= hi {
                         self.ranges.push((lo, hi, units));
                     }
                 }
-                Some(Token::ArrayOpen) => {
+                Some(RawToken::Owned(Token::ArrayOpen)) => {
                     let mut code = lo;
                     loop {
                         match next_or_skip(lx, len) {
-                            Some(Token::HexString(dst)) => {
-                                let units = utf16_units(&dst);
+                            Some(RawToken::Hex(dst)) => {
+                                let units = utf16_units(&decode_hex(dst));
                                 if !units.is_empty() && !is_replacement(&units) && code <= hi {
                                     self.singles.insert(code, String::from_utf16_lossy(&units));
                                 }
                                 code = code.saturating_add(1);
                             }
-                            Some(Token::ArrayClose) => break,
+                            Some(RawToken::Owned(Token::ArrayClose)) => break,
                             Some(_) => {}
                             None => return,
                         }
@@ -196,11 +209,11 @@ impl ToUnicode {
 
 /// Fetches the next token, force-advancing past unlexable bytes; `None`
 /// at end of input.
-fn next_or_skip(lx: &mut Lexer<'_>, len: usize) -> Option<Token> {
+fn next_or_skip<'a>(lx: &mut Lexer<'a>, len: usize) -> Option<RawToken<'a>> {
     loop {
         let before = lx.pos();
-        match lx.next_token() {
-            Ok(Token::Eof) => return None,
+        match lx.next_raw_token() {
+            Ok(RawToken::Owned(Token::Eof)) => return None,
             Ok(t) => return Some(t),
             Err(_) => {
                 if lx.pos() <= before {

--- a/crates/pdfboss-text/src/font.rs
+++ b/crates/pdfboss-text/src/font.rs
@@ -7,9 +7,8 @@
 use crate::cmap::ToUnicode;
 use crate::sfnt;
 use pdfboss_core::cmap::{cid_to_unicode, type0_encoding, CidCmap, CidToUnicode};
-use pdfboss_core::{decoded_stream_data_with, AsyncObjectSource, Dict, Object};
+use pdfboss_core::{decoded_stream_data_with, AsyncObjectSource, Dict, FastMap, Object};
 use pdfboss_encoding as encodings;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// One character code split out of a show string: its value and how many
@@ -53,12 +52,12 @@ pub struct Font {
     encoding: Option<Box<[Option<Decoded>; 256]>>,
     /// Explicit widths in glyph-space units (1/1000 em), keyed by code for
     /// simple fonts and by CID for Type0 (`/W`).
-    widths: HashMap<u32, f32>,
+    widths: FastMap<u32, f32>,
     /// Width used for codes without an explicit entry.
     default_width: f32,
     /// Vertical displacements (`/W2` w1, negative for downward), keyed by
     /// CID.
-    vwidths: HashMap<u32, f32>,
+    vwidths: FastMap<u32, f32>,
     /// `/DW2`'s displacement, default -1000 (ISO 32000-1 §9.7.4.3).
     default_vwidth: f32,
     /// The code that triggers word spacing (single-byte code 32).
@@ -145,9 +144,9 @@ impl Font {
             encoding_known: true,
             vertical: false,
             encoding: None,
-            widths: HashMap::new(),
+            widths: FastMap::default(),
             default_width: 500.0,
-            vwidths: HashMap::new(),
+            vwidths: FastMap::default(),
             default_vwidth: -1000.0,
             space_code: Some(32),
             winansi_high_codes: false,
@@ -520,7 +519,7 @@ impl Font {
     ) -> Font {
         let encoding = Font::load_encoding(src, dict).await;
 
-        let mut widths = HashMap::new();
+        let mut widths = FastMap::default();
         let first = rv(src, dict, "FirstChar")
             .await
             .and_then(|o| o.as_int())
@@ -562,7 +561,7 @@ impl Font {
             encoding,
             widths,
             default_width,
-            vwidths: HashMap::new(),
+            vwidths: FastMap::default(),
             default_vwidth: -1000.0,
             space_code: Some(32),
             winansi_high_codes,
@@ -699,9 +698,9 @@ impl Font {
         let descendant = Font::load_descendant(src, dict).await;
         let encoding = type0_encoding(src, dict).await;
 
-        let mut widths = HashMap::new();
+        let mut widths = FastMap::default();
         let mut default_width = 1000.0;
-        let mut vwidths = HashMap::new();
+        let mut vwidths = FastMap::default();
         let mut default_vwidth = -1000.0;
         let mut ordering = None;
         if let Some(desc) = &descendant {
@@ -781,7 +780,7 @@ impl Font {
     async fn parse_cid_widths<S: AsyncObjectSource>(
         src: &S,
         items: &[Object],
-        widths: &mut HashMap<u32, f32>,
+        widths: &mut FastMap<u32, f32>,
     ) {
         let mut resolved: Vec<Object> = Vec::with_capacity(items.len());
         for item in items {
@@ -830,7 +829,7 @@ impl Font {
     async fn parse_cid_vwidths<S: AsyncObjectSource>(
         src: &S,
         items: &[Object],
-        vwidths: &mut HashMap<u32, f32>,
+        vwidths: &mut FastMap<u32, f32>,
     ) {
         let mut resolved: Vec<Object> = Vec::with_capacity(items.len());
         for item in items {


### PR DESCRIPTION
## The parser optimization

Third leg of the pdf_oxide per-file-wins campaign (#86 AES, #87 SHA). Target: the ~96 parse-bound losses. Profiled per the [no-eBPF workflow](https://tahrioui.de/blog/no-ebpf-for-macos) — self-time from `sample` with guide-prefix-aware tree parsing.

**Three measured mechanisms, three changes:**

1. **CID widths under SipHash.** On `/W`-heavy Type0 fonts (`issue9915_reduced`), 85% of extraction was `HashMap::insert` + SipHash + rehash growth filling `Font::widths`. Now `FastMap` (the in-house FxHash the render crate already uses). `issue9915_reduced`: **2078 → 585 µs**.
2. **CMap parsing through the owned-token API.** Every keyword was `to_vec()`'d and every `<hex>` decoded into a fresh `Vec` just to read a ≤4-byte code. The lexer now carries hex spans borrowed (`RawToken::Hex`, with `decode_hex`/`decode_hex_fixed` for the moment bytes are wanted), and both CMap parsers consume raw tokens — range parsing is allocation-free. Over-long/degenerate codes fold or skip exactly as before (fallback paths keep the owned forms' semantics).
3. **Byte-at-a-time scanners.** `skip_whitespace_and_comments` and `take_regular_run` paid two bounds checks per byte via `data.get(pos)`; they scan slices now, `is_regular` is one table load, comments skip via `memchr2`. isartor 6-3-4: **909 → 700 µs**.

## Verification

- `cargo test --workspace` 1920 passed; Rosetta x86_64 core+text 888 passed; clippy clean; pytest 132 passed
- Styled-span sweep over all 3,910 corpus files: zero exceptions
- Paired best-of-3 vs pdf_oxide: **per-file wins 97.5% → 98.4%** (3822/3884), corpus total 0.63 s vs 25.3 s, worst single-file deficit 2269 → 713 µs

## What remains (documented, not attempted)

Six structural losses (>240 µs deficits: `cidfont_cmap_overflow`, `isartor-6-3-4`, `issue9915_reduced`, `issue11922_reduced`, `issue19550`, `issue6410`) now profile as zlib inflate volume plus honest token throughput over large decompressed content — the next rung would be lexer SIMD or lazier stream handling. The other ~56 "losses" are sub-noise ties that churn between runs.

Note: `perf:` doesn't trigger a release-please bump on its own — this rides into the next release with any fix/feat, or a manual dispatch.