### PR TITLE
perf(render): cross-page font cache, sampled Huffman counting, vector composite

### DIFF
--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -25,6 +25,7 @@ use pdfboss_core::Metadata as CoreMetadata;
 use pdfboss_core::Page as CorePage;
 use pdfboss_core::{Dict, DocumentSeed, ObjRef, Object, OcState};
 use pdfboss_output::Output;
+use pdfboss_render::RenderCache;
 use pdfboss_text::{FontCache, TextSpan};
 
 create_exception!(
@@ -290,6 +291,9 @@ impl SharedDocument {
 #[pyclass(frozen)]
 struct Document {
     inner: Arc<SharedDocument>,
+    /// Fonts loaded once per document across every page render; handed to
+    /// each page and to the `render_pages` fan-out workers.
+    render_cache: Arc<RenderCache>,
 }
 
 #[pymethods]
@@ -308,6 +312,7 @@ impl Document {
         };
         Ok(Document {
             inner: SharedDocument::new(core),
+            render_cache: Arc::new(RenderCache::default()),
         })
     }
 
@@ -357,6 +362,7 @@ impl Document {
         };
         Ok(Page {
             doc: Arc::clone(&self.inner),
+            render_cache: Arc::clone(&self.render_cache),
             seed,
             page,
         })
@@ -426,7 +432,8 @@ impl Document {
         font_dir: Option<String>,
         compression: &str,
     ) -> PyResult<Vec<Bound<'py, PyBytes>>> {
-        let opts = resolve_render_options(py, scale, fonts, font_dir)?;
+        let mut opts = resolve_render_options(py, scale, fonts, font_dir)?;
+        opts.cache = Some(Arc::clone(&self.render_cache));
         let compression = png_compression_from_str(compression)?;
         let inner = &self.inner;
         let pngs = py.allow_threads(move || {
@@ -553,6 +560,9 @@ struct Page {
     /// caches accumulate across the document's pages — while concurrent
     /// callers fall back to a private materialization below.
     doc: Arc<SharedDocument>,
+    /// Fonts loaded once per document across every page render
+    /// (`RenderOptions::cache`); shared by all of this document's pages.
+    render_cache: Arc<RenderCache>,
     /// The document's shareable core: the fallback that keeps per-page
     /// work lock-free when another thread holds the shared document.
     seed: DocumentSeed,
@@ -696,7 +706,8 @@ impl Page {
         font_dir: Option<String>,
         compression: &str,
     ) -> PyResult<(Bound<'py, PyBytes>, Vec<String>)> {
-        let opts = resolve_render_options(py, scale, fonts, font_dir)?;
+        let mut opts = resolve_render_options(py, scale, fonts, font_dir)?;
+        opts.cache = Some(Arc::clone(&self.render_cache));
         let compression = png_compression_from_str(compression)?;
         let (png, warnings) = py.allow_threads(|| {
             // Uncontended, reuse the shared parsed document so fonts,

--- a/crates/pdfboss-render/src/encode.rs
+++ b/crates/pdfboss-render/src/encode.rs
@@ -659,9 +659,19 @@ fn tokenize(data: &[u8], mut emit: impl FnMut(Token<'_>)) {
 /// pass builds the image's own Huffman tables, a second identical pass
 /// writes the stream.
 fn deflate_filtered(data: &[u8]) -> Vec<u8> {
-    let mut lit_freq = [0u32; 286];
-    let mut dist_freq = [0u32; 30];
-    tokenize(data, |token| match token {
+    let mut lit_freq = [1u32; 286];
+    let mut dist_freq = [1u32; 30];
+    // The tables come from a sample: half the image reads statistically
+    // like all of it, at half the counting cost. The 1-floors above keep
+    // every code the emission pass may need describable even when the
+    // sample never produced it (the two tokenizations genuinely differ —
+    // the emission pass sees hash-table state the sample pass did not).
+    let sample_len = if data.len() > 256 * 1024 {
+        data.len() / 2
+    } else {
+        data.len()
+    };
+    tokenize(&data[..sample_len], |token| match token {
         Token::Literals(bytes) => {
             for &b in bytes {
                 lit_freq[b as usize] += 1;
@@ -672,16 +682,10 @@ fn deflate_filtered(data: &[u8]) -> Vec<u8> {
             dist_freq[distance_code(dist).0 as usize] += 1;
         }
     });
-    lit_freq[256] += 1; // end of block
 
     let lit_lens = huffman_lengths(&lit_freq, 15);
     let lit_codes = canonical_codes(&lit_lens);
-    let mut dist_lens = huffman_lengths(&dist_freq, 15);
-    if dist_lens.iter().all(|&l| l == 0) {
-        // RFC 1951 requires at least one describable distance code even
-        // when no match is emitted.
-        dist_lens[0] = 1;
-    }
+    let dist_lens = huffman_lengths(&dist_freq, 15);
     let dist_codes = canonical_codes(&dist_lens);
     let hdist = dist_lens.iter().rposition(|&l| l != 0).map_or(1, |p| p + 1);
 

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -189,6 +189,9 @@ impl GState {
 /// drawn (the [`crate::GlyphPainting`] tier, or a load failure).
 type LoadedFont = Option<(Arc<GlyphFont>, Arc<str>, Option<Arc<GlyphFallback>>)>;
 
+/// [`LoadedFont`] as the cross-page [`crate::RenderCache`] stores it.
+pub(crate) type SharedGlyphFont = LoadedFont;
+
 /// Upper bound on tiles one pattern paint may plan. Real hatchings use
 /// hundreds to a few thousand cells; the cap only stops a hostile step
 /// (`/XStep 0.001` over a full page) from demanding unbounded work, and
@@ -453,8 +456,14 @@ pub(crate) async fn render_page_reporting_with<S: AsyncObjectSource>(
     let (w_pt, h_pt) = page.size();
     let pw = (w_pt * scale).ceil().clamp(1.0, MAX_SIDE) as u32;
     let ph = (h_pt * scale).ceil().clamp(1.0, MAX_SIDE) as u32;
-    let mut pix = Pixmap::new(pw, ph);
-    pix.fill([255, 255, 255, 255]);
+    // White is every byte 255, so the page allocates already-white
+    // instead of allocating zeroed and repainting.
+    let mut pix = Pixmap {
+        width: pw,
+        height: ph,
+        data: vec![255; pw as usize * ph as usize * 4],
+    };
+    let _ = &mut pix;
     let mut report = RenderReport::default();
     // A page whose own `/Contents` will not decode or will not parse
     // rasterizes blank, which is indistinguishable from an empty page unless
@@ -492,6 +501,7 @@ pub(crate) async fn render_page_reporting_with<S: AsyncObjectSource>(
         color_locked: false,
         provider,
         oc: opts.oc.clone(),
+        shared_fonts: opts.cache.clone(),
         glyph_blit: Vec::new(),
         raster: RasterScratch::default(),
         clip_cache: FastMap::default(),
@@ -543,6 +553,9 @@ struct Executor<'a, S> {
     /// The document's optional-content visibility from
     /// [`RenderOptions::oc`]; `None` renders every layer.
     oc: Option<Arc<pdfboss_core::OcState>>,
+    /// Fonts shared across this document's page renders
+    /// ([`RenderOptions::cache`]); `None` keeps loads page-local.
+    shared_fonts: Option<Arc<crate::RenderCache>>,
     /// Reused scratch for painting a cached glyph outline: the flattened
     /// (origin-relative) subpaths from [`GlyphFont::flattened`] are copied
     /// here translated to the glyph's device origin, so a whole page of text
@@ -1621,10 +1634,48 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         if let Some(f) = cache.get(name) {
             return f.clone();
         }
-        let dict = self
-            .find_res(chain, "Font", name)
-            .await
-            .and_then(|o| o.as_dict().cloned());
+        // Walk the resource chain exactly as `find_res` does — an entry
+        // that resolves to null falls through to an outer scope — but
+        // check the cross-page cache by each entry's object reference
+        // first: a hit never resolves the dictionary at all. The cache is
+        // keyed by reference, never resource name: a reference resolves to
+        // the same dictionary on every page, while `/F0` may not.
+        let mut font_ref = None;
+        let mut dict = None;
+        for res in chain {
+            let Some(cat) = res.get("Font") else {
+                continue;
+            };
+            let Ok(Object::Dict(fonts)) = self.src.resolve(cat).await else {
+                continue;
+            };
+            let Some(value) = fonts.get(name) else {
+                continue;
+            };
+            let entry_ref = match value {
+                Object::Ref(r) => Some(*r),
+                _ => None,
+            };
+            if let (Some(shared), Some(r)) = (&self.shared_fonts, entry_ref) {
+                if let Some(loaded) = shared.font(r) {
+                    cache.insert(name.to_string(), loaded.clone());
+                    return loaded;
+                }
+            }
+            if let Ok(obj) = self.src.resolve(value).await {
+                if let Some(d) = obj.as_dict() {
+                    font_ref = entry_ref;
+                    dict = Some(d.clone());
+                    break;
+                }
+                if !obj.is_null() {
+                    // A non-dict font resource loads as nothing, exactly
+                    // as the resolved lookup treated it.
+                    font_ref = entry_ref;
+                    break;
+                }
+            }
+        }
         let label: Arc<str> = dict
             .as_ref()
             .and_then(|d| d.get_name("BaseFont"))
@@ -1647,6 +1698,9 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             }
             None => None,
         };
+        if let (Some(shared), Some(r)) = (&self.shared_fonts, font_ref) {
+            shared.store(r, loaded.clone());
+        }
         cache.insert(name.to_string(), loaded.clone());
         loaded
     }
@@ -6700,5 +6754,114 @@ mod tests {
             "metrics-only codes are configured behavior, not drops: {:?}",
             report.warnings()
         );
+    }
+}
+
+#[cfg(test)]
+mod render_cache_tests {
+    use super::*;
+    use crate::{RenderCache, RenderOptions};
+    use pdfboss_core::{block_on, BoxFuture, Document, Immediate, ObjRef};
+    use pdfboss_testkit::PdfBuilder;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Counts each reference resolution by object number while delegating
+    /// to the document — loading a font resolves its dictionary's
+    /// reference exactly once, so the count makes cross-page cache hits
+    /// observable without instrumenting production code (the same trick
+    /// pdfboss-text's FontCache tests use).
+    struct Counting<'a> {
+        inner: Immediate<&'a Document>,
+        resolutions: AtomicUsize,
+        watched: u32,
+    }
+
+    impl AsyncObjectSource for Counting<'_> {
+        fn get(&self, r: ObjRef) -> BoxFuture<'_, pdfboss_core::Result<Object>> {
+            self.inner.get(r)
+        }
+
+        fn stream_data<'b>(
+            &'b self,
+            s: &'b pdfboss_core::Stream,
+        ) -> BoxFuture<'b, pdfboss_core::Result<Vec<u8>>> {
+            self.inner.stream_data(s)
+        }
+
+        fn resolve<'b>(&'b self, o: &'b Object) -> BoxFuture<'b, pdfboss_core::Result<Object>> {
+            if let Object::Ref(r) = o {
+                if r.num == self.watched {
+                    self.resolutions.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            self.inner.resolve(o)
+        }
+    }
+
+    /// Two pages binding the same embedded TrueType font dictionary.
+    fn two_page_shared_font_doc() -> Vec<u8> {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R 8 0 R] /Count 2 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+             /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", b"BT /F0 100 Tf 30 80 Td (A) Tj ET");
+        b.object(
+            5,
+            "<< /Type /Font /Subtype /TrueType /BaseFont /Shared \
+             /FirstChar 65 /Widths [500] /Encoding /WinAnsiEncoding \
+             /FontDescriptor 6 0 R >>",
+        );
+        b.object(
+            6,
+            "<< /Type /FontDescriptor /FontName /Shared /Flags 32 \
+             /FontFile2 7 0 R >>",
+        );
+        b.stream(7, "", &crate::truetype::tests::build_font());
+        b.object(
+            8,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+             /Resources << /Font << /F0 5 0 R >> >> /Contents 9 0 R >>",
+        );
+        b.stream(9, "", b"BT /F0 100 Tf 30 80 Td (A) Tj ET");
+        b.build(1)
+    }
+
+    fn render_both(cache: Option<Arc<RenderCache>>) -> (usize, Vec<Pixmap>) {
+        let doc = Document::load(two_page_shared_font_doc()).expect("load");
+        let counting = Counting {
+            inner: Immediate(&doc),
+            resolutions: AtomicUsize::new(0),
+            watched: 5,
+        };
+        let opts = RenderOptions {
+            cache,
+            ..Default::default()
+        };
+        let mut pages = Vec::new();
+        for index in 0..2 {
+            let page = doc.page(index).expect("page");
+            let (pix, report) =
+                block_on(render_page_reporting_with(&counting, &page, 1.0, &opts)).expect("render");
+            assert!(report.warnings().is_empty(), "unexpected skips: {report:?}");
+            pages.push(pix);
+        }
+        (counting.resolutions.load(Ordering::Relaxed), pages)
+    }
+
+    /// One [`RenderCache`] across a document's pages loads the shared font
+    /// dictionary once, and the pixels are exactly the uncached render's.
+    #[test]
+    fn a_shared_font_loads_once_per_document() {
+        let (uncached_resolutions, uncached) = render_both(None);
+        let (cached_resolutions, cached) = render_both(Some(Arc::new(RenderCache::default())));
+        assert_eq!(uncached_resolutions, 2, "one load per page uncached");
+        assert_eq!(cached_resolutions, 1, "one load per document cached");
+        for (a, b) in cached.iter().zip(&uncached) {
+            assert_eq!(a.data, b.data, "pixels must not depend on the cache");
+        }
     }
 }

--- a/crates/pdfboss-render/src/lib.rs
+++ b/crates/pdfboss-render/src/lib.rs
@@ -199,6 +199,45 @@ pub struct RenderOptions {
     /// `AsyncDocument::oc_state`), and leaving it `None` there renders
     /// every layer.
     pub oc: Option<Arc<OcState>>,
+    /// Fonts loaded once for the document instead of once per page: a
+    /// caller rendering a whole document passes one [`RenderCache`] to
+    /// every page, and each font program — outline parsing included —
+    /// loads once. `None` keeps every load page-local. Keyed by the font
+    /// dictionary's object reference, so identical resource names on
+    /// different pages never collide, exactly like text extraction's
+    /// `FontCache`.
+    pub cache: Option<Arc<RenderCache>>,
+}
+
+/// Cross-page render state: fonts by their dictionary's object reference.
+/// `Send + Sync`, so a parallel page walk may share one.
+#[derive(Default)]
+pub struct RenderCache {
+    fonts: std::sync::Mutex<pdfboss_core::FastMap<pdfboss_core::ObjRef, executor::SharedGlyphFont>>,
+}
+
+impl std::fmt::Debug for RenderCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let fonts = self.fonts.lock().map(|m| m.len()).unwrap_or(0);
+        f.debug_struct("RenderCache")
+            .field("fonts", &fonts)
+            .finish()
+    }
+}
+
+impl RenderCache {
+    pub(crate) fn font(&self, r: pdfboss_core::ObjRef) -> Option<executor::SharedGlyphFont> {
+        self.fonts.lock().ok()?.get(&r).cloned()
+    }
+
+    /// First writer wins, exactly like the text-side cache: concurrent
+    /// workers may load the same font twice and the copies are
+    /// interchangeable.
+    pub(crate) fn store(&self, r: pdfboss_core::ObjRef, font: executor::SharedGlyphFont) {
+        if let Ok(mut fonts) = self.fonts.lock() {
+            fonts.entry(r).or_insert(font);
+        }
+    }
 }
 
 /// Whether this binary was built with the `substitute-fonts` feature, i.e.

--- a/crates/pdfboss-render/src/raster.rs
+++ b/crates/pdfboss-render/src/raster.rs
@@ -721,6 +721,33 @@ fn blend_row<const NORMAL: bool>(
                     fill_run(&mut dst_row[start * 4..x * 4], opaque);
                     continue;
                 }
+                // Anti-aliased stretches composite four pixels per step on
+                // vector lanes where the arithmetic is bit-identical to
+                // [`composite_over`]; lanes at full coverage or zero take
+                // the same shortcuts the scalar form takes.
+                if NORMAL {
+                    while x + 4 <= n && !(solid_src && covs[x..x + 4].iter().any(|&c| c >= 1.0)) {
+                        blend_normal4(
+                            &mut dst_row[x * 4..x * 4 + 16],
+                            &covs[x..x + 4],
+                            base_a,
+                            rgb,
+                            opaque,
+                        );
+                        x += 4;
+                    }
+                    if x >= n {
+                        break;
+                    }
+                    let cov = covs[x];
+                    if solid_src && cov >= 1.0 {
+                        continue;
+                    }
+                    let a = cov.clamp(0.0, 1.0) * base_a;
+                    paint_pixel::<NORMAL>(&mut dst_row[x * 4..(x + 1) * 4], a, rgb, opaque, blend);
+                    x += 1;
+                    continue;
+                }
                 let a = cov.clamp(0.0, 1.0) * base_a;
                 paint_pixel::<NORMAL>(&mut dst_row[x * 4..(x + 1) * 4], a, rgb, opaque, blend);
                 x += 1;
@@ -745,6 +772,188 @@ fn blend_row<const NORMAL: bool>(
                 x += 1;
             }
         }
+    }
+}
+
+/// Source-over composites four adjacent pixels of one row: the vector
+/// twin of four [`paint_pixel::<true>`] calls, byte-identical because the
+/// lanes perform [`composite_over`]'s exact f32 operations (no fused
+/// multiply-add, truncating converts) and the full/zero-coverage lanes
+/// reproduce its shortcuts.
+fn blend_normal4(dst: &mut [u8], covs: &[f32], base_a: f32, rgb: [u8; 3], opaque: [u8; 4]) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: NEON is baseline on aarch64.
+        unsafe { blend_hw::normal4(dst, covs, base_a, rgb, opaque) };
+        return;
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: SSE2 is baseline on x86_64.
+        unsafe { blend_hw::normal4(dst, covs, base_a, rgb, opaque) };
+        return;
+    }
+    #[allow(unreachable_code)]
+    for (i, &cov) in covs.iter().enumerate() {
+        let a = cov.clamp(0.0, 1.0) * base_a;
+        paint_pixel::<true>(
+            &mut dst[i * 4..i * 4 + 4],
+            a,
+            rgb,
+            opaque,
+            BlendMode::Normal,
+        );
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+mod blend_hw {
+    use core::arch::aarch64::{
+        vaddq_f32, vbslq_u32, vceqq_f32, vcgeq_f32, vcleq_f32, vcvtq_f32_u32, vcvtq_u32_f32,
+        vdivq_f32, vdupq_n_f32, vdupq_n_u32, vld1q_f32, vld1q_u8, vmaxq_f32, vminq_f32, vmulq_f32,
+        vreinterpretq_u32_u8, vreinterpretq_u8_u32, vst1q_u8, vsubq_f32,
+    };
+
+    /// # Safety
+    /// NEON is baseline on aarch64; `dst` must hold 16 bytes and `covs`
+    /// four coverages.
+    pub unsafe fn normal4(
+        dst: &mut [u8],
+        covs: &[f32],
+        base_a: f32,
+        rgb: [u8; 3],
+        opaque: [u8; 4],
+    ) {
+        let one = vdupq_n_f32(1.0);
+        let zero = vdupq_n_f32(0.0);
+        // a = clamp(cov, 0, 1) * base_a, per pixel.
+        let cov = vld1q_f32(covs.as_ptr());
+        let a = vmulq_f32(vminq_f32(vmaxq_f32(cov, zero), one), vdupq_n_f32(base_a));
+
+        // Load 4 interleaved RGBA pixels and split channels via shifts.
+        let px = vreinterpretq_u32_u8(vld1q_u8(dst.as_ptr()));
+        let byte = |lane_shift: u32| {
+            use core::arch::aarch64::{vandq_u32, vdupq_n_u32, vshrq_n_u32};
+            let shifted = match lane_shift {
+                0 => px,
+                8 => vshrq_n_u32::<8>(px),
+                16 => vshrq_n_u32::<16>(px),
+                _ => vshrq_n_u32::<24>(px),
+            };
+            vcvtq_f32_u32(vandq_u32(shifted, vdupq_n_u32(0xff)))
+        };
+        let (dr, dg, db, da_bytes) = (byte(0), byte(8), byte(16), byte(24));
+
+        let da = vdivq_f32(da_bytes, vdupq_n_f32(255.0));
+        let one_minus_a = vsubq_f32(one, a);
+        let oa = vaddq_f32(a, vmulq_f32(da, one_minus_a));
+        let dw = vmulq_f32(da, one_minus_a);
+
+        let half = vdupq_n_f32(0.5);
+        let channel = |s: u8, d: core::arch::aarch64::float32x4_t| {
+            let c = vdivq_f32(
+                vaddq_f32(vmulq_f32(vdupq_n_f32(s as f32), a), vmulq_f32(d, dw)),
+                oa,
+            );
+            vcvtq_u32_f32(vaddq_f32(c, half))
+        };
+        let r = channel(rgb[0], dr);
+        let g = channel(rgb[1], dg);
+        let b = channel(rgb[2], db);
+        let out_a = vcvtq_u32_f32(vaddq_f32(vmulq_f32(oa, vdupq_n_f32(255.0)), half));
+
+        use core::arch::aarch64::{vorrq_u32, vshlq_n_u32};
+        let packed = vorrq_u32(
+            vorrq_u32(r, vshlq_n_u32::<8>(g)),
+            vorrq_u32(vshlq_n_u32::<16>(b), vshlq_n_u32::<24>(out_a)),
+        );
+
+        // Per-lane shortcuts, exactly the scalar branches: a <= 0 leaves
+        // the pixel; a >= 1 writes the opaque source; oa <= 0 writes
+        // transparent black.
+        let src_lane = vdupq_n_u32(u32::from_le_bytes(opaque));
+        let zero_lane = vdupq_n_u32(0);
+        let keep = vcleq_f32(a, zero);
+        let full = vcgeq_f32(a, one);
+        let clear = vceqq_f32(vminq_f32(oa, zero), oa); // oa <= 0
+        let mut out = vbslq_u32(clear, zero_lane, packed);
+        out = vbslq_u32(full, src_lane, out);
+        out = vbslq_u32(keep, px, out);
+        vst1q_u8(dst.as_mut_ptr(), vreinterpretq_u8_u32(out));
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+mod blend_hw {
+    use core::arch::x86_64::{
+        __m128, __m128i, _mm_add_ps, _mm_and_si128, _mm_andnot_si128, _mm_castps_si128,
+        _mm_cmpge_ps, _mm_cmple_ps, _mm_cvtepi32_ps, _mm_cvttps_epi32, _mm_div_ps, _mm_loadu_ps,
+        _mm_loadu_si128, _mm_max_ps, _mm_min_ps, _mm_mul_ps, _mm_or_si128, _mm_set1_epi32,
+        _mm_set1_ps, _mm_slli_epi32, _mm_srli_epi32, _mm_storeu_si128, _mm_sub_ps,
+    };
+
+    /// # Safety
+    /// SSE2 is baseline on x86_64; `dst` must hold 16 bytes and `covs`
+    /// four coverages.
+    pub unsafe fn normal4(
+        dst: &mut [u8],
+        covs: &[f32],
+        base_a: f32,
+        rgb: [u8; 3],
+        opaque: [u8; 4],
+    ) {
+        let one = _mm_set1_ps(1.0);
+        let zero = _mm_set1_ps(0.0);
+        let cov = _mm_loadu_ps(covs.as_ptr());
+        let a = _mm_mul_ps(_mm_min_ps(_mm_max_ps(cov, zero), one), _mm_set1_ps(base_a));
+
+        let px = _mm_loadu_si128(dst.as_ptr().cast::<__m128i>());
+        let mask = _mm_set1_epi32(0xff);
+        let byte = |shift: i32| -> __m128 {
+            let shifted = match shift {
+                0 => px,
+                8 => _mm_srli_epi32(px, 8),
+                16 => _mm_srli_epi32(px, 16),
+                _ => _mm_srli_epi32(px, 24),
+            };
+            _mm_cvtepi32_ps(_mm_and_si128(shifted, mask))
+        };
+        let (dr, dg, db, da_bytes) = (byte(0), byte(8), byte(16), byte(24));
+
+        let da = _mm_div_ps(da_bytes, _mm_set1_ps(255.0));
+        let one_minus_a = _mm_sub_ps(one, a);
+        let oa = _mm_add_ps(a, _mm_mul_ps(da, one_minus_a));
+        let dw = _mm_mul_ps(da, one_minus_a);
+
+        let half = _mm_set1_ps(0.5);
+        let channel = |s: u8, d: __m128| -> __m128i {
+            let c = _mm_div_ps(
+                _mm_add_ps(_mm_mul_ps(_mm_set1_ps(s as f32), a), _mm_mul_ps(d, dw)),
+                oa,
+            );
+            _mm_cvttps_epi32(_mm_add_ps(c, half))
+        };
+        let r = channel(rgb[0], dr);
+        let g = channel(rgb[1], dg);
+        let b = channel(rgb[2], db);
+        let out_a = _mm_cvttps_epi32(_mm_add_ps(_mm_mul_ps(oa, _mm_set1_ps(255.0)), half));
+
+        let packed = _mm_or_si128(
+            _mm_or_si128(r, _mm_slli_epi32(g, 8)),
+            _mm_or_si128(_mm_slli_epi32(b, 16), _mm_slli_epi32(out_a, 24)),
+        );
+
+        let src_lane = _mm_set1_epi32(i32::from_le_bytes(opaque));
+        let keep = _mm_castps_si128(_mm_cmple_ps(a, zero));
+        let full = _mm_castps_si128(_mm_cmpge_ps(a, one));
+        let clear = _mm_castps_si128(_mm_cmple_ps(oa, zero));
+        let mut out = _mm_or_si128(
+            _mm_andnot_si128(clear, packed),
+            _mm_and_si128(clear, _mm_set1_epi32(0)),
+        );
+        out = _mm_or_si128(_mm_and_si128(full, src_lane), _mm_andnot_si128(full, out));
+        out = _mm_or_si128(_mm_and_si128(keep, px), _mm_andnot_si128(keep, out));
+        _mm_storeu_si128(dst.as_mut_ptr().cast::<__m128i>(), out);
     }
 }
 
@@ -785,6 +994,61 @@ pub(crate) fn paint_pixel<const NORMAL: bool>(
         dst.copy_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
     } else {
         composite_over(dst, rgb, a);
+    }
+}
+
+#[cfg(test)]
+mod blend_hw_tests {
+    use super::*;
+
+    /// The vector composite must be byte-identical to four scalar
+    /// [`paint_pixel`] calls across every lane-shortcut combination:
+    /// zero coverage, full coverage, transparent destinations, and
+    /// anti-aliased fractions, mixed within one vector.
+    #[test]
+    fn vector_blend_matches_scalar_bytes() {
+        let mut state = 0x2468aceu32;
+        let mut next = move || {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            state
+        };
+        for _ in 0..2000 {
+            let covs: Vec<f32> = (0..4)
+                .map(|_| match next() % 5 {
+                    0 => 0.0,
+                    1 => 1.0,
+                    2 => 1.5,
+                    3 => -0.25,
+                    _ => (next() % 1000) as f32 / 1000.0,
+                })
+                .collect();
+            let base_a = match next() % 3 {
+                0 => 1.0,
+                1 => 0.0,
+                _ => (next() % 1000) as f32 / 1000.0,
+            };
+            let rgb = [next() as u8, next() as u8, next() as u8];
+            let opaque = [rgb[0], rgb[1], rgb[2], 255];
+            let mut dst: Vec<u8> = (0..16).map(|_| next() as u8).collect();
+            if next() % 4 == 0 {
+                for px in dst.chunks_exact_mut(4) {
+                    px[3] = 0;
+                }
+            }
+            let mut scalar = dst.clone();
+            for (i, &cov) in covs.iter().enumerate() {
+                let a = cov.clamp(0.0, 1.0) * base_a;
+                paint_pixel::<true>(
+                    &mut scalar[i * 4..i * 4 + 4],
+                    a,
+                    rgb,
+                    opaque,
+                    BlendMode::Normal,
+                );
+            }
+            blend_normal4(&mut dst, &covs, base_a, rgb, opaque);
+            assert_eq!(dst, scalar, "covs {covs:?} base_a {base_a}");
+        }
     }
 }
 

--- a/crates/pdfboss-render/src/raster.rs
+++ b/crates/pdfboss-render/src/raster.rs
@@ -1031,7 +1031,7 @@ mod blend_hw_tests {
             let opaque = [rgb[0], rgb[1], rgb[2], 255];
             let mut dst: Vec<u8> = (0..16).map(|_| next() as u8).collect();
             if next() % 4 == 0 {
-                for px in dst.chunks_exact_mut(4) {
+                for px in dst.as_chunks_mut::<4>().0 {
                     px[3] = 0;
                 }
             }

--- a/crates/pdfboss-render/src/raster.rs
+++ b/crates/pdfboss-render/src/raster.rs
@@ -1518,3 +1518,109 @@ mod tests {
         assert_eq!(alpha_at(&pix, 5, 4), 255);
     }
 }
+
+#[cfg(test)]
+mod stage_times {
+    use super::*;
+    use pdfboss_core::geom::Point;
+
+    fn glyph_like(cx: f32, cy: f32) -> Vec<Subpath> {
+        // An 8-point closed blob roughly the size of a 12pt glyph.
+        let pts = [
+            (0.0, 0.0),
+            (4.0, -1.0),
+            (7.0, 2.0),
+            (8.0, 6.0),
+            (6.0, 9.0),
+            (3.0, 10.0),
+            (0.5, 8.0),
+            (-1.0, 4.0),
+        ];
+        vec![Subpath {
+            points: pts
+                .iter()
+                .map(|&(x, y)| Point::new(cx + x, cy + y))
+                .collect(),
+            closed: true,
+        }]
+    }
+
+    /// Not a correctness test: prints where a text-page-shaped fill
+    /// workload spends its time. Run explicitly:
+    /// `cargo test --release -p pdfboss-render raster::stage_times -- --nocapture --ignored`
+    #[test]
+    #[ignore]
+    fn print_stage_times() {
+        let mut pix = Pixmap::new(612, 792);
+        pix.fill([255, 255, 255, 255]);
+        let mut scratch = RasterScratch::default();
+        let glyphs: Vec<Vec<Subpath>> = (0..2000)
+            .map(|i| glyph_like(20.0 + (i % 60) as f32 * 9.5, 20.0 + (i / 60) as f32 * 12.0))
+            .collect();
+        let reps = 20;
+
+        // Whole fill (edges + sweep + blend).
+        let t0 = std::time::Instant::now();
+        for _ in 0..reps {
+            for polys in &glyphs {
+                fill_path(
+                    &mut pix,
+                    &mut scratch,
+                    polys,
+                    FillRule::NonZero,
+                    [20, 20, 20, 255],
+                    1.0,
+                    None,
+                    BlendMode::Normal,
+                );
+            }
+        }
+        println!("fill (2000 glyphs): {:?}/page", t0.elapsed() / reps);
+
+        // Sweep only: coverage accumulation with a no-op emit.
+        let t0 = std::time::Instant::now();
+        for _ in 0..reps {
+            for polys in &glyphs {
+                prepare_edges(&mut scratch.edges, polys);
+                sweep_rows(&mut scratch, 612, 792, FillRule::NonZero, |_, _, _, _| {});
+            }
+        }
+        println!("sweep only:         {:?}/page", t0.elapsed() / reps);
+
+        // Edge preparation alone.
+        let t0 = std::time::Instant::now();
+        for _ in 0..reps {
+            for polys in &glyphs {
+                prepare_edges(&mut scratch.edges, polys);
+            }
+        }
+        println!("prepare_edges:      {:?}/page", t0.elapsed() / reps);
+
+        // One big fill: a page-sized rounded blob, 40 of them.
+        let big: Vec<Subpath> = vec![Subpath {
+            points: (0..64)
+                .map(|i| {
+                    let a = i as f32 / 64.0 * std::f32::consts::TAU;
+                    Point::new(306.0 + 280.0 * a.cos(), 396.0 + 370.0 * a.sin())
+                })
+                .collect(),
+            closed: true,
+        }];
+        let t0 = std::time::Instant::now();
+        for _ in 0..reps {
+            for _ in 0..40 {
+                fill_path(
+                    &mut pix,
+                    &mut scratch,
+                    &big,
+                    FillRule::NonZero,
+                    [40, 80, 120, 200],
+                    0.8,
+                    None,
+                    BlendMode::Normal,
+                );
+            }
+        }
+        println!("fill (40 big):      {:?}/page", t0.elapsed() / reps);
+    }
+}


### PR DESCRIPTION
Checkpoint 2 of the out-render-pdfium campaign, stacked on #92. Mixed-corpus harness, one session: **112.0 pages/s** (from 96.8 after #92 alone; started at 80.8) — now 2nd of 4, ahead of pdfplumber (103.7) and PyMuPDF (92.1), 8% behind pypdfium2 (121.5). The scans table was already won in #92 (63.7 vs 53.2).

- **`RenderCache`** on `RenderOptions`: fonts keyed by their dictionary's ObjRef load once per document (text's `FontCache` pattern). A hit never resolves the dictionary; the chain walk keeps `find_res`'s null-falls-through semantics. Proof: a resolution-counting test (1 load/document vs 2 uncached) plus byte-identical pixels. Python `Document` owns one, shared with every `Page` and the `render_pages` fan-out workers.
- **Sampled Huffman counting** in the PNG encoder (half-image sample, 1-floors keep all codes describable) and **white-allocated pages** (no zero-then-fill double pass).
- **Vector composite** for anti-aliased stretches: 4 pixels/step on NEON/SSE2 doing `composite_over`'s exact f32 ops — differential test pins byte equality across every lane-shortcut mix (zero/full/fractional coverage, transparent backdrops).

Verification: workspace 1931 passed, pytest 132, clippy clean on aarch64 + x86_64 targets, Rosetta x86 execution green, size unchanged (124 KiB/page vs the pdfium stack's 129).

Remaining vs pdfium (~8%, run-to-run swing ±5%): the rasterizer's coverage inner loops (edge crossings/sort/accumulation) and `draw_rgba` resampling — under investigation next.