### PR TITLE
feat(write): PDF creation suite — pdfboss-write crate, async parity, create CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,9 @@ dependencies = [
  "flate2",
  "pdfboss-core",
  "pdfboss-encoding",
+ "pdfboss-output",
  "pdfboss-render",
+ "pdfboss-text",
  "png",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,7 @@ dependencies = [
  "pdfboss-output",
  "pdfboss-render",
  "pdfboss-testkit",
+ "pdfboss-write",
  "reqwest",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdfboss-write"
+version = "0.19.1"
+dependencies = [
+ "flate2",
+ "pdfboss-core",
+ "pdfboss-encoding",
+ "pdfboss-render",
+ "png",
+ "thiserror",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,8 @@ dependencies = [
  "pdfboss-testkit",
  "pdfboss-text",
  "pdfboss-tui",
+ "pdfboss-write",
+ "png",
  "serde_json",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/pdfboss-py",
     "crates/pdfboss-testkit",
     "crates/pdfboss-tui",
+    "crates/pdfboss-write",
 ]
 
 [workspace.package]
@@ -36,6 +37,7 @@ pdfboss-output = { path = "crates/pdfboss-output", version = "0.19.1" } # x-rele
 pdfboss-render = { path = "crates/pdfboss-render", version = "0.19.1" } # x-release-please-version
 pdfboss-aio = { path = "crates/pdfboss-aio", version = "0.19.1" } # x-release-please-version
 pdfboss-tui = { path = "crates/pdfboss-tui", version = "0.19.1" } # x-release-please-version
+pdfboss-write = { path = "crates/pdfboss-write", version = "0.19.1" } # x-release-please-version
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 tokio = { version = "1", default-features = false, features = ["rt", "rt-multi-thread", "fs", "sync", "io-util"] }
 futures-core = "0.3"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ pdfboss text    report.pdf --page 2        # extract text (omit --page for all)
 pdfboss md      report.pdf                 # markdown: headings, lists, tables from layout
 pdfboss render  report.pdf --page 1 -o page.png --scale 2.0
 pdfboss tui     report.pdf                 # interactive terminal explorer
+pdfboss create blank  -o out.pdf --pages 3    # new PDF: empty pages
+pdfboss create text   notes.txt -o out.pdf    # new PDF: word-wrapped text
+pdfboss create images a.png b.jpg -o out.pdf  # new PDF: one page per image
 ```
 
 ```python

--- a/crates/pdfboss-aio/Cargo.toml
+++ b/crates/pdfboss-aio/Cargo.toml
@@ -10,6 +10,7 @@ keywords.workspace = true
 
 [dependencies]
 pdfboss-core = { workspace = true }
+pdfboss-write = { workspace = true, optional = true }
 tokio = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
@@ -20,6 +21,8 @@ reqwest = { workspace = true, optional = true, features = ["stream"] }
 [features]
 # Remote documents over HTTP range requests.
 http = ["dep:reqwest"]
+# Streaming created documents into tokio writers.
+write = ["dep:pdfboss-write"]
 
 [dev-dependencies]
 pdfboss-testkit = { path = "../pdfboss-testkit" }

--- a/crates/pdfboss-aio/src/lib.rs
+++ b/crates/pdfboss-aio/src/lib.rs
@@ -9,6 +9,8 @@ pub mod backend;
 pub mod cache;
 pub mod document;
 pub mod error;
+#[cfg(feature = "write")]
+pub mod sink;
 pub mod stream;
 
 #[cfg(feature = "http")]
@@ -17,4 +19,6 @@ pub use backend::{Backend, BoxFuture, FileBackend, MemBackend};
 pub use cache::CachedBackend;
 pub use document::AsyncDocument;
 pub use error::{Error, Result};
+#[cfg(feature = "write")]
+pub use sink::TokioSink;
 pub use stream::ElementStream;

--- a/crates/pdfboss-aio/src/sink.rs
+++ b/crates/pdfboss-aio/src/sink.rs
@@ -1,0 +1,78 @@
+//! Streams documents built with `pdfboss-write` into tokio writers: files,
+//! sockets, anything implementing [`tokio::io::AsyncWrite`]. Only compiled
+//! with the `write` feature.
+
+use pdfboss_core::source::BoxFuture;
+use pdfboss_write::sink::AsyncByteSink;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+/// Presents any [`tokio::io::AsyncWrite`] as the byte sink the write
+/// crate's emission streams into — hand `TokioSink(file)` to
+/// [`pdfboss_write::Pdf::write_into_with`] or
+/// [`pdfboss_write::Writer::finish_into_with`] and take the writer back
+/// out of the returned sink's field. No flush is ever performed: flush (or
+/// shut down) the recovered writer yourself before dropping it.
+#[derive(Debug)]
+pub struct TokioSink<W>(pub W);
+
+impl<W: AsyncWrite + Unpin + Send> AsyncByteSink for TokioSink<W> {
+    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> BoxFuture<'a, pdfboss_write::Result<()>> {
+        Box::pin(async move {
+            self.0.write_all(buf).await?;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pdfboss_write::{Page, PageSize, Pdf, Standard14};
+    use tokio::io::AsyncWriteExt;
+
+    use super::TokioSink;
+
+    fn hello_doc() -> Pdf {
+        let mut page = Page::new(PageSize::A4);
+        page.canvas
+            .text(
+                "Streamed through tokio",
+                72.0,
+                720.0,
+                Standard14::Helvetica,
+                14.0,
+            )
+            .expect("ASCII encodes");
+        Pdf {
+            pages: vec![page],
+            ..Pdf::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn tokio_sink_over_a_vec_matches_to_bytes() {
+        let expected = hello_doc().to_bytes().expect("to_bytes succeeds");
+        let sink = hello_doc()
+            .write_into_with(TokioSink(Vec::new()))
+            .await
+            .expect("write_into_with succeeds");
+        assert_eq!(sink.0, expected);
+    }
+
+    #[tokio::test]
+    async fn tokio_sink_over_a_file_round_trips() {
+        let path =
+            std::env::temp_dir().join(format!("pdfboss-aio-sink-test-{}.pdf", std::process::id()));
+        let file = tokio::fs::File::create(&path).await.expect("file creates");
+        let mut sink = hello_doc()
+            .write_into_with(TokioSink(file))
+            .await
+            .expect("write_into_with succeeds");
+        sink.0.flush().await.expect("file flushes");
+        drop(sink);
+        let bytes = std::fs::read(&path).expect("file reads back");
+        std::fs::remove_file(&path).ok();
+        assert_eq!(bytes, hello_doc().to_bytes().expect("to_bytes succeeds"));
+        let doc = pdfboss_core::Document::load(bytes).expect("written file loads");
+        assert_eq!(doc.page_count(), 1);
+    }
+}

--- a/crates/pdfboss-cli/Cargo.toml
+++ b/crates/pdfboss-cli/Cargo.toml
@@ -15,6 +15,7 @@ pdfboss-output = { workspace = true }
 pdfboss-render = { workspace = true }
 pdfboss-aio = { workspace = true, features = ["http"] }
 pdfboss-tui = { workspace = true }
+pdfboss-write = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 base64 = "0.22"
@@ -26,6 +27,7 @@ jaq-json = { version = "1", features = ["serde_json"] }
 
 [dev-dependencies]
 pdfboss-testkit = { path = "../pdfboss-testkit" }
+png = "0.18"
 
 [features]
 # Bundled substitute faces are on by default: `cargo install pdfboss-cli`

--- a/crates/pdfboss-cli/src/create.rs
+++ b/crates/pdfboss-cli/src/create.rs
@@ -1,0 +1,790 @@
+//! `pdfboss create`: making new PDFs — blank pages, word-wrapped text
+//! files, and one-page-per-image albums — on top of `pdfboss-write`.
+
+use std::path::{Path, PathBuf};
+
+use clap::Subcommand;
+use pdfboss_write::{Canvas, ImageData, Page, PageSize, Pdf, Standard14};
+
+/// The nested subcommands of `pdfboss create`.
+#[derive(Subcommand)]
+pub enum CreateCommand {
+    /// Empty pages.
+    Blank {
+        /// Output PDF file.
+        #[arg(short, long)]
+        out: PathBuf,
+        /// Number of pages.
+        #[arg(long, default_value_t = 1)]
+        pages: usize,
+        /// Page size.
+        #[arg(long, value_enum, default_value_t = SizeArg::A4)]
+        size: SizeArg,
+        /// Swap page width and height.
+        #[arg(long)]
+        landscape: bool,
+    },
+    /// A UTF-8 text file, word-wrapped into pages.
+    Text {
+        /// Path to the UTF-8 text file.
+        input: PathBuf,
+        /// Output PDF file.
+        #[arg(short, long)]
+        out: PathBuf,
+        /// Font face (one of the fourteen standard fonts).
+        #[arg(long, value_enum, default_value_t = FontArg::Helvetica)]
+        font: FontArg,
+        /// Font size in points.
+        #[arg(long, default_value_t = 11.0)]
+        font_size: f32,
+        /// Page size.
+        #[arg(long, value_enum, default_value_t = SizeArg::A4)]
+        size: SizeArg,
+        /// Swap page width and height.
+        #[arg(long)]
+        landscape: bool,
+        /// Page margin in points, all four sides.
+        #[arg(long, default_value_t = 72.0)]
+        margin: f32,
+    },
+    /// One page per input image (PNG or JPEG, detected by content).
+    Images {
+        /// Paths of the image files.
+        #[arg(required = true)]
+        inputs: Vec<PathBuf>,
+        /// Output PDF file.
+        #[arg(short, long)]
+        out: PathBuf,
+        /// Page size (default: each page matches its image at 72 dpi).
+        #[arg(long, value_enum)]
+        size: Option<SizeArg>,
+        /// Swap page width and height (only meaningful with --size).
+        #[arg(long, requires = "size")]
+        landscape: bool,
+    },
+}
+
+/// `--font` choices for `create text`, mirroring
+/// `pdfboss_write::Standard14`.
+#[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
+pub enum FontArg {
+    /// Helvetica (default).
+    #[default]
+    Helvetica,
+    /// Helvetica-Bold.
+    HelveticaBold,
+    /// Helvetica-Oblique.
+    HelveticaOblique,
+    /// Helvetica-BoldOblique.
+    HelveticaBoldOblique,
+    /// Times-Roman.
+    TimesRoman,
+    /// Times-Bold.
+    TimesBold,
+    /// Times-Italic.
+    TimesItalic,
+    /// Times-BoldItalic.
+    TimesBoldItalic,
+    /// Courier.
+    Courier,
+    /// Courier-Bold.
+    CourierBold,
+    /// Courier-Oblique.
+    CourierOblique,
+    /// Courier-BoldOblique.
+    CourierBoldOblique,
+    /// Symbol.
+    Symbol,
+    /// ZapfDingbats.
+    ZapfDingbats,
+}
+
+impl FontArg {
+    /// The library font this flag names.
+    fn to_standard14(self) -> Standard14 {
+        match self {
+            FontArg::Helvetica => Standard14::Helvetica,
+            FontArg::HelveticaBold => Standard14::HelveticaBold,
+            FontArg::HelveticaOblique => Standard14::HelveticaOblique,
+            FontArg::HelveticaBoldOblique => Standard14::HelveticaBoldOblique,
+            FontArg::TimesRoman => Standard14::TimesRoman,
+            FontArg::TimesBold => Standard14::TimesBold,
+            FontArg::TimesItalic => Standard14::TimesItalic,
+            FontArg::TimesBoldItalic => Standard14::TimesBoldItalic,
+            FontArg::Courier => Standard14::Courier,
+            FontArg::CourierBold => Standard14::CourierBold,
+            FontArg::CourierOblique => Standard14::CourierOblique,
+            FontArg::CourierBoldOblique => Standard14::CourierBoldOblique,
+            FontArg::Symbol => Standard14::Symbol,
+            FontArg::ZapfDingbats => Standard14::ZapfDingbats,
+        }
+    }
+}
+
+/// `--size` choices, mirroring `pdfboss_write::PageSize`'s named sizes.
+#[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
+pub enum SizeArg {
+    /// 297 × 420 mm.
+    A3,
+    /// 210 × 297 mm (default).
+    #[default]
+    A4,
+    /// 148 × 210 mm.
+    A5,
+    /// 8.5 × 11 in.
+    Letter,
+    /// 8.5 × 14 in.
+    Legal,
+}
+
+impl SizeArg {
+    /// The library page size this flag names.
+    fn to_page_size(self) -> PageSize {
+        match self {
+            SizeArg::A3 => PageSize::A3,
+            SizeArg::A4 => PageSize::A4,
+            SizeArg::A5 => PageSize::A5,
+            SizeArg::Letter => PageSize::Letter,
+            SizeArg::Legal => PageSize::Legal,
+        }
+    }
+}
+
+/// Runs one `create` subcommand.
+pub fn cmd_create(command: CreateCommand) -> Result<(), String> {
+    let (pages, out) = match command {
+        CreateCommand::Blank {
+            out,
+            pages,
+            size,
+            landscape,
+        } => (blank_pages(pages, resolved_size(size, landscape))?, out),
+        CreateCommand::Text {
+            input,
+            out,
+            font,
+            font_size,
+            size,
+            landscape,
+            margin,
+        } => {
+            let text =
+                std::fs::read_to_string(&input).map_err(|e| format!("{}: {e}", input.display()))?;
+            let pages = text_pages(
+                &text,
+                font.to_standard14(),
+                font_size,
+                resolved_size(size, landscape),
+                margin,
+            )?;
+            (pages, out)
+        }
+        CreateCommand::Images {
+            inputs,
+            out,
+            size,
+            landscape,
+        } => {
+            let page_size = size.map(|s| resolved_size(s, landscape));
+            let mut pages = Vec::with_capacity(inputs.len());
+            for input in &inputs {
+                let bytes =
+                    std::fs::read(input).map_err(|e| format!("{}: {e}", input.display()))?;
+                let image =
+                    decode_image(&bytes).map_err(|e| format!("{}: {e}", input.display()))?;
+                pages.push(image_page(image, page_size));
+            }
+            (pages, out)
+        }
+    };
+    save(pages, &out)
+}
+
+/// Assembles `pages` into a document, writes it to `out` and prints a
+/// summary line.
+fn save(pages: Vec<Page>, out: &Path) -> Result<(), String> {
+    let count = pages.len();
+    let pdf = Pdf {
+        pages,
+        ..Pdf::default()
+    };
+    pdf.save(out)
+        .map_err(|e| format!("{}: {e}", out.display()))?;
+    let plural = if count == 1 { "" } else { "s" };
+    println!("wrote {} ({count} page{plural})", out.display());
+    Ok(())
+}
+
+/// The library page size for `--size`, swapped by `--landscape`.
+fn resolved_size(size: SizeArg, landscape: bool) -> PageSize {
+    let size = size.to_page_size();
+    if !landscape {
+        return size;
+    }
+    size.landscape()
+}
+
+/// `count` empty pages of `size`; zero pages is an error, not an
+/// unloadable document.
+fn blank_pages(count: usize, size: PageSize) -> Result<Vec<Page>, String> {
+    if count == 0 {
+        return Err("--pages must be at least 1".to_string());
+    }
+    Ok((0..count).map(|_| Page::new(size)).collect())
+}
+
+/// Lays `text` out into pages: word-wrapped between the margins, line
+/// advance 1.2 × font size, a new page whenever the next baseline would
+/// drop below the bottom margin.
+fn text_pages(
+    text: &str,
+    face: Standard14,
+    font_size: f32,
+    page_size: PageSize,
+    margin: f32,
+) -> Result<Vec<Page>, String> {
+    if !font_size.is_finite() || font_size <= 0.0 {
+        return Err(format!("font size {font_size} must be a positive number"));
+    }
+    if !margin.is_finite() || margin < 0.0 {
+        return Err(format!("margin {margin} must be zero or more"));
+    }
+    let (width, height) = page_size.dimensions();
+    let max_width = width - 2.0 * margin;
+    let top = height - margin - font_size;
+    if max_width <= 0.0 || top < margin {
+        return Err(format!(
+            "margin {margin} and font size {font_size} leave no room for text \
+             on a {width} x {height} pt page"
+        ));
+    }
+    let rows = wrap_text(text, face, font_size, max_width)?;
+    let advance = 1.2 * font_size;
+    let mut pages = Vec::new();
+    let mut canvas = Canvas::new();
+    let mut y = top;
+    for row in rows {
+        if y < margin {
+            pages.push(page_with(page_size, std::mem::take(&mut canvas)));
+            y = top;
+        }
+        if !row.is_empty() {
+            canvas
+                .text(&row, margin, y, face, font_size)
+                .map_err(|e| e.to_string())?;
+        }
+        y -= advance;
+    }
+    pages.push(page_with(page_size, canvas));
+    Ok(pages)
+}
+
+/// A page of `size` holding an already-painted canvas.
+fn page_with(size: PageSize, canvas: Canvas) -> Page {
+    Page {
+        size,
+        rotation: 0,
+        canvas,
+    }
+}
+
+/// Expands tabs to four spaces, splits `text` into lines (CRLF tolerated)
+/// and word-wraps each to `max_width`, returning paint-ready rows. Blank
+/// source lines yield one empty row so vertical spacing survives.
+fn wrap_text(
+    text: &str,
+    face: Standard14,
+    size: f32,
+    max_width: f32,
+) -> Result<Vec<String>, String> {
+    let mut rows = Vec::new();
+    for (index, raw) in text.lines().enumerate() {
+        let line = raw.replace('\t', "    ");
+        wrap_line(&line, face, size, max_width, index + 1, &mut rows)?;
+    }
+    Ok(rows)
+}
+
+/// Greedy word wrap of one source line into `rows`: words fill each row up
+/// to `max_width`, the space run before a word survives inside a row and is
+/// dropped at a break, and a word too wide for a whole row is broken hard,
+/// character by character. A line with no words yields one empty row.
+fn wrap_line(
+    line: &str,
+    face: Standard14,
+    size: f32,
+    max_width: f32,
+    line_no: usize,
+    rows: &mut Vec<String>,
+) -> Result<(), String> {
+    let start = rows.len();
+    let mut current = String::new();
+    let mut current_width = 0.0f32;
+    for (spaces, word) in tokens(line) {
+        if word.is_empty() {
+            continue;
+        }
+        let at_line_start = rows.len() == start && current.is_empty();
+        let glue = if at_line_start || !current.is_empty() {
+            spaces
+        } else {
+            ""
+        };
+        let addition = format!("{glue}{word}");
+        let addition_width = measured(face, line_no, &addition, size)?;
+        if current_width + addition_width <= max_width {
+            current.push_str(&addition);
+            current_width += addition_width;
+            continue;
+        }
+        if !current.is_empty() {
+            rows.push(std::mem::take(&mut current));
+            current_width = 0.0;
+        }
+        let word_width = measured(face, line_no, word, size)?;
+        if word_width <= max_width {
+            current.push_str(word);
+            current_width = word_width;
+            continue;
+        }
+        for ch in word.chars() {
+            let ch_width = measured(face, line_no, &String::from(ch), size)?;
+            if !current.is_empty() && current_width + ch_width > max_width {
+                rows.push(std::mem::take(&mut current));
+                current_width = 0.0;
+            }
+            current.push(ch);
+            current_width += ch_width;
+        }
+    }
+    if !current.is_empty() || rows.len() == start {
+        rows.push(current);
+    }
+    Ok(())
+}
+
+/// Splits a line into `(space run, word)` pairs whose concatenation is the
+/// line; a line ending in spaces yields a final pair with an empty word.
+fn tokens(line: &str) -> Vec<(&str, &str)> {
+    let mut out = Vec::new();
+    let mut rest = line;
+    while !rest.is_empty() {
+        let space_len = rest.len() - rest.trim_start_matches(' ').len();
+        let (spaces, tail) = rest.split_at(space_len);
+        let word_len = tail.find(' ').unwrap_or(tail.len());
+        let (word, tail) = tail.split_at(word_len);
+        out.push((spaces, word));
+        rest = tail;
+    }
+    out
+}
+
+/// Measures `piece` at `size` in `face`, mapping failures to a message
+/// carrying the 1-based source line number and, for an unencodable
+/// character, the character itself.
+fn measured(face: Standard14, line_no: usize, piece: &str, size: f32) -> Result<f32, String> {
+    face.text_width(piece, size).map_err(|e| match e {
+        pdfboss_write::Error::Unencodable { ch, font } => {
+            format!("line {line_no}: character {ch:?} is not encodable in {font}")
+        }
+        other => format!("line {line_no}: {other}"),
+    })
+}
+
+/// Sniffs PNG (`89 50 4E 47`) or JPEG (`FF D8`) by magic bytes — never by
+/// file extension — and imports accordingly.
+fn decode_image(bytes: &[u8]) -> Result<ImageData, String> {
+    if bytes.starts_with(&[0x89, b'P', b'N', b'G']) {
+        return ImageData::png(bytes).map_err(|e| e.to_string());
+    }
+    if bytes.starts_with(&[0xFF, 0xD8]) {
+        return ImageData::jpeg(bytes).map_err(|e| e.to_string());
+    }
+    Err("not a PNG or JPEG (unrecognized magic bytes)".to_string())
+}
+
+/// One page holding `image`: sized to the pixels at 72 dpi when `size` is
+/// `None`, else the given size with the image fit inside it, centered.
+fn image_page(image: ImageData, size: Option<PageSize>) -> Page {
+    let (iw, ih) = (image.width() as f32, image.height() as f32);
+    let size = size.unwrap_or(PageSize::Custom {
+        width: iw,
+        height: ih,
+    });
+    let (pw, ph) = size.dimensions();
+    let (x, y, w, h) = fit_box(iw, ih, pw, ph);
+    let mut page = Page::new(size);
+    let handle = page.canvas.add_image(image);
+    page.canvas.draw_image(handle, x, y, w, h);
+    page
+}
+
+/// The largest box of `iw : ih` aspect inside `pw × ph`, centered:
+/// `(x, y, width, height)`.
+fn fit_box(iw: f32, ih: f32, pw: f32, ph: f32) -> (f32, f32, f32, f32) {
+    let scale = (pw / iw).min(ph / ih);
+    let (w, h) = (iw * scale, ih * scale);
+    ((pw - w) / 2.0, (ph - h) / 2.0, w, h)
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{Parser, ValueEnum};
+    use pdfboss_core::content::Op;
+    use pdfboss_core::Matrix;
+
+    use super::*;
+    use crate::{Cli, Command};
+
+    fn parse_create(args: &[&str]) -> CreateCommand {
+        let mut full = vec!["pdfboss", "create"];
+        full.extend_from_slice(args);
+        let cli = Cli::parse_from(full);
+        let Command::Create { command } = cli.command else {
+            panic!("expected create command");
+        };
+        command
+    }
+
+    fn tiny_png() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut encoder = png::Encoder::new(&mut bytes, 3, 2);
+        encoder.set_color(png::ColorType::Rgb);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().unwrap();
+        writer.write_image_data(&[10u8; 18]).unwrap();
+        writer.finish().unwrap();
+        bytes
+    }
+
+    /// SOI, then a baseline SOF0 declaring 8-bit 3 × 2 grayscale — the
+    /// minimum a passthrough import needs to sniff.
+    fn tiny_jpeg() -> Vec<u8> {
+        let (soi, sof0) = ([0xFF, 0xD8], [0xFF, 0xC0]);
+        let (len, precision, height, width, components) = (11u16, 8u8, 2u16, 3u16, 1u8);
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&soi);
+        bytes.extend_from_slice(&sof0);
+        bytes.extend_from_slice(&len.to_be_bytes());
+        bytes.push(precision);
+        bytes.extend_from_slice(&height.to_be_bytes());
+        bytes.extend_from_slice(&width.to_be_bytes());
+        bytes.push(components);
+        bytes
+    }
+
+    #[test]
+    fn blank_parses_with_defaults() {
+        let CreateCommand::Blank {
+            out,
+            pages,
+            size,
+            landscape,
+        } = parse_create(&["blank", "-o", "out.pdf"])
+        else {
+            panic!("expected blank command");
+        };
+        assert_eq!(out, PathBuf::from("out.pdf"));
+        assert_eq!(pages, 1);
+        assert!(matches!(size, SizeArg::A4));
+        assert!(!landscape);
+    }
+
+    #[test]
+    fn blank_requires_out() {
+        let outcome = Cli::try_parse_from(["pdfboss", "create", "blank"]);
+        assert!(outcome.is_err());
+    }
+
+    #[test]
+    fn text_parses_every_flag() {
+        let CreateCommand::Text {
+            input,
+            out,
+            font,
+            font_size,
+            size,
+            landscape,
+            margin,
+        } = parse_create(&[
+            "text",
+            "in.txt",
+            "-o",
+            "o.pdf",
+            "--font",
+            "courier-bold",
+            "--font-size",
+            "9.5",
+            "--size",
+            "a5",
+            "--landscape",
+            "--margin",
+            "36",
+        ])
+        else {
+            panic!("expected text command");
+        };
+        assert_eq!(input, PathBuf::from("in.txt"));
+        assert_eq!(out, PathBuf::from("o.pdf"));
+        assert_eq!(font.to_standard14(), Standard14::CourierBold);
+        assert_eq!(font_size, 9.5);
+        assert!(matches!(size, SizeArg::A5));
+        assert!(landscape);
+        assert_eq!(margin, 36.0);
+    }
+
+    #[test]
+    fn images_parses_multiple_inputs() {
+        let CreateCommand::Images {
+            inputs,
+            out,
+            size,
+            landscape,
+        } = parse_create(&[
+            "images",
+            "a.png",
+            "b.jpg",
+            "-o",
+            "o.pdf",
+            "--size",
+            "letter",
+            "--landscape",
+        ])
+        else {
+            panic!("expected images command");
+        };
+        assert_eq!(inputs, [PathBuf::from("a.png"), PathBuf::from("b.jpg")]);
+        assert_eq!(out, PathBuf::from("o.pdf"));
+        assert!(matches!(size, Some(SizeArg::Letter)));
+        assert!(landscape);
+    }
+
+    #[test]
+    fn images_require_at_least_one_input() {
+        let outcome = Cli::try_parse_from(["pdfboss", "create", "images", "-o", "o.pdf"]);
+        assert!(outcome.is_err());
+    }
+
+    #[test]
+    fn images_landscape_needs_size() {
+        let outcome = Cli::try_parse_from([
+            "pdfboss",
+            "create",
+            "images",
+            "a.png",
+            "-o",
+            "o.pdf",
+            "--landscape",
+        ]);
+        assert!(outcome.is_err());
+    }
+
+    #[test]
+    fn font_arg_mirrors_all_fourteen_in_kebab_case() {
+        let expected_names = [
+            "helvetica",
+            "helvetica-bold",
+            "helvetica-oblique",
+            "helvetica-bold-oblique",
+            "times-roman",
+            "times-bold",
+            "times-italic",
+            "times-bold-italic",
+            "courier",
+            "courier-bold",
+            "courier-oblique",
+            "courier-bold-oblique",
+            "symbol",
+            "zapf-dingbats",
+        ];
+        let variants = FontArg::value_variants();
+        assert_eq!(variants.len(), 14);
+        for ((variant, name), face) in variants.iter().zip(expected_names).zip(Standard14::ALL) {
+            assert_eq!(variant.to_possible_value().unwrap().get_name(), name);
+            assert_eq!(variant.to_standard14(), face);
+            let parsed = FontArg::from_str(name, false).unwrap();
+            assert_eq!(parsed.to_standard14(), face);
+        }
+    }
+
+    #[test]
+    fn size_arg_maps_to_page_sizes() {
+        for (name, expected) in [
+            ("a3", PageSize::A3),
+            ("a4", PageSize::A4),
+            ("a5", PageSize::A5),
+            ("letter", PageSize::Letter),
+            ("legal", PageSize::Legal),
+        ] {
+            let parsed = SizeArg::from_str(name, false).unwrap();
+            assert_eq!(parsed.to_page_size(), expected, "{name}");
+        }
+    }
+
+    #[test]
+    fn resolved_size_swaps_under_landscape() {
+        assert_eq!(
+            resolved_size(SizeArg::Letter, false).dimensions(),
+            (612.0, 792.0)
+        );
+        assert_eq!(
+            resolved_size(SizeArg::Letter, true).dimensions(),
+            (792.0, 612.0)
+        );
+    }
+
+    #[test]
+    fn blank_pages_builds_the_count() {
+        let pages = blank_pages(3, PageSize::A5).unwrap();
+        assert_eq!(pages.len(), 3);
+        assert!(pages.iter().all(|p| p.size == PageSize::A5));
+        assert!(pages.iter().all(|p| p.canvas.ops().is_empty()));
+    }
+
+    #[test]
+    fn blank_pages_rejects_zero() {
+        let err = blank_pages(0, PageSize::A4).unwrap_err();
+        assert!(err.contains("--pages"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn wrap_wraps_greedily_at_word_boundaries() {
+        let face = Standard14::Helvetica;
+        let two_words = face.text_width("aa bb", 10.0).unwrap();
+        let rows = wrap_text("aa bb cc", face, 10.0, two_words + 0.01).unwrap();
+        assert_eq!(rows, ["aa bb", "cc"]);
+        let whole = face.text_width("aa bb cc", 10.0).unwrap();
+        let rows = wrap_text("aa bb cc", face, 10.0, whole + 0.01).unwrap();
+        assert_eq!(rows, ["aa bb cc"]);
+    }
+
+    #[test]
+    fn wrap_hard_breaks_unbreakable_words() {
+        let face = Standard14::Helvetica;
+        let three = face.text_width("aaa", 10.0).unwrap();
+        let rows = wrap_text("aaaaaaaa", face, 10.0, three + 0.01).unwrap();
+        assert_eq!(rows, ["aaa", "aaa", "aa"]);
+        let rows = wrap_text("hi aaaaaaaa", face, 10.0, three + 0.01).unwrap();
+        assert_eq!(rows, ["hi", "aaa", "aaa", "aa"]);
+    }
+
+    #[test]
+    fn wrap_expands_tabs_and_handles_crlf() {
+        let face = Standard14::Helvetica;
+        let rows = wrap_text("a\tb", face, 10.0, 500.0).unwrap();
+        assert_eq!(rows, ["a    b"]);
+        let rows = wrap_text("one\r\ntwo", face, 10.0, 500.0).unwrap();
+        assert_eq!(rows, ["one", "two"]);
+    }
+
+    #[test]
+    fn wrap_keeps_blank_lines_and_indentation() {
+        let face = Standard14::Helvetica;
+        let rows = wrap_text("a\n\nb", face, 10.0, 500.0).unwrap();
+        assert_eq!(rows, ["a", "", "b"]);
+        let rows = wrap_text("  in", face, 10.0, 500.0).unwrap();
+        assert_eq!(rows, ["  in"]);
+    }
+
+    #[test]
+    fn wrap_names_unencodable_char_and_line() {
+        let face = Standard14::Helvetica;
+        let err = wrap_text("ok\nbad \u{2318} here", face, 10.0, 500.0).unwrap_err();
+        assert!(err.contains("line 2"), "no line number in: {err}");
+        assert!(err.contains('\u{2318}'), "no character in: {err}");
+    }
+
+    #[test]
+    fn text_pages_break_at_the_bottom_margin() {
+        let size = PageSize::Custom {
+            width: 200.0,
+            height: 56.0,
+        };
+        let pages = text_pages("l1\nl2\nl3\nl4", Standard14::Helvetica, 10.0, size, 10.0).unwrap();
+        assert_eq!(pages.len(), 2);
+        let shows = |page: &Page| {
+            page.canvas
+                .ops()
+                .iter()
+                .filter(|op| matches!(op, Op::ShowText(..)))
+                .count()
+        };
+        assert_eq!(shows(&pages[0]), 3);
+        assert_eq!(shows(&pages[1]), 1);
+        assert!(pages[0].canvas.ops().contains(&Op::TextMove(10.0, 36.0)));
+    }
+
+    #[test]
+    fn text_pages_empty_input_is_one_empty_page() {
+        let pages = text_pages("", Standard14::Helvetica, 10.0, PageSize::A4, 72.0).unwrap();
+        assert_eq!(pages.len(), 1);
+        assert!(pages[0].canvas.ops().is_empty());
+    }
+
+    #[test]
+    fn text_pages_reject_hostile_geometry() {
+        let err = text_pages("x", Standard14::Helvetica, 10.0, PageSize::A5, 300.0).unwrap_err();
+        assert!(err.contains("margin"), "unexpected message: {err}");
+        let err = text_pages("x", Standard14::Helvetica, 0.0, PageSize::A4, 72.0).unwrap_err();
+        assert!(err.contains("font size"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn fit_box_scales_and_centers() {
+        assert_eq!(
+            fit_box(100.0, 50.0, 200.0, 200.0),
+            (0.0, 50.0, 200.0, 100.0)
+        );
+        assert_eq!(fit_box(50.0, 100.0, 200.0, 100.0), (75.0, 0.0, 50.0, 100.0));
+    }
+
+    #[test]
+    fn image_page_without_size_matches_the_pixels() {
+        let page = image_page(ImageData::gray8(3, 2, vec![0; 6]).unwrap(), None);
+        assert_eq!(
+            page.size,
+            PageSize::Custom {
+                width: 3.0,
+                height: 2.0
+            }
+        );
+        let ops = page.canvas.ops();
+        assert!(ops.contains(&Op::Concat(Matrix {
+            a: 3.0,
+            b: 0.0,
+            c: 0.0,
+            d: 2.0,
+            e: 0.0,
+            f: 0.0,
+        })));
+        assert!(ops
+            .iter()
+            .any(|op| matches!(op, Op::XObject(name) if name.0 == "Im1")));
+    }
+
+    #[test]
+    fn image_page_with_size_fits_and_centers() {
+        let image = ImageData::gray8(100, 50, vec![0; 5000]).unwrap();
+        let page = image_page(image, Some(PageSize::A4));
+        assert_eq!(page.size, PageSize::A4);
+        let (x, y, w, h) = fit_box(100.0, 50.0, 595.28, 841.89);
+        assert!(page.canvas.ops().contains(&Op::Concat(Matrix {
+            a: w,
+            b: 0.0,
+            c: 0.0,
+            d: h,
+            e: x,
+            f: y,
+        })));
+    }
+
+    #[test]
+    fn decode_image_sniffs_magic_bytes() {
+        let image = decode_image(&tiny_png()).unwrap();
+        assert_eq!((image.width(), image.height()), (3, 2));
+        let image = decode_image(&tiny_jpeg()).unwrap();
+        assert_eq!((image.width(), image.height()), (3, 2));
+        let err = decode_image(b"GIF89a not really").unwrap_err();
+        assert!(err.contains("magic"), "unexpected message: {err}");
+    }
+}

--- a/crates/pdfboss-cli/src/main.rs
+++ b/crates/pdfboss-cli/src/main.rs
@@ -1,6 +1,7 @@
 //! The `pdfboss` command-line tool: document info, text extraction, page
 //! rendering and object inspection.
 
+mod create;
 mod hexdump;
 mod input;
 mod json;
@@ -62,6 +63,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Create a new PDF: blank pages, word-wrapped text, or image pages.
+    Create {
+        #[command(subcommand)]
+        command: create::CreateCommand,
+    },
     /// Show version, page count, page sizes and metadata.
     Info {
         /// Path to the PDF file.
@@ -275,6 +281,7 @@ impl PngCompressionArg {
 fn main() {
     let cli = Cli::parse();
     let result: Result<(), Failure> = match cli.command {
+        Command::Create { command } => create::cmd_create(command).map_err(Failure::from),
         Command::Info { file, password } => cmd_info(&file, &password).map_err(Failure::from),
         Command::Text {
             file,

--- a/crates/pdfboss-cli/tests/create_cmd.rs
+++ b/crates/pdfboss-cli/tests/create_cmd.rs
@@ -1,0 +1,249 @@
+//! End-to-end tests for `pdfboss create`, driving the binary and loading
+//! the results back through `pdfboss-core`.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use pdfboss_core::Document;
+
+fn tmp(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(name)
+}
+
+fn pdfboss(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pdfboss"))
+        .args(args)
+        .output()
+        .expect("failed to launch pdfboss binary")
+}
+
+fn load(path: &PathBuf) -> Document {
+    Document::open_with_password(path, "").expect("created PDF failed to load")
+}
+
+fn png_bytes(width: u32, height: u32) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let mut encoder = png::Encoder::new(&mut bytes, width, height);
+    encoder.set_color(png::ColorType::Rgb);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder.write_header().unwrap();
+    writer
+        .write_image_data(&vec![10u8; (width * height * 3) as usize])
+        .unwrap();
+    writer.finish().unwrap();
+    bytes
+}
+
+/// SOI, then a baseline SOF0 declaring 8-bit 3 × 2 grayscale — enough for
+/// the passthrough import to sniff dimensions from.
+fn jpeg_bytes() -> Vec<u8> {
+    let (soi, sof0) = ([0xFF, 0xD8], [0xFF, 0xC0]);
+    let (len, precision, height, width, components) = (11u16, 8u8, 2u16, 3u16, 1u8);
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&soi);
+    bytes.extend_from_slice(&sof0);
+    bytes.extend_from_slice(&len.to_be_bytes());
+    bytes.push(precision);
+    bytes.extend_from_slice(&height.to_be_bytes());
+    bytes.extend_from_slice(&width.to_be_bytes());
+    bytes.push(components);
+    bytes
+}
+
+#[test]
+fn blank_creates_loadable_pages() {
+    let out = tmp("blank.pdf");
+    let output = pdfboss(&[
+        "create",
+        "blank",
+        "-o",
+        out.to_str().unwrap(),
+        "--pages",
+        "3",
+    ]);
+    assert!(output.status.success(), "create blank failed: {output:?}");
+    let doc = load(&out);
+    assert_eq!(doc.page_count(), 3);
+    let (w, h) = doc.page(0).unwrap().size();
+    assert!((w - 595.28).abs() < 0.01, "unexpected width {w}");
+    assert!((h - 841.89).abs() < 0.01, "unexpected height {h}");
+}
+
+#[test]
+fn blank_landscape_letter_swaps_dimensions() {
+    let out = tmp("blank-landscape.pdf");
+    let output = pdfboss(&[
+        "create",
+        "blank",
+        "-o",
+        out.to_str().unwrap(),
+        "--size",
+        "letter",
+        "--landscape",
+    ]);
+    assert!(output.status.success(), "create blank failed: {output:?}");
+    let doc = load(&out);
+    assert_eq!(doc.page_count(), 1);
+    let (w, h) = doc.page(0).unwrap().size();
+    assert!((w - 792.0).abs() < 0.01, "unexpected width {w}");
+    assert!((h - 612.0).abs() < 0.01, "unexpected height {h}");
+}
+
+#[test]
+fn text_round_trips_through_extraction() {
+    let input = tmp("text-input.txt");
+    std::fs::write(&input, "Hello from pdfboss create\nSecond line").unwrap();
+    let out = tmp("text.pdf");
+    let output = pdfboss(&[
+        "create",
+        "text",
+        input.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(output.status.success(), "create text failed: {output:?}");
+    let extracted = pdfboss(&["text", out.to_str().unwrap()]);
+    assert!(extracted.status.success(), "text failed: {extracted:?}");
+    let text = String::from_utf8_lossy(&extracted.stdout).into_owned();
+    assert!(
+        text.contains("Hello from pdfboss create"),
+        "line lost in: {text}"
+    );
+    assert!(text.contains("Second line"), "line lost in: {text}");
+}
+
+#[test]
+fn text_overflow_starts_new_pages() {
+    let input = tmp("text-long.txt");
+    let lines: Vec<String> = (1..=200).map(|i| format!("line {i}")).collect();
+    std::fs::write(&input, lines.join("\n")).unwrap();
+    let out = tmp("text-long.pdf");
+    let output = pdfboss(&[
+        "create",
+        "text",
+        input.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(output.status.success(), "create text failed: {output:?}");
+    let doc = load(&out);
+    assert!(doc.page_count() > 1, "200 lines fit one page?");
+}
+
+#[test]
+fn text_unencodable_char_fails_with_line_number() {
+    let input = tmp("text-bad.txt");
+    std::fs::write(&input, "fine\nbad \u{2318} here").unwrap();
+    let out = tmp("text-bad.pdf");
+    let output = pdfboss(&[
+        "create",
+        "text",
+        input.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(stderr.contains("line 2"), "no line number in: {stderr}");
+    assert!(stderr.contains('\u{2318}'), "no character in: {stderr}");
+}
+
+#[test]
+fn images_make_one_page_per_image_sized_to_pixels() {
+    let first = tmp("img-a.png");
+    let second = tmp("img-b.png");
+    std::fs::write(&first, png_bytes(3, 2)).unwrap();
+    std::fs::write(&second, png_bytes(5, 4)).unwrap();
+    let out = tmp("images.pdf");
+    let output = pdfboss(&[
+        "create",
+        "images",
+        first.to_str().unwrap(),
+        second.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(output.status.success(), "create images failed: {output:?}");
+    let doc = load(&out);
+    assert_eq!(doc.page_count(), 2);
+    assert_eq!(doc.page(0).unwrap().size(), (3.0, 2.0));
+    assert_eq!(doc.page(1).unwrap().size(), (5.0, 4.0));
+    let page = doc.page(0).unwrap();
+    let xobjects = page
+        .resources
+        .get("XObject")
+        .and_then(|o| o.as_dict())
+        .expect("no XObject resources");
+    let image_ref = xobjects
+        .get("Im1")
+        .and_then(|o| o.as_ref())
+        .expect("no Im1 reference");
+    let object = doc.get(image_ref).unwrap();
+    let stream = object.as_stream().expect("image is not a stream");
+    assert_eq!(
+        stream.dict.get_name("Subtype").map(|n| n.0.as_str()),
+        Some("Image")
+    );
+    assert_eq!(stream.dict.get_int("Width"), Some(3));
+    assert_eq!(stream.dict.get_int("Height"), Some(2));
+}
+
+#[test]
+fn images_detect_kind_by_magic_not_extension() {
+    let input = tmp("actually-jpeg.png");
+    std::fs::write(&input, jpeg_bytes()).unwrap();
+    let out = tmp("images-magic.pdf");
+    let output = pdfboss(&[
+        "create",
+        "images",
+        input.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(output.status.success(), "create images failed: {output:?}");
+    let doc = load(&out);
+    assert_eq!(doc.page_count(), 1);
+    assert_eq!(doc.page(0).unwrap().size(), (3.0, 2.0));
+}
+
+#[test]
+fn images_with_size_scale_into_the_page() {
+    let input = tmp("img-a4.png");
+    std::fs::write(&input, png_bytes(3, 2)).unwrap();
+    let out = tmp("images-a4.pdf");
+    let output = pdfboss(&[
+        "create",
+        "images",
+        input.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "--size",
+        "a4",
+    ]);
+    assert!(output.status.success(), "create images failed: {output:?}");
+    let doc = load(&out);
+    let (w, h) = doc.page(0).unwrap().size();
+    assert!((w - 595.28).abs() < 0.01, "unexpected width {w}");
+    assert!((h - 841.89).abs() < 0.01, "unexpected height {h}");
+}
+
+#[test]
+fn images_reject_files_without_image_magic() {
+    let input = tmp("not-an-image.txt");
+    std::fs::write(&input, "just words").unwrap();
+    let out = tmp("images-bad.pdf");
+    let output = pdfboss(&[
+        "create",
+        "images",
+        input.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(stderr.contains("magic"), "unexpected message: {stderr}");
+    assert!(
+        stderr.contains("not-an-image.txt"),
+        "no file name in: {stderr}"
+    );
+}

--- a/crates/pdfboss-core/src/crypt.rs
+++ b/crates/pdfboss-core/src/crypt.rs
@@ -708,7 +708,8 @@ const SHA256_K: [u32; 64] = [
     0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
 ];
 
-fn sha256(input: &[u8]) -> [u8; 32] {
+/// SHA-256 of `input` (FIPS 180-4); public so the writer can derive its `/ID`.
+pub fn sha256(input: &[u8]) -> [u8; 32] {
     let mut h: [u32; 8] = [
         0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
         0x5be0cd19,

--- a/crates/pdfboss-core/src/crypt.rs
+++ b/crates/pdfboss-core/src/crypt.rs
@@ -708,33 +708,91 @@ const SHA256_K: [u32; 64] = [
     0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
 ];
 
+/// Streaming SHA-256 (FIPS 180-4): feed bytes with [`Sha256::update`],
+/// close with [`Sha256::finalize`]. Public so the writer can hash a file's
+/// body as it emits it, without holding the whole file in memory; the
+/// one-shot [`sha256`] delegates here.
+#[derive(Debug, Clone)]
+pub struct Sha256 {
+    h: [u32; 8],
+    tail: [u8; 64],
+    tail_len: usize,
+    total: u64,
+}
+
+impl Default for Sha256 {
+    fn default() -> Sha256 {
+        Sha256::new()
+    }
+}
+
+impl Sha256 {
+    /// A hasher in the FIPS 180-4 initial state.
+    pub fn new() -> Sha256 {
+        Sha256 {
+            h: [
+                0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+                0x5be0cd19,
+            ],
+            tail: [0u8; 64],
+            tail_len: 0,
+            total: 0,
+        }
+    }
+
+    /// Absorbs `input`. Slice boundaries do not affect the digest: any
+    /// sequence of updates whose concatenation is the same message yields
+    /// the same [`Sha256::finalize`] result. Whole blocks are compressed
+    /// straight from `input`; only a partial trailing block is buffered.
+    pub fn update(&mut self, input: &[u8]) {
+        self.total = self.total.wrapping_add(input.len() as u64);
+        let mut input = input;
+        if self.tail_len > 0 {
+            let take = input.len().min(64 - self.tail_len);
+            self.tail[self.tail_len..self.tail_len + take].copy_from_slice(&input[..take]);
+            self.tail_len += take;
+            input = &input[take..];
+            if self.tail_len < 64 {
+                return;
+            }
+            let block = self.tail;
+            sha256_compress(&mut self.h, &block);
+            self.tail_len = 0;
+        }
+        let (blocks, rest) = input.as_chunks::<64>();
+        for block in blocks {
+            sha256_compress(&mut self.h, block);
+        }
+        self.tail[..rest.len()].copy_from_slice(rest);
+        self.tail_len = rest.len();
+    }
+
+    /// Pads and returns the digest of everything absorbed so far.
+    pub fn finalize(mut self) -> [u8; 32] {
+        // Final padding touches at most two blocks: 0x80, zeros, and the
+        // bit length in the last 8 bytes (FIPS 180-4).
+        let mut pad = [0u8; 128];
+        pad[..self.tail_len].copy_from_slice(&self.tail[..self.tail_len]);
+        pad[self.tail_len] = 0x80;
+        let padded = if self.tail_len < 56 { 64 } else { 128 };
+        let bitlen = self.total.wrapping_mul(8);
+        pad[padded - 8..padded].copy_from_slice(&bitlen.to_be_bytes());
+        for block in pad[..padded].as_chunks::<64>().0 {
+            sha256_compress(&mut self.h, block);
+        }
+        let mut out = [0u8; 32];
+        for (i, word) in self.h.iter().enumerate() {
+            out[4 * i..4 * i + 4].copy_from_slice(&word.to_be_bytes());
+        }
+        out
+    }
+}
+
 /// SHA-256 of `input` (FIPS 180-4); public so the writer can derive its `/ID`.
 pub fn sha256(input: &[u8]) -> [u8; 32] {
-    let mut h: [u32; 8] = [
-        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
-        0x5be0cd19,
-    ];
-    let (blocks, tail) = input.as_chunks::<64>();
-    for block in blocks {
-        sha256_compress(&mut h, block);
-    }
-    // Final padding touches at most two blocks: 0x80, zeros, and the bit
-    // length in the last 8 bytes (FIPS 180-4) — the message itself is
-    // hashed in place above, never copied.
-    let mut pad = [0u8; 128];
-    pad[..tail.len()].copy_from_slice(tail);
-    pad[tail.len()] = 0x80;
-    let padded = if tail.len() < 56 { 64 } else { 128 };
-    let bitlen = (input.len() as u64).wrapping_mul(8);
-    pad[padded - 8..padded].copy_from_slice(&bitlen.to_be_bytes());
-    for block in pad[..padded].as_chunks::<64>().0 {
-        sha256_compress(&mut h, block);
-    }
-    let mut out = [0u8; 32];
-    for (i, word) in h.iter().enumerate() {
-        out[4 * i..4 * i + 4].copy_from_slice(&word.to_be_bytes());
-    }
-    out
+    let mut hasher = Sha256::new();
+    hasher.update(input);
+    hasher.finalize()
 }
 
 fn sha256_compress(h: &mut [u32; 8], block: &[u8; 64]) {
@@ -1317,6 +1375,30 @@ mod tests {
         sha512_compress(&mut via_dispatch, &block128);
         sha512_compress_soft(&mut via_soft, &block128);
         assert_eq!(via_dispatch, via_soft);
+    }
+
+    /// The incremental hasher must match the one-shot digest whatever the
+    /// slice boundaries: odd sizes, block-straddling feeds, empty updates.
+    #[test]
+    fn incremental_sha256_matches_the_one_shot() {
+        let input: Vec<u8> = (0..300u16).map(|i| (i % 251) as u8).collect();
+        for splits in [
+            vec![0, 1, 3, 7, 60, 63, 64, 65, 37],
+            vec![300],
+            vec![128, 128, 44],
+            vec![55, 9, 236],
+        ] {
+            let mut hasher = Sha256::new();
+            let mut fed = 0usize;
+            for len in splits {
+                hasher.update(&input[fed..fed + len]);
+                fed += len;
+            }
+            hasher.update(&input[fed..]);
+            assert_eq!(hasher.finalize(), sha256(&input));
+        }
+        assert_eq!(Sha256::new().finalize(), sha256(b""));
+        assert_eq!(Sha256::default().finalize(), sha256(b""));
     }
 
     #[test]

--- a/crates/pdfboss-encoding/src/lib.rs
+++ b/crates/pdfboss-encoding/src/lib.rs
@@ -52,6 +52,165 @@ pub fn win_ansi(code: u8) -> Option<char> {
     }
 }
 
+/// WinAnsiEncoding glyph name for `code` (ISO 32000-1 Annex D.2
+/// "WinAnsiEncoding" column). `None` for exactly the codes [`win_ansi`]
+/// leaves unassigned. Two ASCII codes diverge from StandardEncoding's
+/// names: `0x27` is `quotesingle` and `0x60` is `grave` (the straight
+/// marks, matching `win_ansi`'s identity mapping there). Two codes render
+/// an existing glyph rather than owning one: `0xA0` carries `space` (the
+/// nonbreaking space draws as the space glyph) and `0xAD` carries `hyphen`
+/// (likewise the soft hyphen) — see the self-verifying
+/// `win_ansi_glyph_name_matches_win_ansi_table` test below.
+pub fn win_ansi_glyph_name(code: u8) -> Option<&'static str> {
+    match code {
+        0x27 => Some("quotesingle"),
+        0x60 => Some("grave"),
+        0x20..=0x7E => Some(STANDARD_ASCII_NAMES[(code - 0x20) as usize]),
+        0x80..=0x9F => WIN_ANSI_80_9F_NAMES[(code - 0x80) as usize],
+        0xA0..=0xFF => Some(WIN_ANSI_A0_FF_NAMES[(code - 0xA0) as usize]),
+        _ => None,
+    }
+}
+
+/// WinAnsiEncoding glyph names for codes `0x80..=0x9F`, parallel to
+/// [`WIN_ANSI_80_9F`]; `None` marks the same unassigned codes.
+const WIN_ANSI_80_9F_NAMES: [Option<&str>; 32] = [
+    Some("Euro"),
+    None,
+    Some("quotesinglbase"),
+    Some("florin"),
+    Some("quotedblbase"),
+    Some("ellipsis"),
+    Some("dagger"),
+    Some("daggerdbl"),
+    Some("circumflex"),
+    Some("perthousand"),
+    Some("Scaron"),
+    Some("guilsinglleft"),
+    Some("OE"),
+    None,
+    Some("Zcaron"),
+    None,
+    None,
+    Some("quoteleft"),
+    Some("quoteright"),
+    Some("quotedblleft"),
+    Some("quotedblright"),
+    Some("bullet"),
+    Some("endash"),
+    Some("emdash"),
+    Some("tilde"),
+    Some("trademark"),
+    Some("scaron"),
+    Some("guilsinglright"),
+    Some("oe"),
+    None,
+    Some("zcaron"),
+    Some("Ydieresis"),
+];
+
+/// WinAnsiEncoding glyph names for codes `0xA0..=0xFF` (ISO 32000-1
+/// Annex D.2 "WinAnsiEncoding" column), in code order (index `0` is code
+/// `0xA0`).
+const WIN_ANSI_A0_FF_NAMES: [&str; 96] = [
+    "space",
+    "exclamdown",
+    "cent",
+    "sterling",
+    "currency",
+    "yen",
+    "brokenbar",
+    "section",
+    "dieresis",
+    "copyright",
+    "ordfeminine",
+    "guillemotleft",
+    "logicalnot",
+    "hyphen",
+    "registered",
+    "macron",
+    "degree",
+    "plusminus",
+    "twosuperior",
+    "threesuperior",
+    "acute",
+    "mu",
+    "paragraph",
+    "periodcentered",
+    "cedilla",
+    "onesuperior",
+    "ordmasculine",
+    "guillemotright",
+    "onequarter",
+    "onehalf",
+    "threequarters",
+    "questiondown",
+    "Agrave",
+    "Aacute",
+    "Acircumflex",
+    "Atilde",
+    "Adieresis",
+    "Aring",
+    "AE",
+    "Ccedilla",
+    "Egrave",
+    "Eacute",
+    "Ecircumflex",
+    "Edieresis",
+    "Igrave",
+    "Iacute",
+    "Icircumflex",
+    "Idieresis",
+    "Eth",
+    "Ntilde",
+    "Ograve",
+    "Oacute",
+    "Ocircumflex",
+    "Otilde",
+    "Odieresis",
+    "multiply",
+    "Oslash",
+    "Ugrave",
+    "Uacute",
+    "Ucircumflex",
+    "Udieresis",
+    "Yacute",
+    "Thorn",
+    "germandbls",
+    "agrave",
+    "aacute",
+    "acircumflex",
+    "atilde",
+    "adieresis",
+    "aring",
+    "ae",
+    "ccedilla",
+    "egrave",
+    "eacute",
+    "ecircumflex",
+    "edieresis",
+    "igrave",
+    "iacute",
+    "icircumflex",
+    "idieresis",
+    "eth",
+    "ntilde",
+    "ograve",
+    "oacute",
+    "ocircumflex",
+    "otilde",
+    "odieresis",
+    "divide",
+    "oslash",
+    "ugrave",
+    "uacute",
+    "ucircumflex",
+    "udieresis",
+    "yacute",
+    "thorn",
+    "ydieresis",
+];
+
 /// MacRomanEncoding codes `0x80..=0xFF` (codes below coincide with ASCII).
 const MAC_ROMAN_HIGH: [char; 128] = [
     '\u{C4}', '\u{C5}', '\u{C7}', '\u{C9}', '\u{D1}', '\u{D6}', '\u{DC}', '\u{E1}', '\u{E0}',
@@ -689,6 +848,54 @@ mod tests {
         assert_eq!(win_ansi(0xE9), Some('\u{E9}')); // e acute (Latin-1)
         assert_eq!(win_ansi(0x81), None); // unassigned
         assert_eq!(win_ansi(0x0A), None); // control
+    }
+
+    #[test]
+    fn win_ansi_glyph_name_spot_checks() {
+        assert_eq!(win_ansi_glyph_name(0x41), Some("A"));
+        assert_eq!(win_ansi_glyph_name(0x20), Some("space"));
+        assert_eq!(win_ansi_glyph_name(0x27), Some("quotesingle")); // not quoteright
+        assert_eq!(win_ansi_glyph_name(0x60), Some("grave")); // not quoteleft
+        assert_eq!(win_ansi_glyph_name(0x80), Some("Euro"));
+        assert_eq!(win_ansi_glyph_name(0x93), Some("quotedblleft"));
+        assert_eq!(win_ansi_glyph_name(0xE9), Some("eacute"));
+        assert_eq!(win_ansi_glyph_name(0xFF), Some("ydieresis"));
+        assert_eq!(win_ansi_glyph_name(0x81), None); // unassigned
+        assert_eq!(win_ansi_glyph_name(0x0A), None); // control
+    }
+
+    /// Self-verifying anchor for `win_ansi_glyph_name`: ties the name table
+    /// to the pre-existing, trusted `win_ansi` (code -> Unicode) and
+    /// `glyph_to_unicode` (name -> Unicode) tables. Domain equality must
+    /// hold for every code, and every name must resolve to the code's
+    /// Unicode value — with exactly two documented exceptions, codes that
+    /// render an existing glyph rather than owning one: `0xA0` (nonbreaking
+    /// space, drawn by `space`) and `0xAD` (soft hyphen, drawn by `hyphen`).
+    #[test]
+    fn win_ansi_glyph_name_matches_win_ansi_table() {
+        assert_eq!(win_ansi_glyph_name(0xA0), Some("space"));
+        assert_eq!(win_ansi_glyph_name(0xAD), Some("hyphen"));
+        for code in 0u16..=255 {
+            let code = code as u8;
+            assert_eq!(
+                win_ansi_glyph_name(code).is_some(),
+                win_ansi(code).is_some(),
+                "code {code:#04x}: win_ansi_glyph_name/win_ansi domain mismatch"
+            );
+            let Some(name) = win_ansi_glyph_name(code) else {
+                continue;
+            };
+            let expected = match code {
+                0xA0 => ' ',
+                0xAD => '-',
+                _ => win_ansi(code).unwrap(),
+            };
+            assert_eq!(
+                glyph_to_unicode(name),
+                Some(expected),
+                "code {code:#04x} name {name:?}: glyph_to_unicode disagrees with win_ansi"
+            );
+        }
     }
 
     #[test]

--- a/crates/pdfboss-write/Cargo.toml
+++ b/crates/pdfboss-write/Cargo.toml
@@ -17,3 +17,5 @@ png = "0.18"
 
 [dev-dependencies]
 pdfboss-render = { workspace = true }
+pdfboss-text = { workspace = true }
+pdfboss-output = { workspace = true }

--- a/crates/pdfboss-write/Cargo.toml
+++ b/crates/pdfboss-write/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pdfboss-write"
+description = "PDF creation for pdfboss: COS object writer, content canvas and document assembly"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+
+[dependencies]
+pdfboss-core = { workspace = true }
+pdfboss-encoding = { workspace = true }
+thiserror = "2"
+flate2 = { version = "1", default-features = false, features = ["zlib-rs"] }
+png = "0.18"
+
+[dev-dependencies]
+pdfboss-render = { workspace = true }

--- a/crates/pdfboss-write/src/canvas.rs
+++ b/crates/pdfboss-write/src/canvas.rs
@@ -9,12 +9,15 @@
 //! `/Resources` dictionary from [`CanvasParts`].
 
 use pdfboss_core::content::Op;
-use pdfboss_core::{Matrix, Point};
+use pdfboss_core::{Matrix, Name, Point};
 
 use crate::color::Color;
 use crate::error::Result;
 use crate::font::Standard14;
 use crate::image::ImageData;
+
+#[allow(clippy::excessive_precision)] // the contract names this exact literal
+const KAPPA: f32 = 0.552284749831;
 
 /// Line cap style (ISO 32000 §8.4.3.3).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -71,168 +74,205 @@ impl Canvas {
 
     /// Pushes the graphics state (`q`).
     pub fn save(&mut self) {
-        todo!("save state ({} ops)", self.ops.len())
+        self.ops.push(Op::Save);
     }
 
     /// Pops the graphics state (`Q`).
     pub fn restore(&mut self) {
-        todo!("restore state ({} ops)", self.ops.len())
+        self.ops.push(Op::Restore);
     }
 
     /// Concatenates `m` onto the current transformation matrix (`cm`).
     pub fn transform(&mut self, m: Matrix) {
-        let unused = (&mut self.ops, m);
-        todo!("transform: {unused:?}")
+        self.ops.push(Op::Concat(m));
     }
 
     /// Sets the stroke line width (`w`).
     pub fn set_line_width(&mut self, width: f32) {
-        let unused = (&mut self.ops, width);
-        todo!("line width: {unused:?}")
+        self.ops.push(Op::SetLineWidth(width));
     }
 
     /// Sets the line cap style (`J`).
     pub fn set_line_cap(&mut self, cap: LineCap) {
-        let unused = (&mut self.ops, cap);
-        todo!("line cap: {unused:?}")
+        self.ops.push(Op::SetLineCap(cap as i32));
     }
 
     /// Sets the line join style (`j`).
     pub fn set_line_join(&mut self, join: LineJoin) {
-        let unused = (&mut self.ops, join);
-        todo!("line join: {unused:?}")
+        self.ops.push(Op::SetLineJoin(join as i32));
     }
 
     /// Sets the miter limit (`M`).
     pub fn set_miter_limit(&mut self, limit: f32) {
-        let unused = (&mut self.ops, limit);
-        todo!("miter limit: {unused:?}")
+        self.ops.push(Op::SetMiterLimit(limit));
     }
 
     /// Sets the dash pattern (`d`).
     pub fn set_dash(&mut self, pattern: &[f32], phase: f32) {
-        let unused = (&mut self.ops, pattern, phase);
-        todo!("dash: {unused:?}")
+        self.ops.push(Op::SetDash(pattern.to_vec(), phase));
     }
 
     /// Sets the fill color (`g`/`rg`/`k`).
     pub fn set_fill(&mut self, color: Color) {
-        let unused = (&mut self.ops, color);
-        todo!("fill color: {unused:?}")
+        self.ops.push(color.fill_op());
     }
 
     /// Sets the stroke color (`G`/`RG`/`K`).
     pub fn set_stroke(&mut self, color: Color) {
-        let unused = (&mut self.ops, color);
-        todo!("stroke color: {unused:?}")
+        self.ops.push(color.stroke_op());
     }
 
     /// Begins a new subpath at `(x, y)` (`m`).
     pub fn move_to(&mut self, x: f32, y: f32) {
-        let unused = (&mut self.ops, x, y);
-        todo!("move to: {unused:?}")
+        self.ops.push(Op::MoveTo(x, y));
     }
 
     /// Straight segment to `(x, y)` (`l`).
     pub fn line_to(&mut self, x: f32, y: f32) {
-        let unused = (&mut self.ops, x, y);
-        todo!("line to: {unused:?}")
+        self.ops.push(Op::LineTo(x, y));
     }
 
     /// Cubic Bézier with two control points (`c`).
     #[allow(clippy::too_many_arguments)] // six coordinates is the operator's arity
     pub fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32) {
-        let unused = (&mut self.ops, x1, y1, x2, y2, x3, y3);
-        todo!("curve to: {unused:?}")
+        self.ops.push(Op::CurveTo(x1, y1, x2, y2, x3, y3));
     }
 
     /// Closes the current subpath (`h`).
     pub fn close(&mut self) {
-        todo!("close path ({} ops)", self.ops.len())
+        self.ops.push(Op::ClosePath);
     }
 
     /// Appends a rectangle subpath (`re`).
     pub fn rect(&mut self, x: f32, y: f32, width: f32, height: f32) {
-        let unused = (&mut self.ops, x, y, width, height);
-        todo!("rect: {unused:?}")
+        self.ops.push(Op::Rect(x, y, width, height));
     }
 
-    /// Appends a circle as four Bézier arcs.
+    /// Appends a circle as four Bézier arcs, starting at the rightmost
+    /// point `(cx + r, cy)` and running counter-clockwise.
     pub fn circle(&mut self, cx: f32, cy: f32, r: f32) {
-        let unused = (&mut self.ops, cx, cy, r);
-        todo!("circle: {unused:?}")
+        self.ellipse(cx, cy, r, r);
     }
 
-    /// Appends an axis-aligned ellipse as four Bézier arcs.
+    /// Appends an axis-aligned ellipse as four Bézier arcs, starting at the
+    /// rightmost point `(cx + rx, cy)` and running counter-clockwise.
     pub fn ellipse(&mut self, cx: f32, cy: f32, rx: f32, ry: f32) {
-        let unused = (&mut self.ops, cx, cy, rx, ry);
-        todo!("ellipse: {unused:?}")
+        let ox = KAPPA * rx;
+        let oy = KAPPA * ry;
+        self.ops.push(Op::MoveTo(cx + rx, cy));
+        self.ops
+            .push(Op::CurveTo(cx + rx, cy + oy, cx + ox, cy + ry, cx, cy + ry));
+        self.ops
+            .push(Op::CurveTo(cx - ox, cy + ry, cx - rx, cy + oy, cx - rx, cy));
+        self.ops
+            .push(Op::CurveTo(cx - rx, cy - oy, cx - ox, cy - ry, cx, cy - ry));
+        self.ops
+            .push(Op::CurveTo(cx + ox, cy - ry, cx + rx, cy - oy, cx + rx, cy));
+        self.ops.push(Op::ClosePath);
     }
 
-    /// Appends a closed polygon through `points`.
+    /// Appends a closed polygon through `points`. Fewer than three points
+    /// appends nothing.
     pub fn polygon(&mut self, points: &[Point]) {
-        let unused = (&mut self.ops, points);
-        todo!("polygon: {unused:?}")
+        if points.len() < 3 {
+            return;
+        }
+        self.ops.push(Op::MoveTo(points[0].x, points[0].y));
+        for point in &points[1..] {
+            self.ops.push(Op::LineTo(point.x, point.y));
+        }
+        self.ops.push(Op::ClosePath);
     }
 
     /// Fills the current path, nonzero winding (`f`).
     pub fn fill(&mut self) {
-        todo!("fill ({} ops)", self.ops.len())
+        self.ops.push(Op::Fill);
     }
 
     /// Fills the current path, even-odd (`f*`).
     pub fn fill_even_odd(&mut self) {
-        todo!("fill even-odd ({} ops)", self.ops.len())
+        self.ops.push(Op::FillEvenOdd);
     }
 
     /// Strokes the current path (`S`).
     pub fn stroke(&mut self) {
-        todo!("stroke ({} ops)", self.ops.len())
+        self.ops.push(Op::Stroke);
     }
 
     /// Closes and strokes the current path (`s`).
     pub fn close_stroke(&mut self) {
-        todo!("close-stroke ({} ops)", self.ops.len())
+        self.ops.push(Op::CloseStroke);
     }
 
     /// Fills then strokes the current path (`B`).
     pub fn fill_stroke(&mut self) {
-        todo!("fill-stroke ({} ops)", self.ops.len())
+        self.ops.push(Op::FillStroke);
     }
 
-    /// Intersects the clip with the current path, nonzero (`W n`).
+    /// Intersects the clip with the current path, nonzero (`W n`). The
+    /// path is consumed: it is ended without painting and a fresh path
+    /// starts afterwards.
     pub fn clip(&mut self) {
-        todo!("clip ({} ops)", self.ops.len())
+        self.ops.push(Op::ClipNonZero);
+        self.ops.push(Op::EndPath);
     }
 
-    /// Intersects the clip with the current path, even-odd (`W* n`).
+    /// Intersects the clip with the current path, even-odd (`W* n`). The
+    /// path is consumed: it is ended without painting and a fresh path
+    /// starts afterwards.
     pub fn clip_even_odd(&mut self) {
-        todo!("clip even-odd ({} ops)", self.ops.len())
+        self.ops.push(Op::ClipEvenOdd);
+        self.ops.push(Op::EndPath);
     }
 
     /// Ends the current path without painting (`n`).
     pub fn end_path(&mut self) {
-        todo!("end path ({} ops)", self.ops.len())
+        self.ops.push(Op::EndPath);
     }
 
     /// Shows one line of text with its baseline origin at `(x, y)`
-    /// (`BT`/`Tf`/`Td`/`Tj`/`ET`). Errors on unencodable characters.
+    /// (`BT`/`Tf`/`Td`/`Tj`/`ET`). Errors on unencodable characters
+    /// before any operator is pushed, leaving the canvas untouched.
     pub fn text(&mut self, text: &str, x: f32, y: f32, font: Standard14, size: f32) -> Result<()> {
-        let unused = (&mut self.ops, text, x, y, font, size);
-        todo!("text: {unused:?}")
+        let encoded = font.encode(text)?;
+        let index = match self.fonts.iter().position(|face| *face == font) {
+            Some(index) => index,
+            None => {
+                self.fonts.push(font);
+                self.fonts.len() - 1
+            }
+        };
+        self.ops.push(Op::BeginText);
+        self.ops
+            .push(Op::SetFont(Name(format!("F{}", index + 1)), size));
+        self.ops.push(Op::TextMove(x, y));
+        self.ops.push(Op::ShowText(encoded));
+        self.ops.push(Op::EndText);
+        Ok(())
     }
 
     /// Registers an image for use with [`draw_image`](Canvas::draw_image).
     pub fn add_image(&mut self, image: ImageData) -> ImageHandle {
-        let unused = (&mut self.images, image);
-        todo!("add image: {unused:?}")
+        let handle = ImageHandle(self.images.len());
+        self.images.push(image);
+        handle
     }
 
     /// Paints a registered image into the axis-aligned box at `(x, y)` with
     /// the given size (`q cm Do Q`).
     pub fn draw_image(&mut self, image: ImageHandle, x: f32, y: f32, width: f32, height: f32) {
-        let unused = (&mut self.ops, image, x, y, width, height);
-        todo!("draw image: {unused:?}")
+        self.ops.push(Op::Save);
+        self.ops.push(Op::Concat(Matrix {
+            a: width,
+            b: 0.0,
+            c: 0.0,
+            d: height,
+            e: x,
+            f: y,
+        }));
+        self.ops
+            .push(Op::XObject(Name(format!("Im{}", image.0 + 1))));
+        self.ops.push(Op::Restore);
     }
 
     /// Pushes a raw operator — the escape hatch for anything the methods
@@ -254,5 +294,340 @@ impl Canvas {
             fonts: self.fonts,
             images: self.images,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pdfboss_core::Name;
+
+    use super::*;
+    use crate::error::Error;
+
+    fn name(text: &str) -> Name {
+        Name(text.into())
+    }
+
+    #[test]
+    fn state_ops_push_single_operators() {
+        let mut canvas = Canvas::new();
+        canvas.save();
+        canvas.restore();
+        canvas.transform(Matrix {
+            a: 1.0,
+            b: 2.0,
+            c: 3.0,
+            d: 4.0,
+            e: 5.0,
+            f: 6.0,
+        });
+        canvas.set_line_width(2.5);
+        canvas.set_miter_limit(4.0);
+        canvas.set_dash(&[3.0, 1.0], 0.5);
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::Save,
+                Op::Restore,
+                Op::Concat(Matrix {
+                    a: 1.0,
+                    b: 2.0,
+                    c: 3.0,
+                    d: 4.0,
+                    e: 5.0,
+                    f: 6.0,
+                }),
+                Op::SetLineWidth(2.5),
+                Op::SetMiterLimit(4.0),
+                Op::SetDash(vec![3.0, 1.0], 0.5),
+            ]
+        );
+    }
+
+    #[test]
+    fn line_cap_and_join_map_declaration_order() {
+        let mut canvas = Canvas::new();
+        canvas.set_line_cap(LineCap::Butt);
+        canvas.set_line_cap(LineCap::Round);
+        canvas.set_line_cap(LineCap::Square);
+        canvas.set_line_join(LineJoin::Miter);
+        canvas.set_line_join(LineJoin::Round);
+        canvas.set_line_join(LineJoin::Bevel);
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::SetLineCap(0),
+                Op::SetLineCap(1),
+                Op::SetLineCap(2),
+                Op::SetLineJoin(0),
+                Op::SetLineJoin(1),
+                Op::SetLineJoin(2),
+            ]
+        );
+    }
+
+    #[test]
+    fn fill_and_stroke_colors() {
+        let mut canvas = Canvas::new();
+        canvas.set_fill(Color::Gray(0.5));
+        canvas.set_fill(Color::Rgb(0.1, 0.2, 0.3));
+        canvas.set_fill(Color::Cmyk(0.1, 0.2, 0.3, 0.4));
+        canvas.set_stroke(Color::Gray(0.5));
+        canvas.set_stroke(Color::Rgb(0.1, 0.2, 0.3));
+        canvas.set_stroke(Color::Cmyk(0.1, 0.2, 0.3, 0.4));
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::SetFillGray(0.5),
+                Op::SetFillRGB(0.1, 0.2, 0.3),
+                Op::SetFillCMYK(0.1, 0.2, 0.3, 0.4),
+                Op::SetStrokeGray(0.5),
+                Op::SetStrokeRGB(0.1, 0.2, 0.3),
+                Op::SetStrokeCMYK(0.1, 0.2, 0.3, 0.4),
+            ]
+        );
+    }
+
+    #[test]
+    fn path_construction_ops() {
+        let mut canvas = Canvas::new();
+        canvas.move_to(1.0, 2.0);
+        canvas.line_to(3.0, 4.0);
+        canvas.curve_to(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+        canvas.close();
+        canvas.rect(10.0, 20.0, 30.0, 40.0);
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::MoveTo(1.0, 2.0),
+                Op::LineTo(3.0, 4.0),
+                Op::CurveTo(1.0, 2.0, 3.0, 4.0, 5.0, 6.0),
+                Op::ClosePath,
+                Op::Rect(10.0, 20.0, 30.0, 40.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn circle_appends_four_arcs_and_close() {
+        let mut canvas = Canvas::new();
+        canvas.circle(0.0, 0.0, 1.0);
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::MoveTo(1.0, 0.0),
+                Op::CurveTo(1.0, KAPPA, KAPPA, 1.0, 0.0, 1.0),
+                Op::CurveTo(-KAPPA, 1.0, -1.0, KAPPA, -1.0, 0.0),
+                Op::CurveTo(-1.0, -KAPPA, -KAPPA, -1.0, 0.0, -1.0),
+                Op::CurveTo(KAPPA, -1.0, 1.0, -KAPPA, 1.0, 0.0),
+                Op::ClosePath,
+            ]
+        );
+    }
+
+    #[test]
+    fn ellipse_appends_four_arcs_and_close() {
+        let (cx, cy, rx, ry) = (10.0f32, 20.0f32, 4.0f32, 2.0f32);
+        let ox = KAPPA * rx;
+        let oy = KAPPA * ry;
+        let mut canvas = Canvas::new();
+        canvas.ellipse(cx, cy, rx, ry);
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::MoveTo(cx + rx, cy),
+                Op::CurveTo(cx + rx, cy + oy, cx + ox, cy + ry, cx, cy + ry),
+                Op::CurveTo(cx - ox, cy + ry, cx - rx, cy + oy, cx - rx, cy),
+                Op::CurveTo(cx - rx, cy - oy, cx - ox, cy - ry, cx, cy - ry),
+                Op::CurveTo(cx + ox, cy - ry, cx + rx, cy - oy, cx + rx, cy),
+                Op::ClosePath,
+            ]
+        );
+    }
+
+    #[test]
+    fn polygon_appends_closed_path() {
+        let mut canvas = Canvas::new();
+        canvas.polygon(&[
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            Point::new(5.0, 8.0),
+        ]);
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::MoveTo(0.0, 0.0),
+                Op::LineTo(10.0, 0.0),
+                Op::LineTo(5.0, 8.0),
+                Op::ClosePath,
+            ]
+        );
+    }
+
+    #[test]
+    fn polygon_under_three_points_is_no_op() {
+        let mut canvas = Canvas::new();
+        canvas.polygon(&[]);
+        canvas.polygon(&[Point::new(1.0, 2.0)]);
+        canvas.polygon(&[Point::new(1.0, 2.0), Point::new(3.0, 4.0)]);
+        assert_eq!(canvas.ops(), []);
+    }
+
+    #[test]
+    fn paint_verbs_push_single_operators() {
+        let mut canvas = Canvas::new();
+        canvas.fill();
+        canvas.fill_even_odd();
+        canvas.stroke();
+        canvas.close_stroke();
+        canvas.fill_stroke();
+        canvas.end_path();
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::Fill,
+                Op::FillEvenOdd,
+                Op::Stroke,
+                Op::CloseStroke,
+                Op::FillStroke,
+                Op::EndPath,
+            ]
+        );
+    }
+
+    #[test]
+    fn clip_pairs_consume_the_path() {
+        let mut canvas = Canvas::new();
+        canvas.clip();
+        canvas.clip_even_odd();
+        assert_eq!(
+            canvas.ops(),
+            [Op::ClipNonZero, Op::EndPath, Op::ClipEvenOdd, Op::EndPath,]
+        );
+    }
+
+    #[test]
+    fn text_pushes_five_op_sequence() {
+        let mut canvas = Canvas::new();
+        canvas
+            .text("Hi", 72.0, 720.0, Standard14::Helvetica, 12.0)
+            .unwrap();
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::BeginText,
+                Op::SetFont(name("F1"), 12.0),
+                Op::TextMove(72.0, 720.0),
+                Op::ShowText(b"Hi".to_vec()),
+                Op::EndText,
+            ]
+        );
+        let parts = canvas.into_parts();
+        assert_eq!(parts.fonts, [Standard14::Helvetica]);
+    }
+
+    #[test]
+    fn texts_in_the_same_font_share_f1() {
+        let mut canvas = Canvas::new();
+        canvas
+            .text("one", 0.0, 0.0, Standard14::TimesRoman, 10.0)
+            .unwrap();
+        canvas
+            .text("two", 0.0, 20.0, Standard14::TimesRoman, 10.0)
+            .unwrap();
+        let font_names: Vec<&Op> = canvas
+            .ops()
+            .iter()
+            .filter(|op| matches!(op, Op::SetFont(..)))
+            .collect();
+        assert_eq!(
+            font_names,
+            [
+                &Op::SetFont(name("F1"), 10.0),
+                &Op::SetFont(name("F1"), 10.0),
+            ]
+        );
+        assert_eq!(canvas.into_parts().fonts, [Standard14::TimesRoman]);
+    }
+
+    #[test]
+    fn second_face_gets_f2() {
+        let mut canvas = Canvas::new();
+        canvas
+            .text("one", 0.0, 0.0, Standard14::Helvetica, 10.0)
+            .unwrap();
+        canvas
+            .text("two", 0.0, 20.0, Standard14::CourierBold, 10.0)
+            .unwrap();
+        canvas
+            .text("three", 0.0, 40.0, Standard14::Helvetica, 10.0)
+            .unwrap();
+        let font_names: Vec<&Op> = canvas
+            .ops()
+            .iter()
+            .filter(|op| matches!(op, Op::SetFont(..)))
+            .collect();
+        assert_eq!(
+            font_names,
+            [
+                &Op::SetFont(name("F1"), 10.0),
+                &Op::SetFont(name("F2"), 10.0),
+                &Op::SetFont(name("F1"), 10.0),
+            ]
+        );
+        assert_eq!(
+            canvas.into_parts().fonts,
+            [Standard14::Helvetica, Standard14::CourierBold]
+        );
+    }
+
+    #[test]
+    fn text_error_leaves_canvas_untouched() {
+        let mut canvas = Canvas::new();
+        canvas.save();
+        let result = canvas.text("\u{2318}", 0.0, 0.0, Standard14::Helvetica, 12.0);
+        assert!(matches!(
+            result,
+            Err(Error::Unencodable { ch: '\u{2318}', .. })
+        ));
+        assert_eq!(canvas.ops(), [Op::Save]);
+        assert!(canvas.into_parts().fonts.is_empty());
+    }
+
+    #[test]
+    fn draw_image_emits_save_concat_xobject_restore() {
+        let mut canvas = Canvas::new();
+        let first = canvas.add_image(ImageData::gray8(1, 1, vec![0]).unwrap());
+        let second = canvas.add_image(ImageData::gray8(1, 1, vec![255]).unwrap());
+        canvas.draw_image(first, 10.0, 20.0, 100.0, 50.0);
+        canvas.draw_image(second, 0.0, 0.0, 5.0, 5.0);
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::Save,
+                Op::Concat(Matrix {
+                    a: 100.0,
+                    b: 0.0,
+                    c: 0.0,
+                    d: 50.0,
+                    e: 10.0,
+                    f: 20.0,
+                }),
+                Op::XObject(name("Im1")),
+                Op::Restore,
+                Op::Save,
+                Op::Concat(Matrix {
+                    a: 5.0,
+                    b: 0.0,
+                    c: 0.0,
+                    d: 5.0,
+                    e: 0.0,
+                    f: 0.0,
+                }),
+                Op::XObject(name("Im2")),
+                Op::Restore,
+            ]
+        );
+        assert_eq!(canvas.into_parts().images.len(), 2);
     }
 }

--- a/crates/pdfboss-write/src/canvas.rs
+++ b/crates/pdfboss-write/src/canvas.rs
@@ -1,0 +1,258 @@
+//! The imperative painting surface. A `Canvas` accumulates
+//! `pdfboss_core::content::Op` values — the exact IR the reader parses —
+//! plus the fonts and images those operators reference. Nothing here
+//! serializes; `finish` hands the parts to document assembly.
+//!
+//! Resource naming contract: the font first used gets resource name `F1`,
+//! the next distinct font `F2`, …; image handles map to `Im1`, `Im2`, … in
+//! [`add_image`](Canvas::add_image) order. Assembly builds the matching
+//! `/Resources` dictionary from [`CanvasParts`].
+
+use pdfboss_core::content::Op;
+use pdfboss_core::{Matrix, Point};
+
+use crate::color::Color;
+use crate::error::Result;
+use crate::font::Standard14;
+use crate::image::ImageData;
+
+/// Line cap style (ISO 32000 §8.4.3.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LineCap {
+    /// Squared off at the endpoint.
+    #[default]
+    Butt,
+    /// Semicircle around the endpoint.
+    Round,
+    /// Square projecting half a width beyond the endpoint.
+    Square,
+}
+
+/// Line join style (ISO 32000 §8.4.3.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LineJoin {
+    /// Outer edges extended to a point.
+    #[default]
+    Miter,
+    /// Circular arc around the corner.
+    Round,
+    /// Cut off with a straight edge.
+    Bevel,
+}
+
+/// Handle to an image registered on a canvas.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImageHandle(pub(crate) usize);
+
+/// The accumulated output of a finished canvas.
+#[derive(Debug)]
+pub struct CanvasParts {
+    /// Operators, in paint order.
+    pub ops: Vec<Op>,
+    /// Distinct fonts in first-use order; index `i` is resource `F{i+1}`.
+    pub fonts: Vec<Standard14>,
+    /// Images in registration order; index `i` is resource `Im{i+1}`.
+    pub images: Vec<ImageData>,
+}
+
+/// An imperative painter producing content-stream operators.
+#[derive(Debug, Default)]
+pub struct Canvas {
+    ops: Vec<Op>,
+    fonts: Vec<Standard14>,
+    images: Vec<ImageData>,
+}
+
+impl Canvas {
+    /// Creates an empty canvas.
+    pub fn new() -> Canvas {
+        Canvas::default()
+    }
+
+    /// Pushes the graphics state (`q`).
+    pub fn save(&mut self) {
+        todo!("save state ({} ops)", self.ops.len())
+    }
+
+    /// Pops the graphics state (`Q`).
+    pub fn restore(&mut self) {
+        todo!("restore state ({} ops)", self.ops.len())
+    }
+
+    /// Concatenates `m` onto the current transformation matrix (`cm`).
+    pub fn transform(&mut self, m: Matrix) {
+        let unused = (&mut self.ops, m);
+        todo!("transform: {unused:?}")
+    }
+
+    /// Sets the stroke line width (`w`).
+    pub fn set_line_width(&mut self, width: f32) {
+        let unused = (&mut self.ops, width);
+        todo!("line width: {unused:?}")
+    }
+
+    /// Sets the line cap style (`J`).
+    pub fn set_line_cap(&mut self, cap: LineCap) {
+        let unused = (&mut self.ops, cap);
+        todo!("line cap: {unused:?}")
+    }
+
+    /// Sets the line join style (`j`).
+    pub fn set_line_join(&mut self, join: LineJoin) {
+        let unused = (&mut self.ops, join);
+        todo!("line join: {unused:?}")
+    }
+
+    /// Sets the miter limit (`M`).
+    pub fn set_miter_limit(&mut self, limit: f32) {
+        let unused = (&mut self.ops, limit);
+        todo!("miter limit: {unused:?}")
+    }
+
+    /// Sets the dash pattern (`d`).
+    pub fn set_dash(&mut self, pattern: &[f32], phase: f32) {
+        let unused = (&mut self.ops, pattern, phase);
+        todo!("dash: {unused:?}")
+    }
+
+    /// Sets the fill color (`g`/`rg`/`k`).
+    pub fn set_fill(&mut self, color: Color) {
+        let unused = (&mut self.ops, color);
+        todo!("fill color: {unused:?}")
+    }
+
+    /// Sets the stroke color (`G`/`RG`/`K`).
+    pub fn set_stroke(&mut self, color: Color) {
+        let unused = (&mut self.ops, color);
+        todo!("stroke color: {unused:?}")
+    }
+
+    /// Begins a new subpath at `(x, y)` (`m`).
+    pub fn move_to(&mut self, x: f32, y: f32) {
+        let unused = (&mut self.ops, x, y);
+        todo!("move to: {unused:?}")
+    }
+
+    /// Straight segment to `(x, y)` (`l`).
+    pub fn line_to(&mut self, x: f32, y: f32) {
+        let unused = (&mut self.ops, x, y);
+        todo!("line to: {unused:?}")
+    }
+
+    /// Cubic Bézier with two control points (`c`).
+    #[allow(clippy::too_many_arguments)] // six coordinates is the operator's arity
+    pub fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32) {
+        let unused = (&mut self.ops, x1, y1, x2, y2, x3, y3);
+        todo!("curve to: {unused:?}")
+    }
+
+    /// Closes the current subpath (`h`).
+    pub fn close(&mut self) {
+        todo!("close path ({} ops)", self.ops.len())
+    }
+
+    /// Appends a rectangle subpath (`re`).
+    pub fn rect(&mut self, x: f32, y: f32, width: f32, height: f32) {
+        let unused = (&mut self.ops, x, y, width, height);
+        todo!("rect: {unused:?}")
+    }
+
+    /// Appends a circle as four Bézier arcs.
+    pub fn circle(&mut self, cx: f32, cy: f32, r: f32) {
+        let unused = (&mut self.ops, cx, cy, r);
+        todo!("circle: {unused:?}")
+    }
+
+    /// Appends an axis-aligned ellipse as four Bézier arcs.
+    pub fn ellipse(&mut self, cx: f32, cy: f32, rx: f32, ry: f32) {
+        let unused = (&mut self.ops, cx, cy, rx, ry);
+        todo!("ellipse: {unused:?}")
+    }
+
+    /// Appends a closed polygon through `points`.
+    pub fn polygon(&mut self, points: &[Point]) {
+        let unused = (&mut self.ops, points);
+        todo!("polygon: {unused:?}")
+    }
+
+    /// Fills the current path, nonzero winding (`f`).
+    pub fn fill(&mut self) {
+        todo!("fill ({} ops)", self.ops.len())
+    }
+
+    /// Fills the current path, even-odd (`f*`).
+    pub fn fill_even_odd(&mut self) {
+        todo!("fill even-odd ({} ops)", self.ops.len())
+    }
+
+    /// Strokes the current path (`S`).
+    pub fn stroke(&mut self) {
+        todo!("stroke ({} ops)", self.ops.len())
+    }
+
+    /// Closes and strokes the current path (`s`).
+    pub fn close_stroke(&mut self) {
+        todo!("close-stroke ({} ops)", self.ops.len())
+    }
+
+    /// Fills then strokes the current path (`B`).
+    pub fn fill_stroke(&mut self) {
+        todo!("fill-stroke ({} ops)", self.ops.len())
+    }
+
+    /// Intersects the clip with the current path, nonzero (`W n`).
+    pub fn clip(&mut self) {
+        todo!("clip ({} ops)", self.ops.len())
+    }
+
+    /// Intersects the clip with the current path, even-odd (`W* n`).
+    pub fn clip_even_odd(&mut self) {
+        todo!("clip even-odd ({} ops)", self.ops.len())
+    }
+
+    /// Ends the current path without painting (`n`).
+    pub fn end_path(&mut self) {
+        todo!("end path ({} ops)", self.ops.len())
+    }
+
+    /// Shows one line of text with its baseline origin at `(x, y)`
+    /// (`BT`/`Tf`/`Td`/`Tj`/`ET`). Errors on unencodable characters.
+    pub fn text(&mut self, text: &str, x: f32, y: f32, font: Standard14, size: f32) -> Result<()> {
+        let unused = (&mut self.ops, text, x, y, font, size);
+        todo!("text: {unused:?}")
+    }
+
+    /// Registers an image for use with [`draw_image`](Canvas::draw_image).
+    pub fn add_image(&mut self, image: ImageData) -> ImageHandle {
+        let unused = (&mut self.images, image);
+        todo!("add image: {unused:?}")
+    }
+
+    /// Paints a registered image into the axis-aligned box at `(x, y)` with
+    /// the given size (`q cm Do Q`).
+    pub fn draw_image(&mut self, image: ImageHandle, x: f32, y: f32, width: f32, height: f32) {
+        let unused = (&mut self.ops, image, x, y, width, height);
+        todo!("draw image: {unused:?}")
+    }
+
+    /// Pushes a raw operator — the escape hatch for anything the methods
+    /// above don't cover. Resource-referencing operators are the caller's
+    /// responsibility to keep consistent with the naming contract.
+    pub fn op(&mut self, op: Op) {
+        self.ops.push(op);
+    }
+
+    /// The operators accumulated so far, in paint order.
+    pub fn ops(&self) -> &[Op] {
+        &self.ops
+    }
+
+    /// Consumes the canvas into its parts for document assembly.
+    pub(crate) fn into_parts(self) -> CanvasParts {
+        CanvasParts {
+            ops: self.ops,
+            fonts: self.fonts,
+            images: self.images,
+        }
+    }
+}

--- a/crates/pdfboss-write/src/color.rs
+++ b/crates/pdfboss-write/src/color.rs
@@ -1,0 +1,33 @@
+//! Device color values for content generation. The first public color
+//! vocabulary in the workspace — the render crate keeps its own private
+//! read-side `ColorSpace`.
+
+use pdfboss_core::content::Op;
+
+/// A device color: gray, RGB or CMYK, components in `0.0..=1.0`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Color {
+    /// DeviceGray.
+    Gray(f32),
+    /// DeviceRGB.
+    Rgb(f32, f32, f32),
+    /// DeviceCMYK.
+    Cmyk(f32, f32, f32, f32),
+}
+
+impl Color {
+    /// Black in DeviceGray.
+    pub const BLACK: Color = Color::Gray(0.0);
+    /// White in DeviceGray.
+    pub const WHITE: Color = Color::Gray(1.0);
+
+    /// The operator that selects this color for filling (`g`/`rg`/`k`).
+    pub(crate) fn fill_op(self) -> Op {
+        todo!("fill op for {self:?}")
+    }
+
+    /// The operator that selects this color for stroking (`G`/`RG`/`K`).
+    pub(crate) fn stroke_op(self) -> Op {
+        todo!("stroke op for {self:?}")
+    }
+}

--- a/crates/pdfboss-write/src/color.rs
+++ b/crates/pdfboss-write/src/color.rs
@@ -23,11 +23,52 @@ impl Color {
 
     /// The operator that selects this color for filling (`g`/`rg`/`k`).
     pub(crate) fn fill_op(self) -> Op {
-        todo!("fill op for {self:?}")
+        match self {
+            Color::Gray(gray) => Op::SetFillGray(gray),
+            Color::Rgb(r, g, b) => Op::SetFillRGB(r, g, b),
+            Color::Cmyk(c, m, y, k) => Op::SetFillCMYK(c, m, y, k),
+        }
     }
 
     /// The operator that selects this color for stroking (`G`/`RG`/`K`).
     pub(crate) fn stroke_op(self) -> Op {
-        todo!("stroke op for {self:?}")
+        match self {
+            Color::Gray(gray) => Op::SetStrokeGray(gray),
+            Color::Rgb(r, g, b) => Op::SetStrokeRGB(r, g, b),
+            Color::Cmyk(c, m, y, k) => Op::SetStrokeCMYK(c, m, y, k),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fill_op_maps_each_variant() {
+        assert_eq!(Color::Gray(0.25).fill_op(), Op::SetFillGray(0.25));
+        assert_eq!(
+            Color::Rgb(0.1, 0.2, 0.3).fill_op(),
+            Op::SetFillRGB(0.1, 0.2, 0.3)
+        );
+        assert_eq!(
+            Color::Cmyk(0.1, 0.2, 0.3, 0.4).fill_op(),
+            Op::SetFillCMYK(0.1, 0.2, 0.3, 0.4)
+        );
+        assert_eq!(Color::BLACK.fill_op(), Op::SetFillGray(0.0));
+        assert_eq!(Color::WHITE.fill_op(), Op::SetFillGray(1.0));
+    }
+
+    #[test]
+    fn stroke_op_maps_each_variant() {
+        assert_eq!(Color::Gray(0.75).stroke_op(), Op::SetStrokeGray(0.75));
+        assert_eq!(
+            Color::Rgb(0.4, 0.5, 0.6).stroke_op(),
+            Op::SetStrokeRGB(0.4, 0.5, 0.6)
+        );
+        assert_eq!(
+            Color::Cmyk(0.5, 0.6, 0.7, 0.8).stroke_op(),
+            Op::SetStrokeCMYK(0.5, 0.6, 0.7, 0.8)
+        );
     }
 }

--- a/crates/pdfboss-write/src/content.rs
+++ b/crates/pdfboss-write/src/content.rs
@@ -2,12 +2,618 @@
 //! operator syntax. The writer emits from the same IR the reader parses
 //! into, so `parse_content(serialize_ops(ops)) == ops` is the module's
 //! defining property — every variant of [`Op`] must round-trip.
+//!
+//! Inline images emit exactly the dictionary entries present in
+//! [`ImageParams::dict`], never an invented `/L`: the parser keeps a
+//! declared length key (`/L` or `/Length`) in the parsed dictionary, so
+//! re-emitting the entries reproduces the trusted length, and data
+//! containing a spurious ` EI ` round-trips whenever the dictionary
+//! carries one — the only way the parser can produce such data. Without a
+//! length key the parser stops at the first `EI` token boundary, so
+//! parser-produced data never contains a premature boundary and re-locating
+//! `EI` finds the true end. The parser skips one whitespace byte after `ID`
+//! and strips one before `EI`; the writer emits exactly one of each.
+//!
+//! Two parser-producible corners cannot round-trip byte-exactly and are
+//! accepted: a dictionary or properties value holding an integral `Real`
+//! reparses as `Int` (the crate serializes `2.0` as `2`), and a truncated
+//! source whose declared length exceeds the actual data yields an op whose
+//! dictionary promises more bytes than `data` holds.
 
-use pdfboss_core::content::Op;
+use pdfboss_core::content::{ImageParams, Op, TextItem};
+use pdfboss_core::{Name, Object};
 
-/// Serializes a sequence of content operators. Inline-image dictionaries
-/// are written with their canonical (unabbreviated) keys, which the parser
-/// passes through unchanged.
+use crate::ser::{serialize_object, write_name, write_real_f32, write_string};
+
+/// Serializes a sequence of content operators: operands space-separated,
+/// one space before each operator keyword, a newline after it.
+/// Inline-image dictionaries are written with their canonical
+/// (unabbreviated) keys, which the parser passes through unchanged.
+/// Infallible: a stream inside a `DP`/`BDC` properties value — impossible
+/// in parser-produced ops — is emitted as `null`.
 pub fn serialize_ops(ops: &[Op]) -> Vec<u8> {
-    todo!("serialize {} ops", ops.len())
+    let mut out = Vec::new();
+    for op in ops {
+        push_op(op, &mut out);
+    }
+    out
+}
+
+/// Emits one operator: each operand followed by a space, then the keyword
+/// and a newline.
+fn push_op(op: &Op, out: &mut Vec<u8>) {
+    match op {
+        Op::Save => push_kw(b"q", out),
+        Op::Restore => push_kw(b"Q", out),
+        Op::Concat(m) => push_nums(&[m.a, m.b, m.c, m.d, m.e, m.f], b"cm", out),
+        Op::SetLineWidth(w) => push_nums(&[*w], b"w", out),
+        Op::SetLineCap(cap) => push_int(*cap, b"J", out),
+        Op::SetLineJoin(join) => push_int(*join, b"j", out),
+        Op::SetMiterLimit(limit) => push_nums(&[*limit], b"M", out),
+        Op::SetDash(dashes, phase) => {
+            push_f32_array(dashes, out);
+            out.push(b' ');
+            push_nums(&[*phase], b"d", out);
+        }
+        Op::SetRenderingIntent(n) => push_name_op(n, b"ri", out),
+        Op::SetFlatness(f) => push_nums(&[*f], b"i", out),
+        Op::SetExtGState(n) => push_name_op(n, b"gs", out),
+        Op::MoveTo(x, y) => push_nums(&[*x, *y], b"m", out),
+        Op::LineTo(x, y) => push_nums(&[*x, *y], b"l", out),
+        Op::CurveTo(x1, y1, x2, y2, x3, y3) => {
+            push_nums(&[*x1, *y1, *x2, *y2, *x3, *y3], b"c", out);
+        }
+        Op::CurveToV(x2, y2, x3, y3) => push_nums(&[*x2, *y2, *x3, *y3], b"v", out),
+        Op::CurveToY(x1, y1, x3, y3) => push_nums(&[*x1, *y1, *x3, *y3], b"y", out),
+        Op::ClosePath => push_kw(b"h", out),
+        Op::Rect(x, y, w, h) => push_nums(&[*x, *y, *w, *h], b"re", out),
+        Op::Stroke => push_kw(b"S", out),
+        Op::CloseStroke => push_kw(b"s", out),
+        Op::Fill => push_kw(b"f", out),
+        Op::FillEvenOdd => push_kw(b"f*", out),
+        Op::FillStroke => push_kw(b"B", out),
+        Op::FillStrokeEvenOdd => push_kw(b"B*", out),
+        Op::CloseFillStroke => push_kw(b"b", out),
+        Op::CloseFillStrokeEvenOdd => push_kw(b"b*", out),
+        Op::EndPath => push_kw(b"n", out),
+        Op::ClipNonZero => push_kw(b"W", out),
+        Op::ClipEvenOdd => push_kw(b"W*", out),
+        Op::SetStrokeColorSpace(n) => push_name_op(n, b"CS", out),
+        Op::SetFillColorSpace(n) => push_name_op(n, b"cs", out),
+        Op::SetStrokeColor(comps) => push_nums(comps, b"SC", out),
+        Op::SetStrokeColorN(comps, pattern) => {
+            push_color_n(comps, pattern.as_ref(), b"SCN", out);
+        }
+        Op::SetFillColor(comps) => push_nums(comps, b"sc", out),
+        Op::SetFillColorN(comps, pattern) => push_color_n(comps, pattern.as_ref(), b"scn", out),
+        Op::SetStrokeGray(g) => push_nums(&[*g], b"G", out),
+        Op::SetFillGray(g) => push_nums(&[*g], b"g", out),
+        Op::SetStrokeRGB(r, g, b) => push_nums(&[*r, *g, *b], b"RG", out),
+        Op::SetFillRGB(r, g, b) => push_nums(&[*r, *g, *b], b"rg", out),
+        Op::SetStrokeCMYK(c, m, y, k) => push_nums(&[*c, *m, *y, *k], b"K", out),
+        Op::SetFillCMYK(c, m, y, k) => push_nums(&[*c, *m, *y, *k], b"k", out),
+        Op::BeginText => push_kw(b"BT", out),
+        Op::EndText => push_kw(b"ET", out),
+        Op::SetCharSpacing(v) => push_nums(&[*v], b"Tc", out),
+        Op::SetWordSpacing(v) => push_nums(&[*v], b"Tw", out),
+        Op::SetHorizScaling(v) => push_nums(&[*v], b"Tz", out),
+        Op::SetLeading(v) => push_nums(&[*v], b"TL", out),
+        Op::SetFont(n, size) => {
+            write_name(&n.0, out);
+            out.push(b' ');
+            push_nums(&[*size], b"Tf", out);
+        }
+        Op::SetGlyphWidth(wx, wy) => push_nums(&[*wx, *wy], b"d0", out),
+        Op::SetGlyphWidthBBox(wx, wy, llx, lly, urx, ury) => {
+            push_nums(&[*wx, *wy, *llx, *lly, *urx, *ury], b"d1", out);
+        }
+        Op::SetTextRender(mode) => push_int(*mode, b"Tr", out),
+        Op::SetTextRise(v) => push_nums(&[*v], b"Ts", out),
+        Op::TextMove(tx, ty) => push_nums(&[*tx, *ty], b"Td", out),
+        Op::TextMoveSetLeading(tx, ty) => push_nums(&[*tx, *ty], b"TD", out),
+        Op::SetTextMatrix(m) => push_nums(&[m.a, m.b, m.c, m.d, m.e, m.f], b"Tm", out),
+        Op::TextNextLine => push_kw(b"T*", out),
+        Op::ShowText(s) => push_string_op(s, b"Tj", out),
+        Op::ShowTextAdjusted(items) => push_text_adjusted(items, out),
+        Op::NextLineShowText(s) => push_string_op(s, b"'", out),
+        Op::NextLineShowTextSpaced(aw, ac, s) => {
+            write_real_f32(*aw, out);
+            out.push(b' ');
+            write_real_f32(*ac, out);
+            out.push(b' ');
+            push_string_op(s, b"\"", out);
+        }
+        Op::XObject(n) => push_name_op(n, b"Do", out),
+        Op::InlineImage(img) => push_inline_image(img, out),
+        Op::Shading(n) => push_name_op(n, b"sh", out),
+        Op::MarkedContentPoint(n) => push_name_op(n, b"MP", out),
+        Op::MarkedContentPointProps(tag, props) => push_tag_props(tag, props, b"DP", out),
+        Op::BeginMarkedContent(n) => push_name_op(n, b"BMC", out),
+        Op::BeginMarkedContentProps(tag, props) => push_tag_props(tag, props, b"BDC", out),
+        Op::EndMarkedContent => push_kw(b"EMC", out),
+        Op::BeginCompat => push_kw(b"BX", out),
+        Op::EndCompat => push_kw(b"EX", out),
+    }
+}
+
+/// Writes the operator keyword and its terminating newline.
+fn push_kw(kw: &[u8], out: &mut Vec<u8>) {
+    out.extend_from_slice(kw);
+    out.push(b'\n');
+}
+
+/// Writes numeric operands, each followed by a space, then the keyword.
+fn push_nums(vals: &[f32], kw: &[u8], out: &mut Vec<u8>) {
+    for v in vals {
+        write_real_f32(*v, out);
+        out.push(b' ');
+    }
+    push_kw(kw, out);
+}
+
+/// Writes a plain-integer operand, then the keyword.
+fn push_int(value: i32, kw: &[u8], out: &mut Vec<u8>) {
+    out.extend_from_slice(value.to_string().as_bytes());
+    out.push(b' ');
+    push_kw(kw, out);
+}
+
+/// Writes a single name operand, then the keyword.
+fn push_name_op(n: &Name, kw: &[u8], out: &mut Vec<u8>) {
+    write_name(&n.0, out);
+    out.push(b' ');
+    push_kw(kw, out);
+}
+
+/// Writes a single string operand, then the keyword.
+fn push_string_op(s: &[u8], kw: &[u8], out: &mut Vec<u8>) {
+    write_string(s, out);
+    out.push(b' ');
+    push_kw(kw, out);
+}
+
+/// Writes a `[n1 n2 …]` array of reals (the `d` dash array).
+fn push_f32_array(vals: &[f32], out: &mut Vec<u8>) {
+    out.push(b'[');
+    for (i, v) in vals.iter().enumerate() {
+        if i > 0 {
+            out.push(b' ');
+        }
+        write_real_f32(*v, out);
+    }
+    out.push(b']');
+}
+
+/// Writes color components, the optional pattern name, then `SCN`/`scn`.
+fn push_color_n(comps: &[f32], pattern: Option<&Name>, kw: &[u8], out: &mut Vec<u8>) {
+    for v in comps {
+        write_real_f32(*v, out);
+        out.push(b' ');
+    }
+    if let Some(n) = pattern {
+        write_name(&n.0, out);
+        out.push(b' ');
+    }
+    push_kw(kw, out);
+}
+
+/// Writes a `TJ` array: strings and offsets space-separated in brackets.
+fn push_text_adjusted(items: &[TextItem], out: &mut Vec<u8>) {
+    out.push(b'[');
+    for (i, item) in items.iter().enumerate() {
+        if i > 0 {
+            out.push(b' ');
+        }
+        match item {
+            TextItem::Str(s) => write_string(s, out),
+            TextItem::Offset(v) => write_real_f32(*v, out),
+        }
+    }
+    out.extend_from_slice(b"] ");
+    push_kw(b"TJ", out);
+}
+
+/// Writes the tag and properties operands of `DP`/`BDC`, then the keyword.
+fn push_tag_props(tag: &Name, props: &Object, kw: &[u8], out: &mut Vec<u8>) {
+    write_name(&tag.0, out);
+    out.push(b' ');
+    push_object_or_null(props, out);
+    out.push(b' ');
+    push_kw(kw, out);
+}
+
+/// Serializes an object, falling back to `null` on the impossible nested
+/// stream so [`serialize_ops`] stays infallible.
+fn push_object_or_null(obj: &Object, out: &mut Vec<u8>) {
+    let mark = out.len();
+    if serialize_object(obj, out).is_err() {
+        out.truncate(mark);
+        out.extend_from_slice(b"null");
+    }
+}
+
+/// Writes `BI`, the dictionary entries present (keys sorted bytewise),
+/// `ID`, one whitespace byte, the raw data, one whitespace byte, and `EI`.
+fn push_inline_image(img: &ImageParams, out: &mut Vec<u8>) {
+    out.extend_from_slice(b"BI");
+    let mut entries: Vec<(&Name, &Object)> = img.dict.iter().collect();
+    entries.sort_unstable_by(|a, b| a.0.cmp(b.0));
+    for (key, value) in entries {
+        out.push(b' ');
+        write_name(&key.0, out);
+        out.push(b' ');
+        push_object_or_null(value, out);
+    }
+    out.extend_from_slice(b" ID ");
+    out.extend_from_slice(&img.data);
+    out.extend_from_slice(b" EI\n");
+}
+
+#[cfg(test)]
+mod tests {
+    use pdfboss_core::content::{parse_content, ImageParams, TextItem};
+    use pdfboss_core::geom::Matrix;
+    use pdfboss_core::{Dict, Name, Object};
+
+    use super::*;
+
+    /// Number of `Op` variants; [`variant_index`] fails to compile when the
+    /// enum grows, forcing this constant and the sample table to follow.
+    const VARIANT_COUNT: usize = 70;
+
+    fn name(s: &str) -> Name {
+        Name(s.to_string())
+    }
+
+    fn m(a: f32, b: f32, c: f32, d: f32, e: f32, f: f32) -> Matrix {
+        Matrix { a, b, c, d, e, f }
+    }
+
+    fn image(entries: &[(&str, Object)], data: &[u8]) -> Op {
+        let mut dict = Dict::new();
+        for (key, value) in entries {
+            dict.insert(name(key), value.clone());
+        }
+        Op::InlineImage(ImageParams {
+            dict,
+            data: data.to_vec(),
+        })
+    }
+
+    fn round_trip(ops: &[Op]) {
+        let bytes = serialize_ops(ops);
+        let parsed = parse_content(&bytes).unwrap_or_else(|e| {
+            panic!(
+                "serialized ops parse: {e:?}\n{}",
+                String::from_utf8_lossy(&bytes)
+            )
+        });
+        assert_eq!(
+            parsed,
+            ops,
+            "round-trip of {}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+
+    fn variant_index(op: &Op) -> usize {
+        match op {
+            Op::Save => 0,
+            Op::Restore => 1,
+            Op::Concat(..) => 2,
+            Op::SetLineWidth(..) => 3,
+            Op::SetLineCap(..) => 4,
+            Op::SetLineJoin(..) => 5,
+            Op::SetMiterLimit(..) => 6,
+            Op::SetDash(..) => 7,
+            Op::SetRenderingIntent(..) => 8,
+            Op::SetFlatness(..) => 9,
+            Op::SetExtGState(..) => 10,
+            Op::MoveTo(..) => 11,
+            Op::LineTo(..) => 12,
+            Op::CurveTo(..) => 13,
+            Op::CurveToV(..) => 14,
+            Op::CurveToY(..) => 15,
+            Op::ClosePath => 16,
+            Op::Rect(..) => 17,
+            Op::Stroke => 18,
+            Op::CloseStroke => 19,
+            Op::Fill => 20,
+            Op::FillEvenOdd => 21,
+            Op::FillStroke => 22,
+            Op::FillStrokeEvenOdd => 23,
+            Op::CloseFillStroke => 24,
+            Op::CloseFillStrokeEvenOdd => 25,
+            Op::EndPath => 26,
+            Op::ClipNonZero => 27,
+            Op::ClipEvenOdd => 28,
+            Op::SetStrokeColorSpace(..) => 29,
+            Op::SetFillColorSpace(..) => 30,
+            Op::SetStrokeColor(..) => 31,
+            Op::SetStrokeColorN(..) => 32,
+            Op::SetFillColor(..) => 33,
+            Op::SetFillColorN(..) => 34,
+            Op::SetStrokeGray(..) => 35,
+            Op::SetFillGray(..) => 36,
+            Op::SetStrokeRGB(..) => 37,
+            Op::SetFillRGB(..) => 38,
+            Op::SetStrokeCMYK(..) => 39,
+            Op::SetFillCMYK(..) => 40,
+            Op::BeginText => 41,
+            Op::EndText => 42,
+            Op::SetCharSpacing(..) => 43,
+            Op::SetWordSpacing(..) => 44,
+            Op::SetHorizScaling(..) => 45,
+            Op::SetLeading(..) => 46,
+            Op::SetFont(..) => 47,
+            Op::SetGlyphWidth(..) => 48,
+            Op::SetGlyphWidthBBox(..) => 49,
+            Op::SetTextRender(..) => 50,
+            Op::SetTextRise(..) => 51,
+            Op::TextMove(..) => 52,
+            Op::TextMoveSetLeading(..) => 53,
+            Op::SetTextMatrix(..) => 54,
+            Op::TextNextLine => 55,
+            Op::ShowText(..) => 56,
+            Op::ShowTextAdjusted(..) => 57,
+            Op::NextLineShowText(..) => 58,
+            Op::NextLineShowTextSpaced(..) => 59,
+            Op::XObject(..) => 60,
+            Op::InlineImage(..) => 61,
+            Op::Shading(..) => 62,
+            Op::MarkedContentPoint(..) => 63,
+            Op::MarkedContentPointProps(..) => 64,
+            Op::BeginMarkedContent(..) => 65,
+            Op::BeginMarkedContentProps(..) => 66,
+            Op::EndMarkedContent => 67,
+            Op::BeginCompat => 68,
+            Op::EndCompat => 69,
+        }
+    }
+
+    fn sample_ops() -> Vec<Op> {
+        let mut props = Dict::new();
+        props.insert(name("MCID"), Object::Int(3));
+        vec![
+            Op::Save,
+            Op::Restore,
+            Op::Concat(m(1.0, 0.0, 0.0, 1.0, 10.5, 20.0)),
+            Op::SetLineWidth(2.5),
+            Op::SetLineCap(1),
+            Op::SetLineJoin(2),
+            Op::SetMiterLimit(3.5),
+            Op::SetDash(vec![3.0, 1.5], 0.5),
+            Op::SetRenderingIntent(name("Perceptual")),
+            Op::SetFlatness(1.5),
+            Op::SetExtGState(name("GS1")),
+            Op::MoveTo(10.0, 20.0),
+            Op::LineTo(-30.5, 40.0),
+            Op::CurveTo(1.0, 2.0, 3.0, 4.0, 5.0, 6.0),
+            Op::CurveToV(1.5, 2.5, 3.5, 4.5),
+            Op::CurveToY(5.0, 6.0, 7.0, 8.0),
+            Op::ClosePath,
+            Op::Rect(72.0, 600.0, 100.0, 80.0),
+            Op::Stroke,
+            Op::CloseStroke,
+            Op::Fill,
+            Op::FillEvenOdd,
+            Op::FillStroke,
+            Op::FillStrokeEvenOdd,
+            Op::CloseFillStroke,
+            Op::CloseFillStrokeEvenOdd,
+            Op::EndPath,
+            Op::ClipNonZero,
+            Op::ClipEvenOdd,
+            Op::SetStrokeColorSpace(name("DeviceRGB")),
+            Op::SetFillColorSpace(name("Pattern")),
+            Op::SetStrokeColor(vec![1.0, 0.5, 0.25]),
+            Op::SetStrokeColorN(vec![0.1, 0.2], Some(name("P2"))),
+            Op::SetFillColor(vec![0.5]),
+            Op::SetFillColorN(vec![0.2, 0.4, 0.6], None),
+            Op::SetStrokeGray(0.3),
+            Op::SetFillGray(0.7),
+            Op::SetStrokeRGB(1.0, 0.0, 0.5),
+            Op::SetFillRGB(0.0, 1.0, 0.0),
+            Op::SetStrokeCMYK(0.0, 0.25, 0.5, 1.0),
+            Op::SetFillCMYK(1.0, 0.0, 0.0, 0.125),
+            Op::BeginText,
+            Op::EndText,
+            Op::SetCharSpacing(0.5),
+            Op::SetWordSpacing(1.5),
+            Op::SetHorizScaling(90.0),
+            Op::SetLeading(14.5),
+            Op::SetFont(name("F1"), 12.0),
+            Op::SetGlyphWidth(1000.0, 0.0),
+            Op::SetGlyphWidthBBox(1000.0, 0.0, 0.0, 0.0, 750.0, 700.0),
+            Op::SetTextRender(3),
+            Op::SetTextRise(4.5),
+            Op::TextMove(72.0, 720.0),
+            Op::TextMoveSetLeading(0.0, -14.0),
+            Op::SetTextMatrix(m(2.0, 0.0, 0.0, 2.0, 50.5, 60.0)),
+            Op::TextNextLine,
+            Op::ShowText(b"Hi (there)\\".to_vec()),
+            Op::ShowTextAdjusted(vec![
+                TextItem::Str(b"He".to_vec()),
+                TextItem::Offset(-120.0),
+                TextItem::Str(b"llo".to_vec()),
+                TextItem::Offset(33.5),
+            ]),
+            Op::NextLineShowText(b"next line".to_vec()),
+            Op::NextLineShowTextSpaced(2.0, 3.0, b"spaced".to_vec()),
+            Op::XObject(name("Im1")),
+            image(
+                &[
+                    ("ColorSpace", Object::Name(name("DeviceGray"))),
+                    ("Width", Object::Int(2)),
+                    ("BitsPerComponent", Object::Int(8)),
+                    ("Height", Object::Int(2)),
+                ],
+                &[0, 255, 128, 127],
+            ),
+            Op::Shading(name("Sh1")),
+            Op::MarkedContentPoint(name("Tag")),
+            Op::MarkedContentPointProps(name("Tag"), Object::Name(name("P"))),
+            Op::BeginMarkedContent(name("Span")),
+            Op::BeginMarkedContentProps(name("Span"), Object::Dict(props)),
+            Op::EndMarkedContent,
+            Op::BeginCompat,
+            Op::EndCompat,
+        ]
+    }
+
+    #[test]
+    fn every_variant_round_trips() {
+        let samples = sample_ops();
+        let covered: std::collections::BTreeSet<usize> =
+            samples.iter().map(variant_index).collect();
+        assert_eq!(covered, (0..VARIANT_COUNT).collect());
+        for op in &samples {
+            round_trip(std::slice::from_ref(op));
+        }
+        round_trip(&samples);
+    }
+
+    #[test]
+    fn mixed_sequence_round_trips() {
+        let mut props = Dict::new();
+        props.insert(name("MCID"), Object::Int(0));
+        let ops = vec![
+            Op::Save,
+            Op::Concat(m(0.5, 0.0, 0.0, 0.5, 300.0, 100.0)),
+            Op::Rect(0.0, 0.0, 200.0, 200.0),
+            Op::Fill,
+            Op::BeginMarkedContentProps(name("P"), Object::Dict(props)),
+            Op::BeginText,
+            Op::SetFont(name("F1"), 12.0),
+            Op::TextMove(72.0, 720.0),
+            Op::ShowText(b"Hello, world".to_vec()),
+            Op::ShowTextAdjusted(vec![
+                TextItem::Str(b"kern".to_vec()),
+                TextItem::Offset(-15.5),
+                TextItem::Str(b"ed".to_vec()),
+            ]),
+            Op::EndText,
+            Op::EndMarkedContent,
+            Op::XObject(name("Im1")),
+            Op::Restore,
+        ];
+        round_trip(&ops);
+    }
+
+    #[test]
+    fn inline_image_hazardous_data_round_trips_via_declared_length() {
+        let op = image(
+            &[
+                ("Width", Object::Int(3)),
+                ("Height", Object::Int(1)),
+                ("BitsPerComponent", Object::Int(8)),
+                ("ColorSpace", Object::Name(name("DeviceRGB"))),
+                ("L", Object::Int(9)),
+            ],
+            b"ab EI wxy",
+        );
+        round_trip(std::slice::from_ref(&op));
+        round_trip(&[op, Op::MoveTo(1.0, 2.0)]);
+    }
+
+    #[test]
+    fn parser_produced_length_image_round_trips() {
+        let mut src = b"BI /W 3 /H 1 /BPC 8 /CS /RGB /L 9 ID ".to_vec();
+        src.extend_from_slice(b"ab EI wxy");
+        src.extend_from_slice(b" EI 1 2 m");
+        let parsed = parse_content(&src).expect("source parses");
+        assert_eq!(parsed.len(), 2);
+        round_trip(&parsed);
+    }
+
+    #[test]
+    fn inline_image_ei_boundary_data_round_trips_without_length() {
+        let base = [("Width", Object::Int(1)), ("Height", Object::Int(1))];
+        for data in [
+            b"noEIhazard".as_slice(),
+            b"EIx\x01".as_slice(),
+            b"zxEI".as_slice(),
+            b"tail ".as_slice(),
+        ] {
+            round_trip(std::slice::from_ref(&image(&base, data)));
+        }
+    }
+
+    #[test]
+    fn f32_hard_cases_survive_round_trip() {
+        let ops = vec![
+            Op::SetLineWidth(0.1),
+            Op::SetLineWidth(1e-7),
+            Op::SetLineWidth(-1e-7),
+            Op::MoveTo(-0.25, -123.456),
+            Op::SetDash(vec![0.1, 1e-7, -0.3], 16_777_216.0),
+            Op::ShowTextAdjusted(vec![TextItem::Offset(-120.25), TextItem::Offset(1e-7)]),
+            Op::SetTextRise(f32::MIN_POSITIVE),
+            Op::SetCharSpacing(3.4e38),
+        ];
+        for op in &ops {
+            round_trip(std::slice::from_ref(op));
+        }
+        round_trip(&ops);
+    }
+
+    #[test]
+    fn empty_operand_containers_round_trip() {
+        let ops = vec![
+            Op::SetDash(vec![], 0.0),
+            Op::ShowTextAdjusted(vec![]),
+            Op::SetStrokeColor(vec![]),
+            Op::SetStrokeColorN(vec![], None),
+            Op::SetFillColorN(vec![], Some(name("P1"))),
+            Op::InlineImage(ImageParams {
+                dict: Dict::new(),
+                data: Vec::new(),
+            }),
+        ];
+        for op in &ops {
+            round_trip(std::slice::from_ref(op));
+        }
+        round_trip(&ops);
+    }
+
+    #[test]
+    fn layout_pins_exact_bytes() {
+        assert_eq!(serialize_ops(&[Op::Save]), b"q\n");
+        assert_eq!(
+            serialize_ops(&[Op::Concat(m(1.0, 0.0, 0.0, 1.0, 10.0, 20.0))]),
+            b"1 0 0 1 10 20 cm\n"
+        );
+        assert_eq!(
+            serialize_ops(&[Op::SetDash(vec![3.0, 1.0], 0.5)]),
+            b"[3 1] 0.5 d\n"
+        );
+        assert_eq!(
+            serialize_ops(&[Op::ShowTextAdjusted(vec![
+                TextItem::Str(b"He".to_vec()),
+                TextItem::Offset(-120.0),
+                TextItem::Str(b"llo".to_vec()),
+            ])]),
+            b"[(He) -120 (llo)] TJ\n"
+        );
+        assert_eq!(
+            serialize_ops(&[Op::SetStrokeColorN(vec![0.1, 0.2], Some(name("P2")))]),
+            b"0.1 0.2 /P2 SCN\n"
+        );
+        assert_eq!(
+            serialize_ops(&[Op::NextLineShowTextSpaced(2.0, 3.0, b"spaced".to_vec())]),
+            b"2 3 (spaced) \"\n"
+        );
+        assert_eq!(
+            serialize_ops(&[Op::SetFont(name("F1"), 12.0)]),
+            b"/F1 12 Tf\n"
+        );
+        assert_eq!(serialize_ops(&[Op::SetTextRender(2)]), b"2 Tr\n");
+        let mut want = b"BI /Width 2 ID ".to_vec();
+        want.extend_from_slice(&[0, 255]);
+        want.extend_from_slice(b" EI\n");
+        assert_eq!(
+            serialize_ops(&[image(&[("Width", Object::Int(2))], &[0, 255])]),
+            want
+        );
+    }
 }

--- a/crates/pdfboss-write/src/content.rs
+++ b/crates/pdfboss-write/src/content.rs
@@ -1,0 +1,13 @@
+//! Content-stream serialization: `pdfboss_core::content::Op` values back to
+//! operator syntax. The writer emits from the same IR the reader parses
+//! into, so `parse_content(serialize_ops(ops)) == ops` is the module's
+//! defining property — every variant of [`Op`] must round-trip.
+
+use pdfboss_core::content::Op;
+
+/// Serializes a sequence of content operators. Inline-image dictionaries
+/// are written with their canonical (unabbreviated) keys, which the parser
+/// passes through unchanged.
+pub fn serialize_ops(ops: &[Op]) -> Vec<u8> {
+    todo!("serialize {} ops", ops.len())
+}

--- a/crates/pdfboss-write/src/error.rs
+++ b/crates/pdfboss-write/src/error.rs
@@ -1,0 +1,41 @@
+//! Error type for PDF creation. Writing is strict where reading is lenient:
+//! a writer that silently drops or corrupts content is worse than one that
+//! refuses, so every lossy situation is an error, never a skip.
+
+use pdfboss_core::ObjRef;
+
+/// Alias used across the crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Any error raised while building or serializing a PDF.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Underlying I/O failure while saving.
+    #[error("i/o error: {0}")]
+    Io(#[from] std::io::Error),
+    /// A reserved object was filled twice, or `fill` targeted a
+    /// never-reserved reference.
+    #[error("object {} {} already has a body", .0.num, .0.gen)]
+    AlreadyFilled(ObjRef),
+    /// `finish` found a reserved object that was never filled.
+    #[error("object {} {} was reserved but never filled", .0.num, .0.gen)]
+    Unfilled(ObjRef),
+    /// A `Stream` object appeared nested inside another object; streams are
+    /// only legal as indirect objects (ISO 32000 §7.3.8).
+    #[error("stream objects must be indirect, not nested")]
+    NestedStream,
+    /// A character has no code in the target font's encoding.
+    #[error("character {ch:?} is not encodable in {font}")]
+    Unencodable {
+        /// The character that failed to encode.
+        ch: char,
+        /// Base font name of the font that rejected it.
+        font: &'static str,
+    },
+    /// Image bytes could not be understood or are inconsistent.
+    #[error("invalid image: {0}")]
+    Image(String),
+    /// Anything else.
+    #[error("{0}")]
+    Other(String),
+}

--- a/crates/pdfboss-write/src/font.rs
+++ b/crates/pdfboss-write/src/font.rs
@@ -2,9 +2,9 @@
 //! encoding and AFM metrics from `pdfboss-encoding`. Text in these faces
 //! needs no embedded font program — every conforming reader carries them.
 
-use pdfboss_core::Dict;
+use pdfboss_core::{Dict, Name, Object};
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 /// One of the fourteen standard fonts every PDF consumer provides.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -60,38 +60,234 @@ impl Standard14 {
 
     /// The PostScript base font name, e.g. `"Helvetica-Bold"`.
     pub fn base_font(self) -> &'static str {
-        todo!("base font of {self:?}")
+        match self {
+            Standard14::Helvetica => "Helvetica",
+            Standard14::HelveticaBold => "Helvetica-Bold",
+            Standard14::HelveticaOblique => "Helvetica-Oblique",
+            Standard14::HelveticaBoldOblique => "Helvetica-BoldOblique",
+            Standard14::TimesRoman => "Times-Roman",
+            Standard14::TimesBold => "Times-Bold",
+            Standard14::TimesItalic => "Times-Italic",
+            Standard14::TimesBoldItalic => "Times-BoldItalic",
+            Standard14::Courier => "Courier",
+            Standard14::CourierBold => "Courier-Bold",
+            Standard14::CourierOblique => "Courier-Oblique",
+            Standard14::CourierBoldOblique => "Courier-BoldOblique",
+            Standard14::Symbol => "Symbol",
+            Standard14::ZapfDingbats => "ZapfDingbats",
+        }
     }
 
-    /// Parses a PostScript base font name back to the variant.
+    /// Parses a PostScript base font name back to the variant. Exact names
+    /// only — aliases and subset-tagged forms are the reading side's
+    /// business, not the writer's.
     pub fn from_base_font(name: &str) -> Option<Standard14> {
-        todo!("from base font {name:?}")
+        Standard14::ALL
+            .into_iter()
+            .find(|font| font.base_font() == name)
+    }
+
+    /// Whether this face encodes text as WinAnsi (the twelve text faces)
+    /// rather than a font-specific built-in encoding.
+    fn is_win_ansi(self) -> bool {
+        !matches!(self, Standard14::Symbol | Standard14::ZapfDingbats)
+    }
+
+    /// The WinAnsi code for `ch`, scanning codes in ascending order so a
+    /// duplicated character would resolve to its lowest code. Symbol and
+    /// ZapfDingbats have no encoding tables yet, so every character is an
+    /// [`Error::Unencodable`] there.
+    fn encode_char(self, ch: char) -> Result<u8> {
+        if !self.is_win_ansi() {
+            return Err(Error::Unencodable {
+                ch,
+                font: self.base_font(),
+            });
+        }
+        (0u8..=255)
+            .find(|&code| pdfboss_encoding::win_ansi(code) == Some(ch))
+            .ok_or(Error::Unencodable {
+                ch,
+                font: self.base_font(),
+            })
     }
 
     /// Encodes text to font code bytes: WinAnsi for the twelve text faces,
     /// the font-specific built-in encoding for Symbol and ZapfDingbats.
     /// A character without a code is an [`Error::Unencodable`]
     /// (crate::Error::Unencodable) — never silently dropped or replaced.
+    /// Symbol and ZapfDingbats currently reject every character: their
+    /// encoding tables come with a later phase.
     pub fn encode(self, text: &str) -> Result<Vec<u8>> {
-        todo!("encode {text:?} for {self:?}")
+        text.chars().map(|ch| self.encode_char(ch)).collect()
     }
 
     /// Advance width of one character in units per 1000 of font size, from
     /// the AFM metrics. `None` when the character has no code or metric.
     pub fn width(self, ch: char) -> Option<f32> {
-        todo!("width of {ch:?} in {self:?}")
+        let code = self.encode_char(ch).ok()?;
+        let glyph = pdfboss_encoding::win_ansi_glyph_name(code)?;
+        pdfboss_encoding::standard_14_width(self.base_font(), glyph)
     }
 
     /// Width of a whole string at `size`, in text-space units. Errors on
-    /// unencodable characters, like [`encode`](Standard14::encode).
+    /// unencodable characters, like [`encode`](Standard14::encode); an
+    /// encodable character whose glyph has no AFM metric is an
+    /// [`Error::Other`] naming the glyph. No kerning — the AFM kern pairs
+    /// are not bundled, so this is the sum of bare advance widths.
     pub fn text_width(self, text: &str, size: f32) -> Result<f32> {
-        todo!("width of {text:?} at {size} in {self:?}")
+        let mut sum = 0.0f32;
+        for ch in text.chars() {
+            let code = self.encode_char(ch)?;
+            let glyph = pdfboss_encoding::win_ansi_glyph_name(code).ok_or_else(|| {
+                Error::Other(format!("code {code:#04x} has no WinAnsi glyph name"))
+            })?;
+            let width =
+                pdfboss_encoding::standard_14_width(self.base_font(), glyph).ok_or_else(|| {
+                    Error::Other(format!(
+                        "{} has no metric for glyph {glyph:?}",
+                        self.base_font()
+                    ))
+                })?;
+            sum += width;
+        }
+        Ok(sum * size / 1000.0)
     }
 
     /// The font dictionary describing this face (`/Type /Font`,
     /// `/Subtype /Type1`, `/BaseFont`, and `/Encoding /WinAnsiEncoding`
     /// for the twelve text faces).
     pub(crate) fn font_dict(self) -> Dict {
-        todo!("font dict for {self:?}")
+        let mut dict = Dict::new();
+        dict.insert(Name("Type".into()), Object::Name(Name("Font".into())));
+        dict.insert(Name("Subtype".into()), Object::Name(Name("Type1".into())));
+        dict.insert(
+            Name("BaseFont".into()),
+            Object::Name(Name(self.base_font().into())),
+        );
+        if self.is_win_ansi() {
+            dict.insert(
+                Name("Encoding".into()),
+                Object::Name(Name("WinAnsiEncoding".into())),
+            );
+        }
+        dict
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pdfboss_encoding::standard_14_width;
+
+    use super::*;
+    use crate::error::Error;
+
+    #[test]
+    fn base_font_round_trips_all_fourteen() {
+        for font in Standard14::ALL {
+            assert_eq!(Standard14::from_base_font(font.base_font()), Some(font));
+        }
+        assert_eq!(Standard14::Helvetica.base_font(), "Helvetica");
+        assert_eq!(
+            Standard14::HelveticaBoldOblique.base_font(),
+            "Helvetica-BoldOblique"
+        );
+        assert_eq!(Standard14::TimesRoman.base_font(), "Times-Roman");
+        assert_eq!(Standard14::TimesBoldItalic.base_font(), "Times-BoldItalic");
+        assert_eq!(Standard14::CourierOblique.base_font(), "Courier-Oblique");
+        assert_eq!(Standard14::Symbol.base_font(), "Symbol");
+        assert_eq!(Standard14::ZapfDingbats.base_font(), "ZapfDingbats");
+        assert_eq!(Standard14::from_base_font("helvetica"), None);
+        assert_eq!(Standard14::from_base_font("Arial"), None);
+        assert_eq!(Standard14::from_base_font(""), None);
+    }
+
+    #[test]
+    fn encode_ascii_and_win_ansi_specials() {
+        assert_eq!(Standard14::Helvetica.encode("Hi").unwrap(), b"Hi");
+        assert_eq!(Standard14::TimesRoman.encode("\u{E9}").unwrap(), [0xE9]);
+        assert_eq!(Standard14::Courier.encode("\u{20AC}").unwrap(), [0x80]);
+        assert_eq!(Standard14::Helvetica.encode("\u{201C}").unwrap(), [0x93]);
+    }
+
+    #[test]
+    fn encode_rejects_unencodable_chars() {
+        match Standard14::HelveticaBold.encode("\u{2318}").unwrap_err() {
+            Error::Unencodable { ch, font } => {
+                assert_eq!(ch, '\u{2318}');
+                assert_eq!(font, "Helvetica-Bold");
+            }
+            other => panic!("expected Unencodable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn symbol_faces_reject_every_char_for_now() {
+        for font in [Standard14::Symbol, Standard14::ZapfDingbats] {
+            assert!(matches!(
+                font.encode("a"),
+                Err(Error::Unencodable { ch: 'a', .. })
+            ));
+            assert_eq!(font.width('a'), None);
+        }
+        assert_eq!(Standard14::Symbol.encode("").unwrap(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn width_matches_direct_afm_lookups() {
+        let font = Standard14::Helvetica;
+        for (ch, glyph) in [('H', "H"), ('e', "e"), ('l', "l"), ('o', "o")] {
+            assert_eq!(font.width(ch), standard_14_width("Helvetica", glyph));
+            assert!(font.width(ch).is_some());
+        }
+        assert_eq!(font.width('\u{2318}'), None); // unencodable
+        assert_eq!(font.width('\u{20AC}'), None); // pre-Euro AFMs carry no metric
+    }
+
+    #[test]
+    fn text_width_scales_by_size() {
+        let font = Standard14::TimesBold;
+        let sum: f32 = "Hello".chars().map(|ch| font.width(ch).unwrap()).sum();
+        assert_eq!(font.text_width("Hello", 12.0).unwrap(), sum * 12.0 / 1000.0);
+        assert_eq!(
+            font.text_width("Hello", 1000.0).unwrap(),
+            font.text_width("Hello", 500.0).unwrap() * 2.0
+        );
+        assert_eq!(font.text_width("", 12.0).unwrap(), 0.0);
+        assert!(matches!(
+            font.text_width("a\u{2318}", 12.0),
+            Err(Error::Unencodable { ch: '\u{2318}', .. })
+        ));
+        assert!(matches!(
+            font.text_width("\u{20AC}", 12.0),
+            Err(Error::Other(msg)) if msg.contains("Euro")
+        ));
+    }
+
+    #[test]
+    fn font_dict_win_ansi_and_symbol() {
+        let dict = Standard14::HelveticaOblique.font_dict();
+        assert_eq!(dict.len(), 4);
+        assert_eq!(dict.get_name("Type").map(|n| n.0.as_str()), Some("Font"));
+        assert_eq!(
+            dict.get_name("Subtype").map(|n| n.0.as_str()),
+            Some("Type1")
+        );
+        assert_eq!(
+            dict.get_name("BaseFont").map(|n| n.0.as_str()),
+            Some("Helvetica-Oblique")
+        );
+        assert_eq!(
+            dict.get_name("Encoding").map(|n| n.0.as_str()),
+            Some("WinAnsiEncoding")
+        );
+
+        let dict = Standard14::Symbol.font_dict();
+        assert_eq!(dict.len(), 3);
+        assert_eq!(
+            dict.get_name("BaseFont").map(|n| n.0.as_str()),
+            Some("Symbol")
+        );
+        assert!(dict.get("Encoding").is_none());
     }
 }

--- a/crates/pdfboss-write/src/font.rs
+++ b/crates/pdfboss-write/src/font.rs
@@ -1,0 +1,97 @@
+//! The fourteen standard fonts (ISO 32000 §9.6.2.2), with WinAnsi text
+//! encoding and AFM metrics from `pdfboss-encoding`. Text in these faces
+//! needs no embedded font program — every conforming reader carries them.
+
+use pdfboss_core::Dict;
+
+use crate::error::Result;
+
+/// One of the fourteen standard fonts every PDF consumer provides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Standard14 {
+    /// Helvetica.
+    Helvetica,
+    /// Helvetica-Bold.
+    HelveticaBold,
+    /// Helvetica-Oblique.
+    HelveticaOblique,
+    /// Helvetica-BoldOblique.
+    HelveticaBoldOblique,
+    /// Times-Roman.
+    TimesRoman,
+    /// Times-Bold.
+    TimesBold,
+    /// Times-Italic.
+    TimesItalic,
+    /// Times-BoldItalic.
+    TimesBoldItalic,
+    /// Courier.
+    Courier,
+    /// Courier-Bold.
+    CourierBold,
+    /// Courier-Oblique.
+    CourierOblique,
+    /// Courier-BoldOblique.
+    CourierBoldOblique,
+    /// Symbol (font-specific encoding).
+    Symbol,
+    /// ZapfDingbats (font-specific encoding).
+    ZapfDingbats,
+}
+
+impl Standard14 {
+    /// All fourteen, in ISO 32000 listing order.
+    pub const ALL: [Standard14; 14] = [
+        Standard14::Helvetica,
+        Standard14::HelveticaBold,
+        Standard14::HelveticaOblique,
+        Standard14::HelveticaBoldOblique,
+        Standard14::TimesRoman,
+        Standard14::TimesBold,
+        Standard14::TimesItalic,
+        Standard14::TimesBoldItalic,
+        Standard14::Courier,
+        Standard14::CourierBold,
+        Standard14::CourierOblique,
+        Standard14::CourierBoldOblique,
+        Standard14::Symbol,
+        Standard14::ZapfDingbats,
+    ];
+
+    /// The PostScript base font name, e.g. `"Helvetica-Bold"`.
+    pub fn base_font(self) -> &'static str {
+        todo!("base font of {self:?}")
+    }
+
+    /// Parses a PostScript base font name back to the variant.
+    pub fn from_base_font(name: &str) -> Option<Standard14> {
+        todo!("from base font {name:?}")
+    }
+
+    /// Encodes text to font code bytes: WinAnsi for the twelve text faces,
+    /// the font-specific built-in encoding for Symbol and ZapfDingbats.
+    /// A character without a code is an [`Error::Unencodable`]
+    /// (crate::Error::Unencodable) — never silently dropped or replaced.
+    pub fn encode(self, text: &str) -> Result<Vec<u8>> {
+        todo!("encode {text:?} for {self:?}")
+    }
+
+    /// Advance width of one character in units per 1000 of font size, from
+    /// the AFM metrics. `None` when the character has no code or metric.
+    pub fn width(self, ch: char) -> Option<f32> {
+        todo!("width of {ch:?} in {self:?}")
+    }
+
+    /// Width of a whole string at `size`, in text-space units. Errors on
+    /// unencodable characters, like [`encode`](Standard14::encode).
+    pub fn text_width(self, text: &str, size: f32) -> Result<f32> {
+        todo!("width of {text:?} at {size} in {self:?}")
+    }
+
+    /// The font dictionary describing this face (`/Type /Font`,
+    /// `/Subtype /Type1`, `/BaseFont`, and `/Encoding /WinAnsiEncoding`
+    /// for the twelve text faces).
+    pub(crate) fn font_dict(self) -> Dict {
+        todo!("font dict for {self:?}")
+    }
+}

--- a/crates/pdfboss-write/src/image.rs
+++ b/crates/pdfboss-write/src/image.rs
@@ -3,9 +3,9 @@
 //! to a raster with its alpha split into an `/SMask`; raw rasters cover
 //! generated content. No encode-side JPX/JBIG2/CCITT — by design.
 
-use pdfboss_core::ObjRef;
+use pdfboss_core::{Dict, Name, ObjRef, Object};
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::writer::Writer;
 
 /// A decoded or passthrough image ready to embed as an image XObject.
@@ -20,10 +20,7 @@ pub struct ImageData {
 #[derive(Debug, Clone, PartialEq)]
 enum ImageKind {
     /// Original JPEG bytes, embedded as-is with `/Filter /DCTDecode`.
-    Jpeg {
-        data: Vec<u8>,
-        gray: bool,
-    },
+    Jpeg { data: Vec<u8>, gray: bool },
     /// Uncompressed raster, Flate-compressed on embedding.
     Raster {
         data: Vec<u8>,
@@ -48,7 +45,63 @@ impl ImageData {
     /// reduced to 8), palette (expanded), and alpha (split to `/SMask`)
     /// are all supported.
     pub fn png(bytes: &[u8]) -> Result<ImageData> {
-        todo!("decode png ({} bytes)", bytes.len())
+        let mut decoder = png::Decoder::new(std::io::Cursor::new(bytes));
+        decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+        let mut reader = decoder
+            .read_info()
+            .map_err(|e| Error::Image(format!("png header: {e}")))?;
+        let size = reader
+            .output_buffer_size()
+            .ok_or_else(|| Error::Image("png output buffer size overflows".into()))?;
+        let mut buf = vec![0u8; size];
+        let info = reader
+            .next_frame(&mut buf)
+            .map_err(|e| Error::Image(format!("png pixel data: {e}")))?;
+        buf.truncate(info.buffer_size());
+        if info.bit_depth != png::BitDepth::Eight {
+            return Err(Error::Image(format!(
+                "png bit depth {:?} survived expansion",
+                info.bit_depth
+            )));
+        }
+        let kind = match info.color_type {
+            png::ColorType::Grayscale => ImageKind::Raster {
+                data: buf,
+                color: RasterColor::Gray8,
+                smask: None,
+            },
+            png::ColorType::GrayscaleAlpha => {
+                let (gray, alpha) = split_alpha(&buf, 1);
+                ImageKind::Raster {
+                    data: gray,
+                    color: RasterColor::Gray8,
+                    smask: Some(alpha),
+                }
+            }
+            png::ColorType::Rgb => ImageKind::Raster {
+                data: buf,
+                color: RasterColor::Rgb8,
+                smask: None,
+            },
+            png::ColorType::Rgba => {
+                let (rgb, alpha) = split_alpha(&buf, 3);
+                ImageKind::Raster {
+                    data: rgb,
+                    color: RasterColor::Rgb8,
+                    smask: Some(alpha),
+                }
+            }
+            other => {
+                return Err(Error::Image(format!(
+                    "png color type {other:?} survived expansion"
+                )));
+            }
+        };
+        Ok(ImageData {
+            width: info.width,
+            height: info.height,
+            kind,
+        })
     }
 
     /// Imports a baseline or progressive JPEG by passthrough. Dimensions
@@ -56,26 +109,92 @@ impl ImageData {
     /// three-component (YCbCr/RGB) images are supported, anything else is
     /// an error.
     pub fn jpeg(bytes: &[u8]) -> Result<ImageData> {
-        todo!("sniff jpeg ({} bytes)", bytes.len())
+        if bytes.len() < 2 || bytes[0] != 0xFF || bytes[1] != 0xD8 {
+            return Err(Error::Image("jpeg missing SOI marker".into()));
+        }
+        let mut pos = 2usize;
+        loop {
+            if pos >= bytes.len() {
+                return Err(Error::Image("jpeg truncated before a SOF marker".into()));
+            }
+            if bytes[pos] != 0xFF {
+                return Err(Error::Image(format!(
+                    "jpeg expected a marker at byte {pos}, found 0x{:02X}",
+                    bytes[pos]
+                )));
+            }
+            while pos < bytes.len() && bytes[pos] == 0xFF {
+                pos += 1;
+            }
+            if pos >= bytes.len() {
+                return Err(Error::Image("jpeg truncated inside a marker".into()));
+            }
+            let marker = bytes[pos];
+            pos += 1;
+            match marker {
+                0xC0..=0xC2 => return sniff_sof(bytes, pos),
+                0xC3 | 0xC5..=0xC7 | 0xC9..=0xCB | 0xCD..=0xCF => {
+                    return Err(Error::Image(format!(
+                        "jpeg SOF{} (marker 0xFF{marker:02X}) is not supported for passthrough",
+                        marker as usize - 0xC0
+                    )));
+                }
+                0xD9 => return Err(Error::Image("jpeg ended (EOI) before a SOF marker".into())),
+                0xDA => {
+                    return Err(Error::Image("jpeg scan started before a SOF marker".into()));
+                }
+                0x00 => return Err(Error::Image("jpeg stray 0xFF00 outside a scan".into())),
+                0x01 | 0xD0..=0xD7 => {}
+                other => pos = skip_segment(bytes, pos, other)?,
+            }
+        }
     }
 
     /// Wraps an 8-bit grayscale raster; `data` is `width * height` bytes.
     pub fn gray8(width: u32, height: u32, data: Vec<u8>) -> Result<ImageData> {
-        let unused = (width, height, data);
-        todo!("gray8 raster: {unused:?}")
+        let expected = checked_dims("gray8", width, height)?;
+        check_len("gray8", expected, data.len())?;
+        Ok(ImageData {
+            width,
+            height,
+            kind: ImageKind::Raster {
+                data,
+                color: RasterColor::Gray8,
+                smask: None,
+            },
+        })
     }
 
     /// Wraps an 8-bit RGB raster; `data` is `width * height * 3` bytes.
     pub fn rgb8(width: u32, height: u32, data: Vec<u8>) -> Result<ImageData> {
-        let unused = (width, height, data);
-        todo!("rgb8 raster: {unused:?}")
+        let expected = checked_dims("rgb8", width, height)? * 3;
+        check_len("rgb8", expected, data.len())?;
+        Ok(ImageData {
+            width,
+            height,
+            kind: ImageKind::Raster {
+                data,
+                color: RasterColor::Rgb8,
+                smask: None,
+            },
+        })
     }
 
     /// Wraps a 1-bit raster; rows are packed MSB-first, each row padded to
     /// a whole byte. A set bit is black (sample 0).
     pub fn mono(width: u32, height: u32, data: Vec<u8>) -> Result<ImageData> {
-        let unused = (width, height, data);
-        todo!("mono raster: {unused:?}")
+        checked_dims("mono", width, height)?;
+        let expected = (width as usize).div_ceil(8) * height as usize;
+        check_len("mono", expected, data.len())?;
+        Ok(ImageData {
+            width,
+            height,
+            kind: ImageKind::Raster {
+                data,
+                color: RasterColor::Mono1,
+                smask: None,
+            },
+        })
     }
 
     /// Pixel width.
@@ -89,9 +208,662 @@ impl ImageData {
     }
 
     /// Emits this image (and its soft mask, if any) into `w` as image
-    /// XObject(s), returning the image object's reference.
+    /// XObject(s), returning the image object's reference. The soft mask
+    /// is put first, so its object number precedes the image's.
     pub(crate) fn build_xobject(&self, w: &mut Writer) -> ObjRef {
-        let unused = (self, w);
-        todo!("build xobject: {unused:?}")
+        match &self.kind {
+            ImageKind::Jpeg { data, gray } => {
+                let mut dict = self.base_dict();
+                dict.insert(name("Filter"), Object::Name(name("DCTDecode")));
+                dict.insert(name("BitsPerComponent"), Object::Int(8));
+                dict.insert(name("ColorSpace"), Object::Name(gray_or_rgb(*gray)));
+                w.put_stream_raw(dict, data.clone())
+            }
+            ImageKind::Raster { data, color, smask } => {
+                let mask_ref = smask.as_ref().map(|alpha| {
+                    let mut mask = self.base_dict();
+                    mask.insert(name("BitsPerComponent"), Object::Int(8));
+                    mask.insert(name("ColorSpace"), Object::Name(name("DeviceGray")));
+                    w.put_stream(mask, alpha.clone())
+                });
+                let mut dict = self.base_dict();
+                match color {
+                    RasterColor::Gray8 => {
+                        dict.insert(name("BitsPerComponent"), Object::Int(8));
+                        dict.insert(name("ColorSpace"), Object::Name(name("DeviceGray")));
+                    }
+                    RasterColor::Rgb8 => {
+                        dict.insert(name("BitsPerComponent"), Object::Int(8));
+                        dict.insert(name("ColorSpace"), Object::Name(name("DeviceRGB")));
+                    }
+                    RasterColor::Mono1 => {
+                        dict.insert(name("BitsPerComponent"), Object::Int(1));
+                        dict.insert(name("ColorSpace"), Object::Name(name("DeviceGray")));
+                        dict.insert(
+                            name("Decode"),
+                            Object::Array(vec![Object::Int(1), Object::Int(0)]),
+                        );
+                    }
+                }
+                if let Some(mask_ref) = mask_ref {
+                    dict.insert(name("SMask"), Object::Ref(mask_ref));
+                }
+                w.put_stream(dict, data.clone())
+            }
+        }
+    }
+
+    /// The dictionary entries every image XObject shares.
+    fn base_dict(&self) -> Dict {
+        let mut dict = Dict::new();
+        dict.insert(name("Type"), Object::Name(name("XObject")));
+        dict.insert(name("Subtype"), Object::Name(name("Image")));
+        dict.insert(name("Width"), Object::Int(i64::from(self.width)));
+        dict.insert(name("Height"), Object::Int(i64::from(self.height)));
+        dict
+    }
+}
+
+/// A `Name` from a string literal.
+fn name(text: &str) -> Name {
+    Name(text.to_string())
+}
+
+/// The device color space name for a one- or three-component image.
+fn gray_or_rgb(gray: bool) -> Name {
+    if gray {
+        name("DeviceGray")
+    } else {
+        name("DeviceRGB")
+    }
+}
+
+fn split_alpha(samples: &[u8], color_channels: usize) -> (Vec<u8>, Vec<u8>) {
+    let pixels = samples.len() / (color_channels + 1);
+    let mut color: Vec<u8> = Vec::with_capacity(pixels * color_channels);
+    let mut alpha: Vec<u8> = Vec::with_capacity(pixels);
+    for px in samples.chunks_exact(color_channels + 1) {
+        color.extend_from_slice(&px[..color_channels]);
+        alpha.push(px[color_channels]);
+    }
+    (color, alpha)
+}
+
+fn sniff_sof(bytes: &[u8], pos: usize) -> Result<ImageData> {
+    if pos + 8 > bytes.len() {
+        return Err(Error::Image("jpeg truncated inside its SOF marker".into()));
+    }
+    let precision = bytes[pos + 2];
+    if precision != 8 {
+        return Err(Error::Image(format!(
+            "jpeg sample precision is {precision}, only 8 is supported"
+        )));
+    }
+    let height = u32::from(u16::from_be_bytes([bytes[pos + 3], bytes[pos + 4]]));
+    let width = u32::from(u16::from_be_bytes([bytes[pos + 5], bytes[pos + 6]]));
+    let gray = match bytes[pos + 7] {
+        1 => true,
+        3 => false,
+        n => {
+            return Err(Error::Image(format!(
+                "jpeg has {n} components, only 1 or 3 are supported"
+            )));
+        }
+    };
+    Ok(ImageData {
+        width,
+        height,
+        kind: ImageKind::Jpeg {
+            data: bytes.to_vec(),
+            gray,
+        },
+    })
+}
+
+fn skip_segment(bytes: &[u8], pos: usize, marker: u8) -> Result<usize> {
+    if pos + 2 > bytes.len() {
+        return Err(Error::Image(format!(
+            "jpeg truncated in the length of marker 0xFF{marker:02X}"
+        )));
+    }
+    let len = usize::from(u16::from_be_bytes([bytes[pos], bytes[pos + 1]]));
+    if len < 2 {
+        return Err(Error::Image(format!(
+            "jpeg marker 0xFF{marker:02X} has segment length {len}, minimum is 2"
+        )));
+    }
+    if pos + len > bytes.len() {
+        return Err(Error::Image(format!(
+            "jpeg truncated inside the segment of marker 0xFF{marker:02X}"
+        )));
+    }
+    Ok(pos + len)
+}
+
+fn checked_dims(label: &str, width: u32, height: u32) -> Result<usize> {
+    if width == 0 || height == 0 {
+        return Err(Error::Image(format!(
+            "{label} raster: dimensions {width}x{height} must be nonzero"
+        )));
+    }
+    Ok(width as usize * height as usize)
+}
+
+fn check_len(label: &str, expected: usize, got: usize) -> Result<()> {
+    if got != expected {
+        return Err(Error::Image(format!(
+            "{label} raster: expected {expected} bytes, got {got}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ImageData, ImageKind, RasterColor};
+    use crate::error::Error;
+    use std::io::Write;
+
+    fn encode_png(
+        width: u32,
+        height: u32,
+        color: png::ColorType,
+        depth: png::BitDepth,
+        palette: Option<&[u8]>,
+        data: &[u8],
+    ) -> Vec<u8> {
+        let mut out: Vec<u8> = Vec::new();
+        let mut enc = png::Encoder::new(&mut out, width, height);
+        enc.set_color(color);
+        enc.set_depth(depth);
+        if let Some(p) = palette {
+            enc.set_palette(p.to_vec());
+        }
+        let mut writer = enc.write_header().unwrap();
+        writer.write_image_data(data).unwrap();
+        writer.finish().unwrap();
+        out
+    }
+
+    fn png_chunk(name: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut chunk: Vec<u8> = Vec::new();
+        chunk.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        chunk.extend_from_slice(name);
+        chunk.extend_from_slice(payload);
+        let mut crc = flate2::Crc::new();
+        crc.update(name);
+        crc.update(payload);
+        chunk.extend_from_slice(&crc.sum().to_be_bytes());
+        chunk
+    }
+
+    fn interlaced_gray_2x2(pixels: [u8; 4]) -> Vec<u8> {
+        let [p00, p10, p01, p11] = pixels;
+        let mut ihdr: Vec<u8> = Vec::new();
+        ihdr.extend_from_slice(&2u32.to_be_bytes());
+        ihdr.extend_from_slice(&2u32.to_be_bytes());
+        ihdr.extend_from_slice(&[8, 0, 0, 0, 1]);
+        let raw: [u8; 7] = [0, p00, 0, p10, 0, p01, p11];
+        let mut zlib = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        zlib.write_all(&raw).unwrap();
+        let idat = zlib.finish().unwrap();
+        let mut file: Vec<u8> = vec![137, 80, 78, 71, 13, 10, 26, 10];
+        file.extend_from_slice(&png_chunk(b"IHDR", &ihdr));
+        file.extend_from_slice(&png_chunk(b"IDAT", &idat));
+        file.extend_from_slice(&png_chunk(b"IEND", &[]));
+        file
+    }
+
+    fn raster(img: &ImageData) -> (&[u8], RasterColor, Option<&[u8]>) {
+        match &img.kind {
+            ImageKind::Raster { data, color, smask } => (data, *color, smask.as_deref()),
+            ImageKind::Jpeg { .. } => panic!("expected raster, got jpeg"),
+        }
+    }
+
+    fn image_message(result: crate::error::Result<ImageData>) -> String {
+        match result {
+            Err(Error::Image(msg)) => msg,
+            other => panic!("expected Error::Image, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn png_rgb() {
+        let data: [u8; 12] = [255, 0, 0, 0, 255, 0, 0, 0, 255, 9, 8, 7];
+        let bytes = encode_png(2, 2, png::ColorType::Rgb, png::BitDepth::Eight, None, &data);
+        let img = ImageData::png(&bytes).unwrap();
+        assert_eq!((img.width(), img.height()), (2, 2));
+        let (pixels, color, smask) = raster(&img);
+        assert_eq!(color, RasterColor::Rgb8);
+        assert_eq!(pixels, data);
+        assert!(smask.is_none());
+    }
+
+    #[test]
+    fn png_rgba_splits_smask() {
+        let data: [u8; 16] = [1, 2, 3, 128, 4, 5, 6, 255, 7, 8, 9, 0, 10, 11, 12, 64];
+        let bytes = encode_png(
+            2,
+            2,
+            png::ColorType::Rgba,
+            png::BitDepth::Eight,
+            None,
+            &data,
+        );
+        let img = ImageData::png(&bytes).unwrap();
+        assert_eq!((img.width(), img.height()), (2, 2));
+        let (pixels, color, smask) = raster(&img);
+        assert_eq!(color, RasterColor::Rgb8);
+        assert_eq!(pixels, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+        assert_eq!(smask, Some([128, 255, 0, 64].as_slice()));
+    }
+
+    #[test]
+    fn png_gray() {
+        let data: [u8; 6] = [0, 60, 120, 180, 220, 255];
+        let bytes = encode_png(
+            3,
+            2,
+            png::ColorType::Grayscale,
+            png::BitDepth::Eight,
+            None,
+            &data,
+        );
+        let img = ImageData::png(&bytes).unwrap();
+        assert_eq!((img.width(), img.height()), (3, 2));
+        let (pixels, color, smask) = raster(&img);
+        assert_eq!(color, RasterColor::Gray8);
+        assert_eq!(pixels, data);
+        assert!(smask.is_none());
+    }
+
+    #[test]
+    fn png_gray_alpha_splits_smask() {
+        let data: [u8; 4] = [50, 200, 100, 30];
+        let bytes = encode_png(
+            2,
+            1,
+            png::ColorType::GrayscaleAlpha,
+            png::BitDepth::Eight,
+            None,
+            &data,
+        );
+        let img = ImageData::png(&bytes).unwrap();
+        assert_eq!((img.width(), img.height()), (2, 1));
+        let (pixels, color, smask) = raster(&img);
+        assert_eq!(color, RasterColor::Gray8);
+        assert_eq!(pixels, [50, 100]);
+        assert_eq!(smask, Some([200, 30].as_slice()));
+    }
+
+    #[test]
+    fn png_palette_expands_to_rgb() {
+        let palette: [u8; 6] = [255, 0, 0, 0, 255, 0];
+        let bytes = encode_png(
+            2,
+            1,
+            png::ColorType::Indexed,
+            png::BitDepth::Eight,
+            Some(&palette),
+            &[0, 1],
+        );
+        let img = ImageData::png(&bytes).unwrap();
+        assert_eq!((img.width(), img.height()), (2, 1));
+        let (pixels, color, smask) = raster(&img);
+        assert_eq!(color, RasterColor::Rgb8);
+        assert_eq!(pixels, [255, 0, 0, 0, 255, 0]);
+        assert!(smask.is_none());
+    }
+
+    #[test]
+    fn png_sixteen_bit_reduces_to_eight() {
+        let data: [u8; 12] = [
+            0xAB, 0xCD, 0x12, 0x34, 0xFF, 0xFF, 0x00, 0x01, 0x80, 0x00, 0x7F, 0xFE,
+        ];
+        let bytes = encode_png(
+            2,
+            1,
+            png::ColorType::Rgb,
+            png::BitDepth::Sixteen,
+            None,
+            &data,
+        );
+        let img = ImageData::png(&bytes).unwrap();
+        assert_eq!((img.width(), img.height()), (2, 1));
+        let (pixels, color, smask) = raster(&img);
+        assert_eq!(color, RasterColor::Rgb8);
+        assert_eq!(pixels, [0xAB, 0x12, 0xFF, 0x00, 0x80, 0x7F]);
+        assert!(smask.is_none());
+    }
+
+    #[test]
+    fn png_interlaced_deinterlaces() {
+        let bytes = interlaced_gray_2x2([10, 20, 30, 40]);
+        let img = ImageData::png(&bytes).unwrap();
+        assert_eq!((img.width(), img.height()), (2, 2));
+        let (pixels, color, smask) = raster(&img);
+        assert_eq!(color, RasterColor::Gray8);
+        assert_eq!(pixels, [10, 20, 30, 40]);
+        assert!(smask.is_none());
+    }
+
+    #[test]
+    fn png_garbage_is_image_error() {
+        let msg = image_message(ImageData::png(&[1, 2, 3, 4, 5, 6, 7, 8]));
+        assert!(!msg.is_empty());
+    }
+
+    fn jpeg_sof(marker: u8, precision: u8, width: u16, height: u16, components: u8) -> Vec<u8> {
+        let mut seg: Vec<u8> = vec![0xFF, marker];
+        seg.extend_from_slice(&(8 + 3 * components as u16).to_be_bytes());
+        seg.push(precision);
+        seg.extend_from_slice(&height.to_be_bytes());
+        seg.extend_from_slice(&width.to_be_bytes());
+        seg.push(components);
+        for id in 0..components {
+            seg.extend_from_slice(&[id + 1, 0x11, 0]);
+        }
+        seg
+    }
+
+    fn jpeg_app1() -> Vec<u8> {
+        let payload = b"pdfboss-write";
+        let mut seg: Vec<u8> = vec![0xFF, 0xE1];
+        seg.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+        seg.extend_from_slice(payload);
+        seg
+    }
+
+    fn jpeg_bytes(segments: &[Vec<u8>]) -> Vec<u8> {
+        let mut out: Vec<u8> = vec![0xFF, 0xD8];
+        for seg in segments {
+            out.extend_from_slice(seg);
+        }
+        out.extend_from_slice(&[0xFF, 0xD9]);
+        out
+    }
+
+    #[test]
+    fn jpeg_color_baseline() {
+        let bytes = jpeg_bytes(&[jpeg_app1(), jpeg_sof(0xC0, 8, 5, 7, 3)]);
+        let img = ImageData::jpeg(&bytes).unwrap();
+        assert_eq!((img.width(), img.height()), (5, 7));
+        match &img.kind {
+            ImageKind::Jpeg { data, gray } => {
+                assert_eq!(data, &bytes);
+                assert!(!gray);
+            }
+            ImageKind::Raster { .. } => panic!("expected jpeg passthrough"),
+        }
+    }
+
+    #[test]
+    fn jpeg_gray_with_fill_bytes() {
+        let mut sof = jpeg_sof(0xC1, 8, 9, 4, 1);
+        sof.insert(0, 0xFF);
+        let bytes = jpeg_bytes(&[jpeg_app1(), sof]);
+        let img = ImageData::jpeg(&bytes).unwrap();
+        assert_eq!((img.width(), img.height()), (9, 4));
+        match &img.kind {
+            ImageKind::Jpeg { data, gray } => {
+                assert_eq!(data, &bytes);
+                assert!(gray);
+            }
+            ImageKind::Raster { .. } => panic!("expected jpeg passthrough"),
+        }
+    }
+
+    #[test]
+    fn jpeg_progressive_sof2() {
+        let bytes = jpeg_bytes(&[jpeg_sof(0xC2, 8, 640, 480, 3)]);
+        let img = ImageData::jpeg(&bytes).unwrap();
+        assert_eq!((img.width(), img.height()), (640, 480));
+    }
+
+    #[test]
+    fn jpeg_four_components_rejected_naming_count() {
+        let bytes = jpeg_bytes(&[jpeg_sof(0xC0, 8, 4, 4, 4)]);
+        let msg = image_message(ImageData::jpeg(&bytes));
+        assert!(msg.contains('4'), "message should name the count: {msg}");
+    }
+
+    #[test]
+    fn jpeg_lossless_sof3_rejected() {
+        let bytes = jpeg_bytes(&[jpeg_sof(0xC3, 8, 4, 4, 1)]);
+        image_message(ImageData::jpeg(&bytes));
+    }
+
+    #[test]
+    fn jpeg_truncated_rejected() {
+        let full = jpeg_bytes(&[jpeg_app1(), jpeg_sof(0xC0, 8, 5, 7, 3)]);
+        image_message(ImageData::jpeg(&full[..6]));
+    }
+
+    #[test]
+    fn jpeg_missing_soi_rejected() {
+        image_message(ImageData::jpeg(&[0x00, 0x11, 0x22]));
+    }
+
+    #[test]
+    fn jpeg_non_eight_bit_precision_rejected() {
+        let bytes = jpeg_bytes(&[jpeg_sof(0xC1, 12, 4, 4, 1)]);
+        let msg = image_message(ImageData::jpeg(&bytes));
+        assert!(
+            msg.contains("12"),
+            "message should name the precision: {msg}"
+        );
+    }
+
+    #[test]
+    fn gray8_accepts_exact_length() {
+        let img = ImageData::gray8(2, 3, vec![1, 2, 3, 4, 5, 6]).unwrap();
+        assert_eq!((img.width(), img.height()), (2, 3));
+        let (pixels, color, smask) = raster(&img);
+        assert_eq!(color, RasterColor::Gray8);
+        assert_eq!(pixels, [1, 2, 3, 4, 5, 6]);
+        assert!(smask.is_none());
+    }
+
+    #[test]
+    fn gray8_wrong_length_names_expected_and_got() {
+        let msg = image_message(ImageData::gray8(2, 3, vec![0; 5]));
+        assert!(msg.contains('6') && msg.contains('5'), "{msg}");
+    }
+
+    #[test]
+    fn rgb8_accepts_exact_length() {
+        let img = ImageData::rgb8(2, 1, vec![9, 8, 7, 6, 5, 4]).unwrap();
+        assert_eq!((img.width(), img.height()), (2, 1));
+        let (pixels, color, smask) = raster(&img);
+        assert_eq!(color, RasterColor::Rgb8);
+        assert_eq!(pixels, [9, 8, 7, 6, 5, 4]);
+        assert!(smask.is_none());
+    }
+
+    #[test]
+    fn rgb8_wrong_length_names_expected_and_got() {
+        let msg = image_message(ImageData::rgb8(2, 1, vec![0; 7]));
+        assert!(msg.contains('6') && msg.contains('7'), "{msg}");
+    }
+
+    #[test]
+    fn mono_accepts_row_padded_length() {
+        let img = ImageData::mono(10, 3, vec![0; 6]).unwrap();
+        assert_eq!((img.width(), img.height()), (10, 3));
+        let (pixels, color, smask) = raster(&img);
+        assert_eq!(color, RasterColor::Mono1);
+        assert_eq!(pixels, [0; 6]);
+        assert!(smask.is_none());
+    }
+
+    #[test]
+    fn mono_wrong_length_names_expected_and_got() {
+        let msg = image_message(ImageData::mono(10, 3, vec![0; 4]));
+        assert!(msg.contains('6') && msg.contains('4'), "{msg}");
+    }
+
+    #[test]
+    fn zero_dimensions_rejected() {
+        image_message(ImageData::gray8(0, 3, vec![]));
+        image_message(ImageData::rgb8(3, 0, vec![]));
+        image_message(ImageData::mono(0, 0, vec![]));
+    }
+
+    use pdfboss_core::{Dict, Document, Name, ObjRef, Object, Stream};
+
+    use crate::writer::{WriteOptions, Writer, XrefStyle};
+
+    fn name(text: &str) -> Name {
+        Name(text.into())
+    }
+
+    fn document_with_xobject(img: &ImageData, compress: bool) -> (Document, ObjRef) {
+        let mut w = Writer::new(WriteOptions {
+            xref: XrefStyle::Table,
+            compress,
+            object_streams: false,
+            version: (1, 7),
+        });
+        let image_ref = img.build_xobject(&mut w);
+        let content = w.put_stream(Dict::new(), b"q Q\n".to_vec());
+        let pages = w.reserve();
+        let mut page = Dict::new();
+        page.insert(name("Type"), Object::Name(name("Page")));
+        page.insert(name("Parent"), Object::Ref(pages));
+        page.insert(
+            name("MediaBox"),
+            Object::Array(vec![
+                Object::Int(0),
+                Object::Int(0),
+                Object::Int(100),
+                Object::Int(100),
+            ]),
+        );
+        page.insert(name("Contents"), Object::Ref(content));
+        let page_ref = w.put(Object::Dict(page));
+        let mut tree = Dict::new();
+        tree.insert(name("Type"), Object::Name(name("Pages")));
+        tree.insert(name("Kids"), Object::Array(vec![Object::Ref(page_ref)]));
+        tree.insert(name("Count"), Object::Int(1));
+        w.fill(pages, Object::Dict(tree)).unwrap();
+        let mut catalog = Dict::new();
+        catalog.insert(name("Type"), Object::Name(name("Catalog")));
+        catalog.insert(name("Pages"), Object::Ref(pages));
+        let root = w.put(Object::Dict(catalog));
+        let doc = Document::load(w.finish(root).unwrap()).unwrap();
+        (doc, image_ref)
+    }
+
+    fn xobject_stream(doc: &Document, r: ObjRef) -> Stream {
+        doc.resolve(&Object::Ref(r))
+            .unwrap()
+            .as_stream()
+            .unwrap()
+            .clone()
+    }
+
+    #[test]
+    fn xobject_jpeg_gray_passes_through_raw() {
+        let bytes = jpeg_bytes(&[jpeg_sof(0xC0, 8, 9, 4, 1)]);
+        let img = ImageData::jpeg(&bytes).unwrap();
+        let (doc, image_ref) = document_with_xobject(&img, true);
+        let stream = xobject_stream(&doc, image_ref);
+        assert_eq!(stream.dict.get_name("Type"), Some(&name("XObject")));
+        assert_eq!(stream.dict.get_name("Subtype"), Some(&name("Image")));
+        assert_eq!(stream.dict.get_int("Width"), Some(9));
+        assert_eq!(stream.dict.get_int("Height"), Some(4));
+        assert_eq!(stream.dict.get_name("Filter"), Some(&name("DCTDecode")));
+        assert_eq!(stream.dict.get_int("BitsPerComponent"), Some(8));
+        assert_eq!(
+            stream.dict.get_name("ColorSpace"),
+            Some(&name("DeviceGray"))
+        );
+        assert_eq!(stream.data, bytes);
+    }
+
+    #[test]
+    fn xobject_jpeg_color_uses_device_rgb() {
+        let bytes = jpeg_bytes(&[jpeg_sof(0xC0, 8, 5, 7, 3)]);
+        let img = ImageData::jpeg(&bytes).unwrap();
+        let (doc, image_ref) = document_with_xobject(&img, true);
+        let stream = xobject_stream(&doc, image_ref);
+        assert_eq!(stream.dict.get_int("Width"), Some(5));
+        assert_eq!(stream.dict.get_int("Height"), Some(7));
+        assert_eq!(stream.dict.get_name("Filter"), Some(&name("DCTDecode")));
+        assert_eq!(stream.dict.get_name("ColorSpace"), Some(&name("DeviceRGB")));
+        assert_eq!(stream.data, bytes);
+    }
+
+    #[test]
+    fn xobject_rgb_raster_flate_round_trips() {
+        let pixels = vec![255, 0, 0, 0, 255, 0, 0, 0, 255, 9, 8, 7];
+        let img = ImageData::rgb8(2, 2, pixels.clone()).unwrap();
+        let (doc, image_ref) = document_with_xobject(&img, true);
+        let stream = xobject_stream(&doc, image_ref);
+        assert_eq!(stream.dict.get_name("Type"), Some(&name("XObject")));
+        assert_eq!(stream.dict.get_name("Subtype"), Some(&name("Image")));
+        assert_eq!(stream.dict.get_int("Width"), Some(2));
+        assert_eq!(stream.dict.get_int("Height"), Some(2));
+        assert_eq!(stream.dict.get_name("Filter"), Some(&name("FlateDecode")));
+        assert_eq!(stream.dict.get_int("BitsPerComponent"), Some(8));
+        assert_eq!(stream.dict.get_name("ColorSpace"), Some(&name("DeviceRGB")));
+        assert!(stream.dict.get("SMask").is_none());
+        assert!(stream.dict.get("Decode").is_none());
+        assert_eq!(doc.stream_data(&stream).unwrap(), pixels);
+    }
+
+    #[test]
+    fn xobject_smask_is_emitted_first_as_gray8() {
+        let data: [u8; 16] = [1, 2, 3, 128, 4, 5, 6, 255, 7, 8, 9, 0, 10, 11, 12, 64];
+        let bytes = encode_png(
+            2,
+            2,
+            png::ColorType::Rgba,
+            png::BitDepth::Eight,
+            None,
+            &data,
+        );
+        let img = ImageData::png(&bytes).unwrap();
+        let (doc, image_ref) = document_with_xobject(&img, false);
+        assert_eq!(
+            image_ref.num, 2,
+            "the soft mask must claim the number first"
+        );
+        let stream = xobject_stream(&doc, image_ref);
+        let mask_ref = stream.dict.get_ref("SMask").expect("SMask reference");
+        assert_eq!(mask_ref.num, image_ref.num - 1);
+        let mask = xobject_stream(&doc, mask_ref);
+        assert_eq!(mask.dict.get_name("Type"), Some(&name("XObject")));
+        assert_eq!(mask.dict.get_name("Subtype"), Some(&name("Image")));
+        assert_eq!(mask.dict.get_int("Width"), Some(2));
+        assert_eq!(mask.dict.get_int("Height"), Some(2));
+        assert_eq!(mask.dict.get_int("BitsPerComponent"), Some(8));
+        assert_eq!(mask.dict.get_name("ColorSpace"), Some(&name("DeviceGray")));
+        assert_eq!(doc.stream_data(&mask).unwrap(), [128, 255, 0, 64]);
+        assert_eq!(
+            doc.stream_data(&stream).unwrap(),
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        );
+    }
+
+    #[test]
+    fn xobject_mono1_adds_inverted_decode() {
+        let rows = vec![0b1010_1010u8; 6];
+        let img = ImageData::mono(10, 3, rows.clone()).unwrap();
+        let (doc, image_ref) = document_with_xobject(&img, false);
+        let stream = xobject_stream(&doc, image_ref);
+        assert_eq!(stream.dict.get_int("Width"), Some(10));
+        assert_eq!(stream.dict.get_int("Height"), Some(3));
+        assert_eq!(stream.dict.get_int("BitsPerComponent"), Some(1));
+        assert_eq!(
+            stream.dict.get_name("ColorSpace"),
+            Some(&name("DeviceGray"))
+        );
+        assert_eq!(
+            stream.dict.get_array("Decode"),
+            Some([Object::Int(1), Object::Int(0)].as_slice())
+        );
+        assert_eq!(doc.stream_data(&stream).unwrap(), rows);
     }
 }

--- a/crates/pdfboss-write/src/image.rs
+++ b/crates/pdfboss-write/src/image.rs
@@ -1,0 +1,97 @@
+//! Image import for document creation. JPEG passes through untouched as
+//! `/DCTDecode` (dimensions sniffed from its SOF marker); PNG is decoded
+//! to a raster with its alpha split into an `/SMask`; raw rasters cover
+//! generated content. No encode-side JPX/JBIG2/CCITT — by design.
+
+use pdfboss_core::ObjRef;
+
+use crate::error::Result;
+use crate::writer::Writer;
+
+/// A decoded or passthrough image ready to embed as an image XObject.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImageData {
+    width: u32,
+    height: u32,
+    kind: ImageKind,
+}
+
+/// How the pixels are held.
+#[derive(Debug, Clone, PartialEq)]
+enum ImageKind {
+    /// Original JPEG bytes, embedded as-is with `/Filter /DCTDecode`.
+    Jpeg {
+        data: Vec<u8>,
+        gray: bool,
+    },
+    /// Uncompressed raster, Flate-compressed on embedding.
+    Raster {
+        data: Vec<u8>,
+        color: RasterColor,
+        smask: Option<Vec<u8>>,
+    },
+}
+
+/// Raster sample layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RasterColor {
+    /// 8-bit DeviceGray.
+    Gray8,
+    /// 8-bit DeviceRGB, samples interleaved.
+    Rgb8,
+    /// 1-bit DeviceGray, rows packed MSB-first and byte-padded.
+    Mono1,
+}
+
+impl ImageData {
+    /// Imports a PNG. Truecolor and grayscale (8- and 16-bit, the latter
+    /// reduced to 8), palette (expanded), and alpha (split to `/SMask`)
+    /// are all supported.
+    pub fn png(bytes: &[u8]) -> Result<ImageData> {
+        todo!("decode png ({} bytes)", bytes.len())
+    }
+
+    /// Imports a baseline or progressive JPEG by passthrough. Dimensions
+    /// and component count are read from the SOF marker; grayscale and
+    /// three-component (YCbCr/RGB) images are supported, anything else is
+    /// an error.
+    pub fn jpeg(bytes: &[u8]) -> Result<ImageData> {
+        todo!("sniff jpeg ({} bytes)", bytes.len())
+    }
+
+    /// Wraps an 8-bit grayscale raster; `data` is `width * height` bytes.
+    pub fn gray8(width: u32, height: u32, data: Vec<u8>) -> Result<ImageData> {
+        let unused = (width, height, data);
+        todo!("gray8 raster: {unused:?}")
+    }
+
+    /// Wraps an 8-bit RGB raster; `data` is `width * height * 3` bytes.
+    pub fn rgb8(width: u32, height: u32, data: Vec<u8>) -> Result<ImageData> {
+        let unused = (width, height, data);
+        todo!("rgb8 raster: {unused:?}")
+    }
+
+    /// Wraps a 1-bit raster; rows are packed MSB-first, each row padded to
+    /// a whole byte. A set bit is black (sample 0).
+    pub fn mono(width: u32, height: u32, data: Vec<u8>) -> Result<ImageData> {
+        let unused = (width, height, data);
+        todo!("mono raster: {unused:?}")
+    }
+
+    /// Pixel width.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Pixel height.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Emits this image (and its soft mask, if any) into `w` as image
+    /// XObject(s), returning the image object's reference.
+    pub(crate) fn build_xobject(&self, w: &mut Writer) -> ObjRef {
+        let unused = (self, w);
+        todo!("build xobject: {unused:?}")
+    }
+}

--- a/crates/pdfboss-write/src/image.rs
+++ b/crates/pdfboss-write/src/image.rs
@@ -301,6 +301,11 @@ fn sniff_sof(bytes: &[u8], pos: usize) -> Result<ImageData> {
     }
     let height = u32::from(u16::from_be_bytes([bytes[pos + 3], bytes[pos + 4]]));
     let width = u32::from(u16::from_be_bytes([bytes[pos + 5], bytes[pos + 6]]));
+    if width == 0 || height == 0 {
+        return Err(Error::Image(format!(
+            "jpeg declares degenerate dimensions {width}x{height}"
+        )));
+    }
     let gray = match bytes[pos + 7] {
         1 => true,
         3 => false,
@@ -865,5 +870,14 @@ mod tests {
             Some([Object::Int(1), Object::Int(0)].as_slice())
         );
         assert_eq!(doc.stream_data(&stream).unwrap(), rows);
+    }
+
+    #[test]
+    fn jpeg_rejects_degenerate_dimensions() {
+        for (width, height) in [(0u16, 8u16), (8, 0), (0, 0)] {
+            let bytes = jpeg_bytes(&[jpeg_sof(0xC0, 8, width, height, 3)]);
+            let msg = image_message(ImageData::jpeg(&bytes));
+            assert!(msg.contains("degenerate"), "{width}x{height}: {msg}");
+        }
     }
 }

--- a/crates/pdfboss-write/src/lib.rs
+++ b/crates/pdfboss-write/src/lib.rs
@@ -24,6 +24,7 @@ pub mod font;
 pub mod image;
 pub mod pdf;
 pub mod ser;
+pub mod sink;
 pub mod writer;
 
 pub use canvas::{Canvas, CanvasParts, ImageHandle, LineCap, LineJoin};
@@ -33,4 +34,5 @@ pub use error::{Error, Result};
 pub use font::Standard14;
 pub use image::ImageData;
 pub use pdf::{Date, Metadata, Page, PageSize, Pdf};
+pub use sink::{AsyncByteSink, Immediate};
 pub use writer::{WriteOptions, Writer, XrefStyle};

--- a/crates/pdfboss-write/src/lib.rs
+++ b/crates/pdfboss-write/src/lib.rs
@@ -1,0 +1,36 @@
+//! PDF creation for pdfboss: the write-side twin of `pdfboss-core`.
+//!
+//! Three altitudes, each complete on its own and lowering into the one
+//! beneath:
+//!
+//! - **document** — [`Pdf`] and [`Page`]: plain structs whose fields are
+//!   the composition, saved with [`Pdf::save`].
+//! - **canvas** — [`Canvas`]: an imperative painter accumulating
+//!   `pdfboss_core::content::Op`, the same IR the reader parses, so every
+//!   generated content stream round-trips through `parse_content`.
+//! - **cos** — [`Writer`]: numbered objects in, finished file bytes out,
+//!   with stream compression, object streams, both cross-reference styles
+//!   and a deterministic `/ID`.
+//!
+//! Determinism is a feature: the same input produces byte-identical
+//! output. The crate never reads clocks or randomness — dates appear only
+//! when callers supply them.
+
+pub mod canvas;
+pub mod color;
+pub mod content;
+pub mod error;
+pub mod font;
+pub mod image;
+pub mod pdf;
+pub mod ser;
+pub mod writer;
+
+pub use canvas::{Canvas, CanvasParts, ImageHandle, LineCap, LineJoin};
+pub use color::Color;
+pub use content::serialize_ops;
+pub use error::{Error, Result};
+pub use font::Standard14;
+pub use image::ImageData;
+pub use pdf::{Date, Metadata, Page, PageSize, Pdf};
+pub use writer::{WriteOptions, Writer, XrefStyle};

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -10,6 +10,7 @@ use crate::canvas::Canvas;
 use crate::content::serialize_ops;
 use crate::error::{Error, Result};
 use crate::font::Standard14;
+use crate::sink::AsyncByteSink;
 use crate::writer::{WriteOptions, Writer};
 
 /// A page size, in default user-space units (1/72 inch), portrait.
@@ -171,6 +172,30 @@ impl Pdf {
     /// page with no cross-page deduplication — the same raster drawn on
     /// two pages is stored twice.
     pub fn to_bytes(self) -> Result<Vec<u8>> {
+        let (w, root) = self.assemble()?;
+        w.finish(root)
+    }
+
+    /// [`Pdf::to_bytes`] streaming into a [`std::io::Write`]: the same
+    /// bytes, delivered in bounded chunks instead of one buffer. Unlike
+    /// `to_bytes`, an error can leave a prefix of the file already written
+    /// to `out`. No flush is performed.
+    pub fn write_into(self, out: impl std::io::Write) -> Result<()> {
+        let (w, root) = self.assemble()?;
+        w.finish_into(root, out)
+    }
+
+    /// [`Pdf::to_bytes`] streaming into any [`AsyncByteSink`] — the
+    /// asynchronous twin of [`Pdf::write_into`]. An error can leave a
+    /// prefix of the file already written. Hands the sink back unflushed.
+    pub async fn write_into_with<S: AsyncByteSink>(self, sink: S) -> Result<S> {
+        let (w, root) = self.assemble()?;
+        w.finish_into_with(root, sink).await
+    }
+
+    /// Builds the writer every write path finishes: all objects placed,
+    /// the catalog's reference returned alongside.
+    fn assemble(self) -> Result<(Writer, ObjRef)> {
         let Pdf {
             metadata,
             pages,
@@ -251,7 +276,7 @@ impl Pdf {
         catalog.insert(name("Type"), Object::Name(name("Catalog")));
         catalog.insert(name("Pages"), Object::Ref(pages_root));
         let root = w.put(Object::Dict(catalog));
-        w.finish(root)
+        Ok((w, root))
     }
 
     /// Serializes and writes the document to `path`.
@@ -397,5 +422,44 @@ mod tests {
             utc_offset_minutes: -330,
         };
         assert_eq!(date.to_pdf_string(), "D:19991231235958-05'30");
+    }
+
+    /// Two pages with text and an image — enough to exercise fonts,
+    /// XObjects and the reserved page tree through every write path.
+    fn two_page_doc() -> Pdf {
+        let mut first = Page::new(PageSize::A4);
+        first
+            .canvas
+            .text("Streamed parity", 72.0, 720.0, Standard14::Helvetica, 14.0)
+            .expect("ASCII encodes");
+        let image = crate::image::ImageData::gray8(2, 2, vec![0, 85, 170, 255])
+            .expect("2x2 grayscale builds");
+        let handle = first.canvas.add_image(image);
+        first.canvas.draw_image(handle, 72.0, 400.0, 144.0, 144.0);
+        let mut second = Page::new(PageSize::Letter);
+        second
+            .canvas
+            .text("Page two", 72.0, 700.0, Standard14::TimesRoman, 12.0)
+            .expect("ASCII encodes");
+        Pdf {
+            pages: vec![first, second],
+            ..Pdf::default()
+        }
+    }
+
+    /// The three write paths are one assembly and one emission: identical
+    /// bytes whether buffered, streamed into an `io::Write`, or streamed
+    /// into an async sink.
+    #[test]
+    fn write_into_and_write_into_with_match_to_bytes() {
+        let bytes = two_page_doc().to_bytes().expect("to_bytes succeeds");
+        let mut via_io = Vec::new();
+        two_page_doc()
+            .write_into(&mut via_io)
+            .expect("write_into succeeds");
+        assert_eq!(via_io, bytes);
+        let via_sink = pdfboss_core::block_on(two_page_doc().write_into_with(Vec::new()))
+            .expect("write_into_with succeeds");
+        assert_eq!(via_sink, bytes);
     }
 }

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -4,9 +4,13 @@
 
 use std::path::Path;
 
+use pdfboss_core::{Dict, Name, ObjRef, Object};
+
 use crate::canvas::Canvas;
-use crate::error::Result;
-use crate::writer::WriteOptions;
+use crate::content::serialize_ops;
+use crate::error::{Error, Result};
+use crate::font::Standard14;
+use crate::writer::{WriteOptions, Writer};
 
 /// A page size, in default user-space units (1/72 inch), portrait.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -34,12 +38,23 @@ pub enum PageSize {
 impl PageSize {
     /// Width and height in user-space units.
     pub fn dimensions(self) -> (f32, f32) {
-        todo!("dimensions of {self:?}")
+        match self {
+            PageSize::A3 => (841.89, 1190.55),
+            PageSize::A4 => (595.28, 841.89),
+            PageSize::A5 => (419.53, 595.28),
+            PageSize::Letter => (612.0, 792.0),
+            PageSize::Legal => (612.0, 1008.0),
+            PageSize::Custom { width, height } => (width, height),
+        }
     }
 
     /// The same size with width and height swapped.
     pub fn landscape(self) -> PageSize {
-        todo!("landscape of {self:?}")
+        let (width, height) = self.dimensions();
+        PageSize::Custom {
+            width: height,
+            height: width,
+        }
     }
 }
 
@@ -65,9 +80,31 @@ pub struct Date {
 }
 
 impl Date {
-    /// Formats as a PDF date string, `D:YYYYMMDDHHmmSSOHH'mm`.
+    /// Formats as a PDF date string, `D:YYYYMMDDHHmmSSOHH'mm` — with a
+    /// literal `Z` in place of the offset when the date is exactly UTC.
     pub fn to_pdf_string(self) -> String {
-        todo!("format {self:?}")
+        let Date {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            utc_offset_minutes,
+        } = self;
+        let mut out = format!("D:{year:04}{month:02}{day:02}{hour:02}{minute:02}{second:02}");
+        if utc_offset_minutes == 0 {
+            out.push('Z');
+            return out;
+        }
+        let sign = if utc_offset_minutes < 0 { '-' } else { '+' };
+        let magnitude = utc_offset_minutes.unsigned_abs();
+        out.push_str(&format!(
+            "{sign}{:02}'{:02}",
+            magnitude / 60,
+            magnitude % 60
+        ));
+        out
     }
 }
 
@@ -128,13 +165,237 @@ pub struct Pdf {
 
 impl Pdf {
     /// Serializes the document to complete PDF file bytes.
+    ///
+    /// Fonts are shared document-wide: each distinct [`Standard14`] face
+    /// gets one font object, in first-use order. Images are embedded per
+    /// page with no cross-page deduplication — the same raster drawn on
+    /// two pages is stored twice.
     pub fn to_bytes(self) -> Result<Vec<u8>> {
-        todo!("assemble {} pages", self.pages.len())
+        let Pdf {
+            metadata,
+            pages,
+            options,
+        } = self;
+        let mut w = Writer::new(options);
+        let pages_root = w.reserve();
+        let mut font_cache: Vec<(Standard14, ObjRef)> = Vec::new();
+        let mut kids = Vec::with_capacity(pages.len());
+        for page in pages {
+            if page.rotation % 90 != 0 {
+                return Err(Error::Other(format!(
+                    "page rotation {} is not a multiple of 90",
+                    page.rotation
+                )));
+            }
+            let (width, height) = page.size.dimensions();
+            let rotation = page.rotation;
+            let parts = page.canvas.into_parts();
+            let content = w.put_stream(Dict::new(), serialize_ops(&parts.ops));
+            let mut fonts = Dict::new();
+            for (index, face) in parts.fonts.iter().enumerate() {
+                let cached = font_cache
+                    .iter()
+                    .find(|(seen, _)| seen == face)
+                    .map(|(_, r)| *r);
+                let font_ref = match cached {
+                    Some(r) => r,
+                    None => {
+                        let r = w.put(Object::Dict(face.font_dict()));
+                        font_cache.push((*face, r));
+                        r
+                    }
+                };
+                fonts.insert(Name(format!("F{}", index + 1)), Object::Ref(font_ref));
+            }
+            let mut xobjects = Dict::new();
+            for (index, image) in parts.images.iter().enumerate() {
+                let image_ref = image.build_xobject(&mut w);
+                xobjects.insert(Name(format!("Im{}", index + 1)), Object::Ref(image_ref));
+            }
+            let mut resources = Dict::new();
+            if !fonts.is_empty() {
+                resources.insert(name("Font"), Object::Dict(fonts));
+            }
+            if !xobjects.is_empty() {
+                resources.insert(name("XObject"), Object::Dict(xobjects));
+            }
+            let mut dict = Dict::new();
+            dict.insert(name("Type"), Object::Name(name("Page")));
+            dict.insert(name("Parent"), Object::Ref(pages_root));
+            dict.insert(
+                name("MediaBox"),
+                Object::Array(vec![
+                    Object::Int(0),
+                    Object::Int(0),
+                    Object::Real(f64::from(width)),
+                    Object::Real(f64::from(height)),
+                ]),
+            );
+            dict.insert(name("Contents"), Object::Ref(content));
+            dict.insert(name("Resources"), Object::Dict(resources));
+            if rotation != 0 {
+                dict.insert(name("Rotate"), Object::Int(i64::from(rotation)));
+            }
+            kids.push(Object::Ref(w.put(Object::Dict(dict))));
+        }
+        let mut tree = Dict::new();
+        tree.insert(name("Type"), Object::Name(name("Pages")));
+        tree.insert(name("Count"), Object::Int(kids.len() as i64));
+        tree.insert(name("Kids"), Object::Array(kids));
+        w.fill(pages_root, Object::Dict(tree))?;
+        if let Some(info) = metadata.and_then(info_dict) {
+            let info_ref = w.put(Object::Dict(info));
+            w.set_info(info_ref);
+        }
+        let mut catalog = Dict::new();
+        catalog.insert(name("Type"), Object::Name(name("Catalog")));
+        catalog.insert(name("Pages"), Object::Ref(pages_root));
+        let root = w.put(Object::Dict(catalog));
+        w.finish(root)
     }
 
     /// Serializes and writes the document to `path`.
     pub fn save(self, path: impl AsRef<Path>) -> Result<()> {
-        let unused = path.as_ref();
-        todo!("save to {unused:?}")
+        let path = path.as_ref();
+        let bytes = self.to_bytes()?;
+        std::fs::write(path, bytes)?;
+        Ok(())
+    }
+}
+
+/// A `Name` from a string literal.
+fn name(text: &str) -> Name {
+    Name(text.to_string())
+}
+
+/// Builds the `/Info` dictionary, or `None` when every field is `None`.
+fn info_dict(meta: Metadata) -> Option<Dict> {
+    let mut dict = Dict::new();
+    let texts = [
+        ("Title", meta.title),
+        ("Author", meta.author),
+        ("Subject", meta.subject),
+        ("Keywords", meta.keywords),
+        ("Creator", meta.creator),
+        ("Producer", meta.producer),
+    ];
+    for (key, value) in texts {
+        if let Some(value) = value {
+            dict.insert(name(key), text_string(&value));
+        }
+    }
+    let dates = [
+        ("CreationDate", meta.creation_date),
+        ("ModDate", meta.modification_date),
+    ];
+    for (key, value) in dates {
+        if let Some(date) = value {
+            dict.insert(name(key), Object::String(date.to_pdf_string().into_bytes()));
+        }
+    }
+    if dict.is_empty() {
+        return None;
+    }
+    Some(dict)
+}
+
+/// Encodes a text string (ISO 32000 §7.9.2.2): pure ASCII passes through
+/// as its own bytes, anything else becomes UTF-16BE with a `FE FF` byte
+/// order mark.
+fn text_string(value: &str) -> Object {
+    if value.is_ascii() {
+        return Object::String(value.as_bytes().to_vec());
+    }
+    let mut bytes = vec![0xFE, 0xFF];
+    for unit in value.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_be_bytes());
+    }
+    Object::String(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dimensions_match_the_contract() {
+        assert_eq!(PageSize::A3.dimensions(), (841.89, 1190.55));
+        assert_eq!(PageSize::A4.dimensions(), (595.28, 841.89));
+        assert_eq!(PageSize::A5.dimensions(), (419.53, 595.28));
+        assert_eq!(PageSize::Letter.dimensions(), (612.0, 792.0));
+        assert_eq!(PageSize::Legal.dimensions(), (612.0, 1008.0));
+        assert_eq!(
+            PageSize::Custom {
+                width: 10.0,
+                height: 20.0
+            }
+            .dimensions(),
+            (10.0, 20.0)
+        );
+    }
+
+    #[test]
+    fn landscape_swaps_into_custom() {
+        assert_eq!(
+            PageSize::A4.landscape(),
+            PageSize::Custom {
+                width: 841.89,
+                height: 595.28
+            }
+        );
+        assert_eq!(
+            PageSize::Custom {
+                width: 1.0,
+                height: 2.0
+            }
+            .landscape(),
+            PageSize::Custom {
+                width: 2.0,
+                height: 1.0
+            }
+        );
+        assert_eq!(PageSize::Letter.landscape().dimensions(), (792.0, 612.0));
+    }
+
+    #[test]
+    fn date_utc_formats_with_z() {
+        let date = Date {
+            year: 2026,
+            month: 8,
+            day: 27,
+            hour: 12,
+            minute: 30,
+            second: 15,
+            utc_offset_minutes: 0,
+        };
+        assert_eq!(date.to_pdf_string(), "D:20260827123015Z");
+    }
+
+    #[test]
+    fn date_positive_offset_pads_single_digits() {
+        let date = Date {
+            year: 987,
+            month: 1,
+            day: 2,
+            hour: 3,
+            minute: 4,
+            second: 5,
+            utc_offset_minutes: 120,
+        };
+        assert_eq!(date.to_pdf_string(), "D:09870102030405+02'00");
+    }
+
+    #[test]
+    fn date_negative_offset_keeps_minutes() {
+        let date = Date {
+            year: 1999,
+            month: 12,
+            day: 31,
+            hour: 23,
+            minute: 59,
+            second: 58,
+            utc_offset_minutes: -330,
+        };
+        assert_eq!(date.to_pdf_string(), "D:19991231235958-05'30");
     }
 }

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -1,0 +1,140 @@
+//! Document assembly: pages of canvas content, document metadata, and the
+//! save path. `Pdf` is a plain struct — the fields are the composition,
+//! and `Default` fills everything optional.
+
+use std::path::Path;
+
+use crate::canvas::Canvas;
+use crate::error::Result;
+use crate::writer::WriteOptions;
+
+/// A page size, in default user-space units (1/72 inch), portrait.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum PageSize {
+    /// 297 × 420 mm.
+    A3,
+    /// 210 × 297 mm.
+    #[default]
+    A4,
+    /// 148 × 210 mm.
+    A5,
+    /// 8.5 × 11 in.
+    Letter,
+    /// 8.5 × 14 in.
+    Legal,
+    /// Explicit dimensions in user-space units.
+    Custom {
+        /// Width in units.
+        width: f32,
+        /// Height in units.
+        height: f32,
+    },
+}
+
+impl PageSize {
+    /// Width and height in user-space units.
+    pub fn dimensions(self) -> (f32, f32) {
+        todo!("dimensions of {self:?}")
+    }
+
+    /// The same size with width and height swapped.
+    pub fn landscape(self) -> PageSize {
+        todo!("landscape of {self:?}")
+    }
+}
+
+/// A calendar date and time with a UTC offset, for `/CreationDate` and
+/// `/ModDate`. The writer never reads a clock — dates appear in output
+/// only when a caller provides them, keeping builds reproducible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Date {
+    /// Four-digit year.
+    pub year: u16,
+    /// Month, 1–12.
+    pub month: u8,
+    /// Day of month, 1–31.
+    pub day: u8,
+    /// Hour, 0–23.
+    pub hour: u8,
+    /// Minute, 0–59.
+    pub minute: u8,
+    /// Second, 0–59.
+    pub second: u8,
+    /// Offset from UTC in minutes (positive east).
+    pub utc_offset_minutes: i16,
+}
+
+impl Date {
+    /// Formats as a PDF date string, `D:YYYYMMDDHHmmSSOHH'mm`.
+    pub fn to_pdf_string(self) -> String {
+        todo!("format {self:?}")
+    }
+}
+
+/// Document information written to the `/Info` dictionary. Every field is
+/// optional; an all-`None` value writes no dictionary at all.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Metadata {
+    /// `/Title`.
+    pub title: Option<String>,
+    /// `/Author`.
+    pub author: Option<String>,
+    /// `/Subject`.
+    pub subject: Option<String>,
+    /// `/Keywords`.
+    pub keywords: Option<String>,
+    /// `/Creator` (the producing application's name).
+    pub creator: Option<String>,
+    /// `/Producer`.
+    pub producer: Option<String>,
+    /// `/CreationDate`.
+    pub creation_date: Option<Date>,
+    /// `/ModDate`.
+    pub modification_date: Option<Date>,
+}
+
+/// One page: its size, rotation and painted content.
+#[derive(Debug, Default)]
+pub struct Page {
+    /// Page size (the `/MediaBox`).
+    pub size: PageSize,
+    /// Clockwise view rotation in degrees; must be a multiple of 90.
+    pub rotation: i32,
+    /// The page's painted content.
+    pub canvas: Canvas,
+}
+
+impl Page {
+    /// An empty page of the given size.
+    pub fn new(size: PageSize) -> Page {
+        Page {
+            size,
+            ..Page::default()
+        }
+    }
+}
+
+/// A document under construction. The fields are the composition:
+/// singleton slots are `Option`s, pages keep the order given.
+#[derive(Debug, Default)]
+pub struct Pdf {
+    /// Document information, if any.
+    pub metadata: Option<Metadata>,
+    /// Pages, in reading order.
+    pub pages: Vec<Page>,
+    /// File-emission options.
+    pub options: WriteOptions,
+}
+
+impl Pdf {
+    /// Serializes the document to complete PDF file bytes.
+    pub fn to_bytes(self) -> Result<Vec<u8>> {
+        todo!("assemble {} pages", self.pages.len())
+    }
+
+    /// Serializes and writes the document to `path`.
+    pub fn save(self, path: impl AsRef<Path>) -> Result<()> {
+        let unused = path.as_ref();
+        todo!("save to {unused:?}")
+    }
+}

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -201,6 +201,11 @@ impl Pdf {
             pages,
             options,
         } = self;
+        if pages.is_empty() {
+            return Err(Error::Other(
+                "a document needs at least one page".to_string(),
+            ));
+        }
         let mut w = Writer::new(options);
         let pages_root = w.reserve();
         let mut font_cache: Vec<(Standard14, ObjRef)> = Vec::new();
@@ -461,5 +466,13 @@ mod tests {
         let via_sink = pdfboss_core::block_on(two_page_doc().write_into_with(Vec::new()))
             .expect("write_into_with succeeds");
         assert_eq!(via_sink, bytes);
+    }
+
+    #[test]
+    fn zero_page_document_is_an_error() {
+        let err = Pdf::default()
+            .to_bytes()
+            .expect_err("a page-less document must not serialize");
+        assert!(err.to_string().contains("at least one page"), "{err}");
     }
 }

--- a/crates/pdfboss-write/src/ser.rs
+++ b/crates/pdfboss-write/src/ser.rs
@@ -6,9 +6,9 @@
 //! indirect object and its `/Length` bookkeeping belongs to the
 //! [`Writer`](crate::Writer), so a nested `Object::Stream` is an error.
 
-use pdfboss_core::{Dict, Object};
+use pdfboss_core::{Dict, Name, Object};
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 /// Serializes any non-stream object into `out`.
 ///
@@ -16,23 +16,65 @@ use crate::error::Result;
 /// never produce `-0`. Non-finite reals serialize as `0` (PDF has no
 /// representation for them).
 pub fn serialize_object(obj: &Object, out: &mut Vec<u8>) -> Result<()> {
-    let unused = (obj, out);
-    todo!("serialize object: {unused:?}")
+    match obj {
+        Object::Null => out.extend_from_slice(b"null"),
+        Object::Bool(true) => out.extend_from_slice(b"true"),
+        Object::Bool(false) => out.extend_from_slice(b"false"),
+        Object::Int(i) => out.extend_from_slice(i.to_string().as_bytes()),
+        Object::Real(r) => write_real(*r, out),
+        Object::String(bytes) => write_string(bytes, out),
+        Object::Name(n) => write_name(&n.0, out),
+        Object::Array(items) => {
+            out.push(b'[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(b' ');
+                }
+                serialize_object(item, out)?;
+            }
+            out.push(b']');
+        }
+        Object::Dict(d) => serialize_dict(d, out)?,
+        Object::Ref(r) => {
+            out.extend_from_slice(r.num.to_string().as_bytes());
+            out.push(b' ');
+            out.extend_from_slice(r.gen.to_string().as_bytes());
+            out.extend_from_slice(b" R");
+        }
+        Object::Stream(_) => return Err(Error::NestedStream),
+    }
+    Ok(())
 }
 
 /// Serializes a dictionary with `<< … >>` delimiters, keys sorted
 /// bytewise for deterministic output.
 pub fn serialize_dict(dict: &Dict, out: &mut Vec<u8>) -> Result<()> {
-    let unused = (dict, out);
-    todo!("serialize dict: {unused:?}")
+    out.extend_from_slice(b"<<");
+    let mut entries: Vec<(&Name, &Object)> = dict.iter().collect();
+    entries.sort_unstable_by(|a, b| a.0.cmp(b.0));
+    for (key, value) in entries {
+        out.push(b' ');
+        write_name(&key.0, out);
+        out.push(b' ');
+        serialize_object(value, out)?;
+    }
+    out.extend_from_slice(b" >>");
+    Ok(())
 }
 
 /// Writes a name object with its leading solidus, escaping every byte
 /// outside the regular range as `#xx` (delimiters, whitespace, `#` itself,
 /// and anything outside `0x21..=0x7E`).
 pub fn write_name(name: &str, out: &mut Vec<u8>) {
-    let unused = (name, out);
-    todo!("write name: {unused:?}")
+    out.push(b'/');
+    for &byte in name.as_bytes() {
+        if (0x21..=0x7E).contains(&byte) && !b"()<>[]{}/%#".contains(&byte) {
+            out.push(byte);
+            continue;
+        }
+        out.push(b'#');
+        push_hex(byte, out);
+    }
 }
 
 /// Writes a string object. Byte content that is printable ASCII (plus tab,
@@ -40,21 +82,400 @@ pub fn write_name(name: &str, out: &mut Vec<u8>) {
 /// anything else uses the hex form. The choice is a pure function of the
 /// bytes, keeping output deterministic.
 pub fn write_string(bytes: &[u8], out: &mut Vec<u8>) {
-    let unused = (bytes, out);
-    todo!("write string: {unused:?}")
+    let literal = bytes
+        .iter()
+        .all(|&b| (0x20..=0x7E).contains(&b) || matches!(b, b'\n' | b'\r' | b'\t'));
+    if !literal {
+        out.push(b'<');
+        for &byte in bytes {
+            push_hex(byte, out);
+        }
+        out.push(b'>');
+        return;
+    }
+    out.push(b'(');
+    for &byte in bytes {
+        match byte {
+            b'\\' | b'(' | b')' => {
+                out.push(b'\\');
+                out.push(byte);
+            }
+            b'\n' => out.extend_from_slice(b"\\n"),
+            b'\r' => out.extend_from_slice(b"\\r"),
+            b'\t' => out.extend_from_slice(b"\\t"),
+            other => out.push(other),
+        }
+    }
+    out.push(b')');
 }
 
 /// Writes a real number in plain decimal: no exponent, trailing zeros
 /// trimmed, `-0` normalized to `0`, non-finite values written as `0`.
 /// Whole values write as integers (`72` not `72.0`).
 pub fn write_real(value: f64, out: &mut Vec<u8>) {
-    let unused = (value, out);
-    todo!("write real: {unused:?}")
+    if !value.is_finite() || value == 0.0 {
+        out.push(b'0');
+        return;
+    }
+    if value.fract() == 0.0 && value.abs() < 9_007_199_254_740_992.0 {
+        out.extend_from_slice((value as i64).to_string().as_bytes());
+        return;
+    }
+    out.extend_from_slice(plain_decimal(&value.to_string()).as_bytes());
 }
 
 /// Like [`write_real`], for `f32` values (content-stream operands): the
 /// shortest decimal that parses back to the identical `f32`.
 pub fn write_real_f32(value: f32, out: &mut Vec<u8>) {
-    let unused = (value, out);
-    todo!("write f32: {unused:?}")
+    if !value.is_finite() || value == 0.0 {
+        out.push(b'0');
+        return;
+    }
+    out.extend_from_slice(plain_decimal(&value.to_string()).as_bytes());
+}
+
+const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+fn push_hex(byte: u8, out: &mut Vec<u8>) {
+    out.push(HEX[usize::from(byte >> 4)]);
+    out.push(HEX[usize::from(byte & 0x0F)]);
+}
+
+fn plain_decimal(formatted: &str) -> String {
+    let expanded = match formatted.split_once(['e', 'E']) {
+        None => formatted.to_string(),
+        Some((mantissa, exponent)) => expand_exponent(mantissa, exponent),
+    };
+    if !expanded.contains('.') {
+        return expanded;
+    }
+    expanded
+        .trim_end_matches('0')
+        .trim_end_matches('.')
+        .to_string()
+}
+
+fn expand_exponent(mantissa: &str, exponent: &str) -> String {
+    let exp: i32 = exponent
+        .parse()
+        .expect("float formatting produced a malformed exponent");
+    let (sign, unsigned) = match mantissa.strip_prefix('-') {
+        Some(rest) => ("-", rest),
+        None => ("", mantissa),
+    };
+    let (int_part, frac_part) = match unsigned.split_once('.') {
+        Some(parts) => parts,
+        None => (unsigned, ""),
+    };
+    let digits = format!("{int_part}{frac_part}");
+    let point = int_part.len() as i32 + exp;
+    if point <= 0 {
+        let zeros = "0".repeat(point.unsigned_abs() as usize);
+        return format!("{sign}0.{zeros}{digits}");
+    }
+    let point = point as usize;
+    if point >= digits.len() {
+        let zeros = "0".repeat(point - digits.len());
+        return format!("{sign}{digits}{zeros}");
+    }
+    format!("{sign}{}.{}", &digits[..point], &digits[point..])
+}
+
+#[cfg(test)]
+mod tests {
+    use pdfboss_core::parser::{NoResolve, Parser};
+    use pdfboss_core::{Dict, Name, ObjRef, Object, Stream};
+
+    use super::*;
+    use crate::error::Error;
+
+    fn name(text: &str) -> Name {
+        Name(text.to_string())
+    }
+
+    fn ser(obj: &Object) -> String {
+        let mut out = Vec::new();
+        serialize_object(obj, &mut out).expect("serializable object");
+        String::from_utf8(out).expect("serialized syntax is UTF-8")
+    }
+
+    fn real_str(value: f64) -> String {
+        let mut out = Vec::new();
+        write_real(value, &mut out);
+        String::from_utf8(out).expect("real syntax is ASCII")
+    }
+
+    fn real32_str(value: f32) -> String {
+        let mut out = Vec::new();
+        write_real_f32(value, &mut out);
+        String::from_utf8(out).expect("real syntax is ASCII")
+    }
+
+    fn name_str(text: &str) -> String {
+        let mut out = Vec::new();
+        write_name(text, &mut out);
+        String::from_utf8(out).expect("name syntax is ASCII")
+    }
+
+    fn string_str(bytes: &[u8]) -> String {
+        let mut out = Vec::new();
+        write_string(bytes, &mut out);
+        String::from_utf8(out).expect("string syntax is ASCII")
+    }
+
+    #[test]
+    fn scalars_serialize_exactly() {
+        assert_eq!(ser(&Object::Null), "null");
+        assert_eq!(ser(&Object::Bool(true)), "true");
+        assert_eq!(ser(&Object::Bool(false)), "false");
+        assert_eq!(ser(&Object::Int(42)), "42");
+        assert_eq!(ser(&Object::Int(-7)), "-7");
+        assert_eq!(ser(&Object::Int(i64::MIN)), "-9223372036854775808");
+        assert_eq!(ser(&Object::Int(i64::MAX)), "9223372036854775807");
+    }
+
+    #[test]
+    fn real_pins_exact_bytes() {
+        assert_eq!(real_str(0.0), "0");
+        assert_eq!(real_str(-0.0), "0");
+        assert_eq!(real_str(f64::NAN), "0");
+        assert_eq!(real_str(f64::INFINITY), "0");
+        assert_eq!(real_str(f64::NEG_INFINITY), "0");
+        assert_eq!(real_str(72.0), "72");
+        assert_eq!(real_str(-72.0), "-72");
+        assert_eq!(real_str(0.5), "0.5");
+        assert_eq!(real_str(-0.25), "-0.25");
+        assert_eq!(real_str(0.1), "0.1");
+        assert_eq!(real_str(1e-7), "0.0000001");
+        assert_eq!(real_str(1.5e-10), "0.00000000015");
+        assert_eq!(real_str(9007199254740991.0), "9007199254740991");
+        assert_eq!(real_str(-9007199254740991.0), "-9007199254740991");
+        assert_eq!(real_str(9007199254740992.0), "9007199254740992");
+        assert_eq!(real_str(1e300), format!("1{}", "0".repeat(300)));
+    }
+
+    #[test]
+    fn real_f32_round_trips_hard_cases() {
+        let cases = [
+            0.1f32,
+            1e-7f32,
+            16777216.0f32,
+            f32::MIN_POSITIVE,
+            3.4e38f32,
+            1073741824.0f32,
+        ];
+        for value in cases {
+            let text = real32_str(value);
+            assert!(
+                !text.contains(['e', 'E']),
+                "{value} produced exponent form {text}"
+            );
+            let parsed: f32 = text.parse().expect("output parses as f32");
+            assert_eq!(parsed.to_bits(), value.to_bits(), "{value} -> {text}");
+        }
+        assert_eq!(real32_str(-0.0f32), "0");
+        assert_eq!(real32_str(f32::NAN), "0");
+        assert_eq!(real32_str(f32::INFINITY), "0");
+    }
+
+    #[test]
+    fn real_f32_pins_exact_bytes() {
+        assert_eq!(real32_str(0.1f32), "0.1");
+        assert_eq!(real32_str(1e-7f32), "0.0000001");
+        assert_eq!(real32_str(16777216.0f32), "16777216");
+        assert_eq!(real32_str(1073741824.0f32), "1073741800");
+        assert_eq!(real32_str(3.4e38f32), format!("34{}", "0".repeat(37)));
+        assert_eq!(
+            real32_str(f32::MIN_POSITIVE),
+            format!("0.{}11754944", "0".repeat(37))
+        );
+    }
+
+    #[test]
+    fn plain_decimal_expands_exponents() {
+        assert_eq!(plain_decimal("1e300"), format!("1{}", "0".repeat(300)));
+        assert_eq!(plain_decimal("3.4e38"), format!("34{}", "0".repeat(37)));
+        assert_eq!(
+            plain_decimal("1.1754944e-38"),
+            format!("0.{}11754944", "0".repeat(37))
+        );
+        assert_eq!(plain_decimal("-2.5e3"), "-2500");
+        assert_eq!(plain_decimal("1.25e2"), "125");
+        assert_eq!(plain_decimal("1.25e1"), "12.5");
+        assert_eq!(plain_decimal("1.25e-1"), "0.125");
+        assert_eq!(plain_decimal("1e-1"), "0.1");
+        assert_eq!(plain_decimal("2.5E3"), "2500");
+        assert_eq!(plain_decimal("0.5"), "0.5");
+        assert_eq!(plain_decimal("1.50"), "1.5");
+        assert_eq!(plain_decimal("2.0"), "2");
+    }
+
+    #[test]
+    fn names_escape_irregular_bytes() {
+        assert_eq!(name_str("Type"), "/Type");
+        assert_eq!(name_str(""), "/");
+        assert_eq!(name_str("A B"), "/A#20B");
+        assert_eq!(name_str("A#B"), "/A#23B");
+        assert_eq!(name_str("A(B)"), "/A#28B#29");
+        assert_eq!(name_str("a/b"), "/a#2Fb");
+        assert_eq!(name_str("x[y]z"), "/x#5By#5Dz");
+        assert_eq!(name_str("{}"), "/#7B#7D");
+        assert_eq!(name_str("<>"), "/#3C#3E");
+        assert_eq!(name_str("%"), "/#25");
+        assert_eq!(name_str("Ä"), "/#C3#84");
+        assert_eq!(name_str("é"), "/#C3#A9");
+        assert_eq!(name_str("\u{7F}"), "/#7F");
+        assert_eq!(name_str("~!$&*+-.;=?@^"), "/~!$&*+-.;=?@^");
+    }
+
+    #[test]
+    fn strings_use_literal_form_with_escapes() {
+        assert_eq!(string_str(b"Hello"), "(Hello)");
+        assert_eq!(string_str(b""), "()");
+        assert_eq!(string_str(b"a(b)c"), "(a\\(b\\)c)");
+        assert_eq!(string_str(b"a\\b"), "(a\\\\b)");
+        assert_eq!(string_str(b"a\tb\nc\rd"), "(a\\tb\\nc\\rd)");
+    }
+
+    #[test]
+    fn strings_fall_back_to_hex_form() {
+        assert_eq!(string_str(&[0x00, 0xFF, 0x41]), "<00FF41>");
+        assert_eq!(string_str(&[0x7F]), "<7F>");
+        assert_eq!(string_str(&[0x1F]), "<1F>");
+        let long: Vec<u8> = (0u8..=255).collect();
+        let hex: String = (0u8..=255).map(|b| format!("{b:02X}")).collect();
+        assert_eq!(string_str(&long), format!("<{hex}>"));
+    }
+
+    #[test]
+    fn arrays_separate_items_with_single_spaces() {
+        assert_eq!(ser(&Object::Array(vec![])), "[]");
+        let arr = Object::Array(vec![
+            Object::Int(1),
+            Object::Real(2.5),
+            Object::Name(name("X")),
+        ]);
+        assert_eq!(ser(&arr), "[1 2.5 /X]");
+        let nested = Object::Array(vec![
+            Object::Array(vec![Object::Int(1), Object::Int(2)]),
+            Object::Array(vec![Object::Int(3)]),
+        ]);
+        assert_eq!(ser(&nested), "[[1 2] [3]]");
+    }
+
+    #[test]
+    fn dicts_sort_keys_bytewise() {
+        assert_eq!(ser(&Object::Dict(Dict::new())), "<< >>");
+
+        let mut d = Dict::new();
+        d.insert(name("Z"), Object::Int(2));
+        d.insert(name("A"), Object::Int(1));
+        assert_eq!(ser(&Object::Dict(d)), "<< /A 1 /Z 2 >>");
+
+        let mut d = Dict::new();
+        d.insert(name("a"), Object::Int(4));
+        d.insert(name("B"), Object::Int(3));
+        d.insert(name("AB"), Object::Int(2));
+        d.insert(name("AA"), Object::Int(1));
+        assert_eq!(ser(&Object::Dict(d)), "<< /AA 1 /AB 2 /B 3 /a 4 >>");
+    }
+
+    #[test]
+    fn nested_containers_serialize_recursively() {
+        let mut inner = Dict::new();
+        inner.insert(name("X"), Object::Int(1));
+        let mut outer = Dict::new();
+        outer.insert(name("D"), Object::Dict(inner));
+        outer.insert(
+            name("Arr"),
+            Object::Array(vec![Object::Null, Object::Bool(false)]),
+        );
+        assert_eq!(
+            ser(&Object::Dict(outer)),
+            "<< /Arr [null false] /D << /X 1 >> >>"
+        );
+    }
+
+    #[test]
+    fn refs_serialize_as_num_gen_r() {
+        assert_eq!(ser(&Object::Ref(ObjRef { num: 12, gen: 3 })), "12 3 R");
+        assert_eq!(ser(&Object::Ref(ObjRef { num: 1, gen: 0 })), "1 0 R");
+    }
+
+    #[test]
+    fn nested_streams_are_errors() {
+        let stream = Object::Stream(Stream {
+            dict: Dict::new(),
+            data: b"x".to_vec(),
+        });
+        let mut out = Vec::new();
+        let top = serialize_object(&stream, &mut out);
+        assert!(matches!(top, Err(Error::NestedStream)));
+
+        let in_array = serialize_object(&Object::Array(vec![stream.clone()]), &mut out);
+        assert!(matches!(in_array, Err(Error::NestedStream)));
+
+        let mut d = Dict::new();
+        d.insert(name("S"), stream);
+        let in_dict = serialize_object(&Object::Dict(d), &mut out);
+        assert!(matches!(in_dict, Err(Error::NestedStream)));
+    }
+
+    #[test]
+    fn serialized_objects_parse_back_equal() {
+        let mut inner = Dict::new();
+        inner.insert(name("Z"), Object::Int(1));
+        inner.insert(
+            name("A"),
+            Object::Array(vec![Object::Real(0.5), Object::Null]),
+        );
+        let mut outer = Dict::new();
+        outer.insert(
+            name("Kids"),
+            Object::Array(vec![Object::Ref(ObjRef { num: 7, gen: 0 })]),
+        );
+        outer.insert(name("Inner"), Object::Dict(inner));
+        outer.insert(name("Weird Name#"), Object::String(b"a(b)\\c".to_vec()));
+
+        let objects = vec![
+            Object::Null,
+            Object::Bool(true),
+            Object::Bool(false),
+            Object::Int(-42),
+            Object::Real(2.5),
+            Object::Real(-0.125),
+            Object::String(b"a(b)\\c".to_vec()),
+            Object::String(b"tab\there".to_vec()),
+            Object::String(vec![0u8, 255, 128]),
+            Object::Name(name("Weird Name#\u{C4}")),
+            Object::Ref(ObjRef { num: 12, gen: 3 }),
+            Object::Array(vec![]),
+            Object::Dict(Dict::new()),
+            Object::Dict(outer),
+        ];
+        for obj in objects {
+            let mut out = Vec::new();
+            serialize_object(&obj, &mut out).expect("serializable object");
+            let parsed = Parser::new(&out)
+                .parse_object(&NoResolve)
+                .expect("serialized bytes parse");
+            assert_eq!(
+                parsed,
+                obj,
+                "round-trip of {}",
+                String::from_utf8_lossy(&out)
+            );
+        }
+    }
+
+    #[test]
+    fn integral_reals_parse_back_as_ints() {
+        let mut out = Vec::new();
+        serialize_object(&Object::Real(72.0), &mut out).expect("serializable object");
+        assert_eq!(out, b"72");
+        let parsed = Parser::new(&out)
+            .parse_object(&NoResolve)
+            .expect("serialized bytes parse");
+        assert_eq!(parsed, Object::Int(72));
+    }
 }

--- a/crates/pdfboss-write/src/ser.rs
+++ b/crates/pdfboss-write/src/ser.rs
@@ -23,7 +23,10 @@ pub fn serialize_object(obj: &Object, out: &mut Vec<u8>) -> Result<()> {
         Object::Int(i) => out.extend_from_slice(i.to_string().as_bytes()),
         Object::Real(r) => write_real(*r, out),
         Object::String(bytes) => write_string(bytes, out),
-        Object::Name(n) => write_name(&n.0, out),
+        Object::Name(n) => {
+            nul_free(n)?;
+            write_name(&n.0, out);
+        }
         Object::Array(items) => {
             out.push(b'[');
             for (i, item) in items.iter().enumerate() {
@@ -53,6 +56,7 @@ pub fn serialize_dict(dict: &Dict, out: &mut Vec<u8>) -> Result<()> {
     let mut entries: Vec<(&Name, &Object)> = dict.iter().collect();
     entries.sort_unstable_by(|a, b| a.0.cmp(b.0));
     for (key, value) in entries {
+        nul_free(key)?;
         out.push(b' ');
         write_name(&key.0, out);
         out.push(b' ');
@@ -132,6 +136,20 @@ pub fn write_real_f32(value: f32, out: &mut Vec<u8>) {
         return;
     }
     out.extend_from_slice(plain_decimal(&value.to_string()).as_bytes());
+}
+
+/// Rejects a name containing NUL: ISO 32000 forbids the `#00` escape, so
+/// such a name has no legal spelling. Object and dictionary serialization
+/// validate here; [`write_name`] itself stays infallible for callers whose
+/// names are structurally NUL-free (content-stream resource names).
+fn nul_free(name: &Name) -> Result<()> {
+    if name.0.bytes().all(|b| b != 0) {
+        return Ok(());
+    }
+    Err(Error::Other(format!(
+        "name {:?} contains NUL, which has no legal escape in a name",
+        name.0
+    )))
 }
 
 const HEX: &[u8; 16] = b"0123456789ABCDEF";
@@ -477,5 +495,17 @@ mod tests {
             .parse_object(&NoResolve)
             .expect("serialized bytes parse");
         assert_eq!(parsed, Object::Int(72));
+    }
+
+    #[test]
+    fn names_with_nul_bytes_are_rejected() {
+        let mut out = Vec::new();
+        let err = serialize_object(&Object::Name(name("a\0b")), &mut out)
+            .expect_err("a NUL in a name must not serialize");
+        assert!(err.to_string().contains("NUL"), "{err}");
+        let mut d = Dict::new();
+        d.insert(name("a\0b"), Object::Int(1));
+        let mut out = Vec::new();
+        assert!(serialize_dict(&d, &mut out).is_err());
     }
 }

--- a/crates/pdfboss-write/src/ser.rs
+++ b/crates/pdfboss-write/src/ser.rs
@@ -1,0 +1,53 @@
+//! COS object serialization: `Object` values to PDF syntax bytes
+//! (ISO 32000 §7.3). Output is deterministic — dictionary keys are emitted
+//! in sorted order regardless of insertion order.
+//!
+//! Streams are deliberately absent here: a stream is only legal as an
+//! indirect object and its `/Length` bookkeeping belongs to the
+//! [`Writer`](crate::Writer), so a nested `Object::Stream` is an error.
+
+use pdfboss_core::{Dict, Object};
+
+use crate::error::Result;
+
+/// Serializes any non-stream object into `out`.
+///
+/// Numbers are written without exponents; reals trim trailing zeros and
+/// never produce `-0`. Non-finite reals serialize as `0` (PDF has no
+/// representation for them).
+pub fn serialize_object(obj: &Object, out: &mut Vec<u8>) -> Result<()> {
+    let unused = (obj, out);
+    todo!("serialize object: {unused:?}")
+}
+
+/// Serializes a dictionary with `<< … >>` delimiters, keys sorted
+/// bytewise for deterministic output.
+pub fn serialize_dict(dict: &Dict, out: &mut Vec<u8>) -> Result<()> {
+    let unused = (dict, out);
+    todo!("serialize dict: {unused:?}")
+}
+
+/// Writes a name object with its leading solidus, escaping every byte
+/// outside the regular range as `#xx` (delimiters, whitespace, `#` itself,
+/// and anything outside `0x21..=0x7E`).
+pub fn write_name(name: &str, out: &mut Vec<u8>) {
+    let unused = (name, out);
+    todo!("write name: {unused:?}")
+}
+
+/// Writes a string object. Byte content that is printable ASCII (plus tab,
+/// newline and carriage return) uses the literal form with `\`-escapes;
+/// anything else uses the hex form. The choice is a pure function of the
+/// bytes, keeping output deterministic.
+pub fn write_string(bytes: &[u8], out: &mut Vec<u8>) {
+    let unused = (bytes, out);
+    todo!("write string: {unused:?}")
+}
+
+/// Writes a real number in plain decimal: no exponent, trailing zeros
+/// trimmed, `-0` normalized to `0`, non-finite values written as `0`.
+/// Whole values write as integers (`72` not `72.0`).
+pub fn write_real(value: f64, out: &mut Vec<u8>) {
+    let unused = (value, out);
+    todo!("write real: {unused:?}")
+}

--- a/crates/pdfboss-write/src/ser.rs
+++ b/crates/pdfboss-write/src/ser.rs
@@ -51,3 +51,10 @@ pub fn write_real(value: f64, out: &mut Vec<u8>) {
     let unused = (value, out);
     todo!("write real: {unused:?}")
 }
+
+/// Like [`write_real`], for `f32` values (content-stream operands): the
+/// shortest decimal that parses back to the identical `f32`.
+pub fn write_real_f32(value: f32, out: &mut Vec<u8>) {
+    let unused = (value, out);
+    todo!("write f32: {unused:?}")
+}

--- a/crates/pdfboss-write/src/sink.rs
+++ b/crates/pdfboss-write/src/sink.rs
@@ -1,0 +1,170 @@
+//! The byte-sink abstraction shared by the synchronous and asynchronous
+//! write APIs.
+//!
+//! `pdfboss-write` keeps exactly one implementation of file emission —
+//! the algorithm behind [`crate::Writer::finish_into_with`] — and several
+//! ways of accepting its bytes. [`AsyncByteSink`] is what an asynchronous
+//! consumer provides; `Vec<u8>` is a sink in its own right for the
+//! in-memory path; [`Immediate`] presents any [`std::io::Write`] as a sink
+//! whose futures are already complete, which is how the synchronous entry
+//! points share the asynchronous implementation through
+//! [`pdfboss_core::block_on`] — exactly the pattern the read side's
+//! `pdfboss_core::source` module documents.
+//!
+//! Emission follows that module's three signing rules, mirrored for
+//! writing: entry points take the sink by value, carry no `Send`/`Sync`
+//! bounds of their own, and call the trait method rather than a free twin.
+
+use std::io::Write;
+
+use pdfboss_core::source::BoxFuture;
+
+use crate::error::{Error, Result};
+
+/// Accepts emitted file bytes, awaiting whatever I/O that takes.
+///
+/// This is the trait the shared emission algorithm is written against.
+/// [`BoxFuture`] is `Send`-bounded, so an implementation over a non-`Send`
+/// writer must do its work eagerly and return an already-complete future —
+/// as [`Immediate`] does — rather than capture the writer.
+pub trait AsyncByteSink {
+    /// Writes all of `buf`, erroring if any byte cannot be accepted.
+    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> BoxFuture<'a, Result<()>>;
+}
+
+/// An exclusive reference to a sink is itself a sink, forwarding the
+/// write — the write-side counterpart of `pdfboss_core::source`'s `&T`
+/// impl, and what lets a caller keep one sink across several by-value
+/// entry-point calls.
+impl<S: AsyncByteSink + ?Sized> AsyncByteSink for &mut S {
+    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> BoxFuture<'a, Result<()>> {
+        (**self).write_all(buf)
+    }
+}
+
+/// The in-memory sink: bytes accumulate in the vector and the returned
+/// future is already complete.
+impl AsyncByteSink for Vec<u8> {
+    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> BoxFuture<'a, Result<()>> {
+        self.extend_from_slice(buf);
+        Box::pin(std::future::ready(Ok(())))
+    }
+}
+
+/// Presents a synchronous [`std::io::Write`] as an [`AsyncByteSink`]
+/// whose futures are already complete.
+///
+/// The write happens eagerly, when the method is called; the returned
+/// future merely reports its result. That keeps the future free of any
+/// borrow of the writer — so it is `Send` whatever the writer is — and a
+/// future tree built over this type completes on its first poll, never
+/// parking inside [`pdfboss_core::block_on`]. No flush is ever performed:
+/// the writer comes back (or drops) exactly as buffered.
+#[derive(Debug, Clone)]
+pub struct Immediate<W>(pub W);
+
+impl<W: Write> AsyncByteSink for Immediate<W> {
+    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> BoxFuture<'a, Result<()>> {
+        let outcome = self.0.write_all(buf).map_err(Error::from);
+        Box::pin(std::future::ready(outcome))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::io::Write;
+    use std::rc::Rc;
+
+    use pdfboss_core::block_on;
+
+    use super::{AsyncByteSink, Immediate};
+
+    #[test]
+    fn a_vec_is_a_sink() {
+        let mut sink = Vec::new();
+        block_on(AsyncByteSink::write_all(&mut sink, b"abc")).expect("a Vec accepts everything");
+        block_on(AsyncByteSink::write_all(&mut sink, b"def")).expect("a Vec accepts everything");
+        assert_eq!(sink, b"abcdef");
+    }
+
+    #[test]
+    fn a_reference_to_a_sink_is_a_sink() {
+        fn feed<S: AsyncByteSink>(mut sink: S) -> S {
+            block_on(sink.write_all(b"xy")).expect("the test sinks accept everything");
+            sink
+        }
+
+        let mut sink = Vec::new();
+        feed(&mut sink);
+        let sink = feed(sink);
+        assert_eq!(sink, b"xyxy");
+    }
+
+    #[test]
+    fn immediate_writes_through_to_the_writer() {
+        let mut sink = Immediate(Vec::new());
+        block_on(sink.write_all(b"hello")).expect("a Vec accepts everything");
+        assert_eq!(sink.0, b"hello");
+    }
+
+    /// A writer that shares state through `Rc` — deliberately not `Send` —
+    /// so this pins the design point: `Immediate`'s eager write keeps the
+    /// future `Send` without capturing the writer.
+    struct SharedWriter(Rc<RefCell<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.borrow_mut().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn immediate_futures_are_send_even_over_a_non_send_writer() {
+        fn assert_send<T: Send>(_: &T) {}
+
+        let shared = Rc::new(RefCell::new(Vec::new()));
+        let mut sink = Immediate(SharedWriter(Rc::clone(&shared)));
+        let future = sink.write_all(b"eager");
+        assert_send(&future);
+        block_on(future).expect("the shared writer accepts everything");
+        assert_eq!(*shared.borrow(), b"eager");
+    }
+
+    /// The write happens when the method is called, not when the future is
+    /// polled — the same eagerness divergence `pdfboss_core::source`
+    /// documents for its `Immediate`.
+    #[test]
+    fn immediate_writes_eagerly() {
+        let shared = Rc::new(RefCell::new(Vec::new()));
+        let mut sink = Immediate(SharedWriter(Rc::clone(&shared)));
+        let unpolled = sink.write_all(b"already there");
+        assert_eq!(*shared.borrow(), b"already there");
+        drop(unpolled);
+    }
+
+    /// A writer that refuses everything, so the error path is covered.
+    struct Refusing;
+
+    impl Write for Refusing {
+        fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("refused"))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn immediate_surfaces_write_errors() {
+        let mut sink = Immediate(Refusing);
+        let err = block_on(sink.write_all(b"x")).unwrap_err();
+        assert!(matches!(err, crate::error::Error::Io(_)));
+    }
+}

--- a/crates/pdfboss-write/src/writer.rs
+++ b/crates/pdfboss-write/src/writer.rs
@@ -260,6 +260,7 @@ async fn emit_table<S: AsyncByteSink>(
     let mut section = format!("xref\n0 {}\n", bodies.len() + 1).into_bytes();
     section.extend_from_slice(b"0000000000 65535 f\r\n");
     for offset in offsets {
+        let offset = table_offset(offset)?;
         section.extend_from_slice(format!("{offset:010} 00000 n\r\n").as_bytes());
     }
     section.extend_from_slice(b"trailer\n");
@@ -452,6 +453,18 @@ fn push_row(rows: &mut Vec<u8>, kind: u8, second: u32, third: u16) {
 fn field_offset(position: usize) -> Result<u32> {
     u32::try_from(position)
         .map_err(|_| Error::Other("file offset exceeds the 4-byte xref field".to_string()))
+}
+
+/// A byte position as the 10-digit offset field of a classic xref table
+/// (ISO 32000-1 §7.5.4 mandates exactly-20-byte entries; a wider offset
+/// would silently desynchronize every later entry).
+fn table_offset(position: usize) -> Result<usize> {
+    if position as u64 <= 9_999_999_999 {
+        return Ok(position);
+    }
+    Err(Error::Other(
+        "file offset exceeds the 10-digit xref table field".to_string(),
+    ))
 }
 
 /// A `Name` from a string literal.
@@ -800,6 +813,38 @@ mod tests {
         assert_eq!(stream.data, CONTENT);
         assert!(stream.dict.get("Filter").is_none());
         assert_eq!(stream.dict.get_int("Length"), Some(CONTENT.len() as i64));
+    }
+
+    #[test]
+    fn table_offsets_past_ten_digits_are_rejected() {
+        assert_eq!(table_offset(9_999_999_999).ok(), Some(9_999_999_999));
+        assert!(table_offset(10_000_000_000).is_err());
+    }
+
+    #[test]
+    fn id_derives_from_the_emitted_content() {
+        let (a, refs) = minimal_pdf(table_options());
+        assert_eq!(refs.root.gen, 0);
+        let (b, other_refs) = skeleton(
+            table_options(),
+            Dict::new(),
+            b"BT /F1 12 Tf 72 720 Td (Hello, other) Tj ET".to_vec(),
+            false,
+        );
+        assert_eq!(other_refs.root.gen, 0);
+        let id_of = |bytes: &[u8]| {
+            let xref = load_xref(bytes).expect("xref loads");
+            let id = xref.trailer.get_array("ID").expect("/ID array present");
+            id[0]
+                .as_str_bytes()
+                .expect("/ID entry is a string")
+                .to_vec()
+        };
+        assert_ne!(
+            id_of(&a),
+            id_of(&b),
+            "/ID must depend on the emitted content"
+        );
     }
 
     #[test]

--- a/crates/pdfboss-write/src/writer.rs
+++ b/crates/pdfboss-write/src/writer.rs
@@ -7,9 +7,14 @@
 //! produces byte-identical output. Nothing here reads clocks or RNGs; the
 //! `/ID` derives from a SHA-256 of the emitted body.
 
-use pdfboss_core::{Dict, ObjRef, Object};
+use std::io::Write;
 
-use crate::error::Result;
+use flate2::write::ZlibEncoder;
+use flate2::Compression;
+use pdfboss_core::{Dict, Name, ObjRef, Object, Stream};
+
+use crate::error::{Error, Result};
+use crate::ser::{serialize_dict, serialize_object};
 
 /// Which cross-reference flavor `finish` emits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -78,35 +83,57 @@ impl Writer {
     /// Claims an object number now to be filled later — for cycles like
     /// the page tree, where children point at a parent not yet built.
     pub fn reserve(&mut self) -> ObjRef {
-        todo!("reserve slot {}", self.slots.len())
+        self.push(Slot::Reserved)
     }
 
     /// Adds a complete object and returns its reference.
     pub fn put(&mut self, obj: Object) -> ObjRef {
-        let unused = (&mut self.slots, obj);
-        todo!("put object: {unused:?}")
+        self.push(Slot::Filled(obj))
     }
 
     /// Adds a stream object. `/Length` is computed on emission; when
     /// [`WriteOptions::compress`] is set and `dict` names no `/Filter`,
     /// the data is Flate-compressed and `/Filter /FlateDecode` added.
-    pub fn put_stream(&mut self, dict: Dict, data: Vec<u8>) -> ObjRef {
-        let unused = (&mut self.slots, dict, data);
-        todo!("put stream: {unused:?}")
+    pub fn put_stream(&mut self, mut dict: Dict, data: Vec<u8>) -> ObjRef {
+        let data = compress_into(&mut dict, data, self.options.compress);
+        self.push(Slot::Filled(Object::Stream(Stream { dict, data })))
     }
 
     /// Adds a stream object without touching its filters — for data that
     /// is already encoded (e.g. a JPEG passed through as `/DCTDecode`,
     /// with `/Filter` set by the caller). `/Length` is still computed.
     pub fn put_stream_raw(&mut self, dict: Dict, data: Vec<u8>) -> ObjRef {
-        let unused = (&mut self.slots, dict, data);
-        todo!("put raw stream: {unused:?}")
+        self.push(Slot::Filled(Object::Stream(Stream { dict, data })))
     }
 
     /// Fills a previously [`reserve`](Writer::reserve)d object.
     pub fn fill(&mut self, r: ObjRef, obj: Object) -> Result<()> {
-        let unused = (&mut self.slots, r, obj);
-        todo!("fill reserved: {unused:?}")
+        if r.gen != 0 {
+            return Err(Error::Other(format!(
+                "cannot fill {} {} R: this writer only issues generation 0",
+                r.num, r.gen
+            )));
+        }
+        if r.num == 0 || r.num as usize > self.slots.len() {
+            return Err(Error::Other(format!(
+                "cannot fill {} 0 R: this writer never allocated that object number",
+                r.num
+            )));
+        }
+        let slot = &mut self.slots[r.num as usize - 1];
+        if matches!(slot, Slot::Filled(_)) {
+            return Err(Error::AlreadyFilled(r));
+        }
+        *slot = Slot::Filled(obj);
+        Ok(())
+    }
+
+    fn push(&mut self, slot: Slot) -> ObjRef {
+        self.slots.push(slot);
+        ObjRef {
+            num: self.slots.len() as u32,
+            gen: 0,
+        }
     }
 
     /// Registers the document information dictionary for the trailer.
@@ -120,7 +147,616 @@ impl Writer {
     /// registered info dictionary, and a `/ID` pair derived from a
     /// SHA-256 of the emitted body.
     pub fn finish(self, root: ObjRef) -> Result<Vec<u8>> {
-        let unused = (self.options, self.info, root);
-        todo!("finish file: {unused:?}")
+        let Writer {
+            options,
+            slots,
+            info,
+        } = self;
+        let mut bodies = Vec::with_capacity(slots.len());
+        for (index, slot) in slots.into_iter().enumerate() {
+            match slot {
+                Slot::Reserved => {
+                    return Err(Error::Unfilled(ObjRef {
+                        num: index as u32 + 1,
+                        gen: 0,
+                    }))
+                }
+                Slot::Filled(obj) => bodies.push(obj),
+            }
+        }
+        match options.xref {
+            XrefStyle::Table => finish_table(options, &bodies, root, info),
+            XrefStyle::Stream => finish_stream(options, &bodies, root, info),
+        }
+    }
+}
+
+/// Objects a single object stream may hold before the next one starts.
+const OBJSTM_CAPACITY: usize = 200;
+
+/// One cross-reference row for the stream flavor: a top-level object at a
+/// byte offset (type 1) or an object packed into an object stream (type 2).
+#[derive(Clone, Copy)]
+enum Row {
+    Top(u32),
+    Packed { container: u32, index: u16 },
+}
+
+/// Emits the classic-table flavor: bodies, `xref` table, `trailer`
+/// dictionary, `startxref` and `%%EOF`.
+fn finish_table(
+    options: WriteOptions,
+    bodies: &[Object],
+    root: ObjRef,
+    info: Option<ObjRef>,
+) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    write_header(&mut out, options.version);
+    let mut offsets = Vec::with_capacity(bodies.len());
+    for (index, body) in bodies.iter().enumerate() {
+        offsets.push(out.len());
+        write_indirect(&mut out, index as u32 + 1, body)?;
+    }
+    let id = file_id(&out);
+    let xref_off = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", bodies.len() + 1).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f\r\n");
+    for offset in offsets {
+        out.extend_from_slice(format!("{offset:010} 00000 n\r\n").as_bytes());
+    }
+    out.extend_from_slice(b"trailer\n");
+    let trailer = trailer_dict(bodies.len() as i64 + 1, root, info, id);
+    serialize_dict(&trailer, &mut out)?;
+    out.extend_from_slice(format!("\nstartxref\n{xref_off}\n%%EOF").as_bytes());
+    Ok(out)
+}
+
+/// Emits the cross-reference-stream flavor: bodies (non-stream objects
+/// packed into object streams when the option is set), then a `/Type /XRef`
+/// stream as the last object, `startxref` and `%%EOF`. Object numbering is
+/// dense from 0 through the xref stream itself, so `/Index` is never
+/// needed.
+fn finish_stream(
+    options: WriteOptions,
+    bodies: &[Object],
+    root: ObjRef,
+    info: Option<ObjRef>,
+) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    write_header(&mut out, options.version);
+    let user_count = bodies.len() as u32;
+
+    let packed: Vec<u32> = if options.object_streams {
+        bodies
+            .iter()
+            .enumerate()
+            .filter(|(_, body)| !matches!(body, Object::Stream(_)))
+            .map(|(index, _)| index as u32 + 1)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let chunks: Vec<&[u32]> = packed.chunks(OBJSTM_CAPACITY).collect();
+
+    let mut rows: Vec<Row> = vec![Row::Top(0); bodies.len()];
+    for (c, chunk) in chunks.iter().enumerate() {
+        for (index, num) in chunk.iter().enumerate() {
+            rows[*num as usize - 1] = Row::Packed {
+                container: user_count + c as u32 + 1,
+                index: index as u16,
+            };
+        }
+    }
+
+    for (index, body) in bodies.iter().enumerate() {
+        if matches!(rows[index], Row::Packed { .. }) {
+            continue;
+        }
+        rows[index] = Row::Top(field_offset(out.len())?);
+        write_indirect(&mut out, index as u32 + 1, body)?;
+    }
+
+    let mut container_offsets = Vec::with_capacity(chunks.len());
+    for (c, chunk) in chunks.iter().enumerate() {
+        let pairs: Vec<(u32, &Object)> = chunk
+            .iter()
+            .map(|&num| (num, &bodies[num as usize - 1]))
+            .collect();
+        let container = build_objstm(&pairs, options.compress)?;
+        container_offsets.push(field_offset(out.len())?);
+        write_indirect(
+            &mut out,
+            user_count + c as u32 + 1,
+            &Object::Stream(container),
+        )?;
+    }
+
+    let xref_num = user_count + chunks.len() as u32 + 1;
+    let id = file_id(&out);
+    let xref_off = field_offset(out.len())?;
+
+    let mut data = Vec::with_capacity(7 * (xref_num as usize + 1));
+    push_row(&mut data, 0, 0, 65535);
+    for row in rows {
+        match row {
+            Row::Top(offset) => push_row(&mut data, 1, offset, 0),
+            Row::Packed { container, index } => push_row(&mut data, 2, container, index),
+        }
+    }
+    for offset in container_offsets {
+        push_row(&mut data, 1, offset, 0);
+    }
+    push_row(&mut data, 1, xref_off, 0);
+
+    let mut dict = trailer_dict(xref_num as i64 + 1, root, info, id);
+    dict.insert(literal("Type"), Object::Name(literal("XRef")));
+    dict.insert(
+        literal("W"),
+        Object::Array(vec![Object::Int(1), Object::Int(4), Object::Int(2)]),
+    );
+    let data = compress_into(&mut dict, data, options.compress);
+    write_indirect(&mut out, xref_num, &Object::Stream(Stream { dict, data }))?;
+    out.extend_from_slice(format!("startxref\n{xref_off}\n%%EOF").as_bytes());
+    Ok(out)
+}
+
+/// `%PDF-M.m` plus the binary comment marking the file as 8-bit data.
+fn write_header(out: &mut Vec<u8>, version: (u8, u8)) {
+    out.extend_from_slice(format!("%PDF-{}.{}\n", version.0, version.1).as_bytes());
+    out.extend_from_slice(b"%\xE2\xE3\xCF\xD3\n");
+}
+
+/// Emits `num 0 obj` through `endobj`. Every top-level `Object::Stream` —
+/// however it entered the writer — is framed as a stream with a direct
+/// `/Length` of its stored byte count; everything else serializes through
+/// [`crate::ser`].
+fn write_indirect(out: &mut Vec<u8>, num: u32, obj: &Object) -> Result<()> {
+    out.extend_from_slice(format!("{num} 0 obj\n").as_bytes());
+    match obj {
+        Object::Stream(s) => {
+            let mut dict = s.dict.clone();
+            dict.insert(literal("Length"), Object::Int(s.data.len() as i64));
+            serialize_dict(&dict, out)?;
+            out.extend_from_slice(b"\nstream\n");
+            out.extend_from_slice(&s.data);
+            out.extend_from_slice(b"\nendstream");
+        }
+        direct => serialize_object(direct, out)?,
+    }
+    out.extend_from_slice(b"\nendobj\n");
+    Ok(())
+}
+
+/// Serializes one object-stream container from `(num, body)` pairs: `2·N`
+/// header integers, then the bodies, each followed by a space so adjacent
+/// tokens cannot fuse.
+fn build_objstm(pairs: &[(u32, &Object)], compress: bool) -> Result<Stream> {
+    let mut header = Vec::new();
+    let mut payload = Vec::new();
+    for (num, body) in pairs {
+        header.extend_from_slice(format!("{num} {} ", payload.len()).as_bytes());
+        serialize_object(body, &mut payload)?;
+        payload.push(b' ');
+    }
+    let mut dict = Dict::new();
+    dict.insert(literal("Type"), Object::Name(literal("ObjStm")));
+    dict.insert(literal("N"), Object::Int(pairs.len() as i64));
+    dict.insert(literal("First"), Object::Int(header.len() as i64));
+    header.extend_from_slice(&payload);
+    let data = compress_into(&mut dict, header, compress);
+    Ok(Stream { dict, data })
+}
+
+/// The shared trailer entries: `/Size`, `/Root`, the optional `/Info`, and
+/// the `/ID` pair.
+fn trailer_dict(size: i64, root: ObjRef, info: Option<ObjRef>, id: Object) -> Dict {
+    let mut trailer = Dict::new();
+    trailer.insert(literal("Size"), Object::Int(size));
+    trailer.insert(literal("Root"), Object::Ref(root));
+    if let Some(info) = info {
+        trailer.insert(literal("Info"), Object::Ref(info));
+    }
+    trailer.insert(literal("ID"), id);
+    trailer
+}
+
+/// The `/ID` array: two identical 16-byte strings from a SHA-256 of every
+/// byte emitted before the cross-reference.
+fn file_id(emitted: &[u8]) -> Object {
+    let digest = pdfboss_core::crypt::sha256(emitted);
+    let id = Object::String(digest[..16].to_vec());
+    Object::Array(vec![id.clone(), id])
+}
+
+/// Flate-compresses `data` and records `/Filter /FlateDecode` in `dict`
+/// when `compress` is set and the dictionary names no filter of its own;
+/// otherwise the data passes through untouched.
+fn compress_into(dict: &mut Dict, data: Vec<u8>, compress: bool) -> Vec<u8> {
+    if !compress || dict.get("Filter").is_some() {
+        return data;
+    }
+    dict.insert(literal("Filter"), Object::Name(literal("FlateDecode")));
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(&data)
+        .expect("writing into a Vec cannot fail");
+    encoder
+        .finish()
+        .expect("finishing an in-memory zlib stream cannot fail")
+}
+
+/// One `[1 4 2]` cross-reference-stream row.
+fn push_row(rows: &mut Vec<u8>, kind: u8, second: u32, third: u16) {
+    rows.push(kind);
+    rows.extend_from_slice(&second.to_be_bytes());
+    rows.extend_from_slice(&third.to_be_bytes());
+}
+
+/// A byte position as the 4-byte offset field of the cross-reference.
+fn field_offset(position: usize) -> Result<u32> {
+    u32::try_from(position)
+        .map_err(|_| Error::Other("file offset exceeds the 4-byte xref field".to_string()))
+}
+
+/// A `Name` from a string literal.
+fn literal(text: &str) -> Name {
+    Name(text.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use pdfboss_core::xref::load_xref;
+    use pdfboss_core::{Dict, Document, Name, ObjRef, Object, Stream};
+
+    use super::*;
+    use crate::error::Error;
+
+    const CONTENT: &[u8] = b"BT /F1 12 Tf 72 720 Td (Hello, writer) Tj ET";
+
+    fn name(text: &str) -> Name {
+        Name(text.to_string())
+    }
+
+    fn table_options() -> WriteOptions {
+        WriteOptions {
+            xref: XrefStyle::Table,
+            compress: false,
+            object_streams: false,
+            version: (1, 7),
+        }
+    }
+
+    fn stream_options() -> WriteOptions {
+        WriteOptions {
+            xref: XrefStyle::Stream,
+            compress: false,
+            object_streams: false,
+            version: (1, 5),
+        }
+    }
+
+    fn objstm_options() -> WriteOptions {
+        WriteOptions {
+            xref: XrefStyle::Stream,
+            compress: true,
+            object_streams: true,
+            version: (1, 7),
+        }
+    }
+
+    struct Refs {
+        content: ObjRef,
+        pages: ObjRef,
+        page: ObjRef,
+        root: ObjRef,
+    }
+
+    fn page_dict(pages: ObjRef, content: ObjRef) -> Dict {
+        let mut page = Dict::new();
+        page.insert(name("Type"), Object::Name(name("Page")));
+        page.insert(name("Parent"), Object::Ref(pages));
+        page.insert(
+            name("MediaBox"),
+            Object::Array(vec![
+                Object::Int(0),
+                Object::Int(0),
+                Object::Int(612),
+                Object::Int(792),
+            ]),
+        );
+        page.insert(name("Contents"), Object::Ref(content));
+        page
+    }
+
+    /// Builds a one-page document around the given content stream, going
+    /// through `put_stream_raw` when `raw` is set.
+    fn skeleton(
+        options: WriteOptions,
+        content_dict: Dict,
+        content_data: Vec<u8>,
+        raw: bool,
+    ) -> (Vec<u8>, Refs) {
+        let mut w = Writer::new(options);
+        let content = if raw {
+            w.put_stream_raw(content_dict, content_data)
+        } else {
+            w.put_stream(content_dict, content_data)
+        };
+        let pages = w.reserve();
+        let page = w.put(Object::Dict(page_dict(pages, content)));
+        let mut tree = Dict::new();
+        tree.insert(name("Type"), Object::Name(name("Pages")));
+        tree.insert(name("Kids"), Object::Array(vec![Object::Ref(page)]));
+        tree.insert(name("Count"), Object::Int(1));
+        w.fill(pages, Object::Dict(tree))
+            .expect("pages slot is fillable");
+        let mut catalog = Dict::new();
+        catalog.insert(name("Type"), Object::Name(name("Catalog")));
+        catalog.insert(name("Pages"), Object::Ref(pages));
+        let root = w.put(Object::Dict(catalog));
+        let bytes = w.finish(root).expect("minimal document finishes");
+        (
+            bytes,
+            Refs {
+                content,
+                pages,
+                page,
+                root,
+            },
+        )
+    }
+
+    fn minimal_pdf(options: WriteOptions) -> (Vec<u8>, Refs) {
+        skeleton(options, Dict::new(), CONTENT.to_vec(), false)
+    }
+
+    fn assert_minimal_loads(bytes: &[u8], refs: &Refs) -> Document {
+        let doc = Document::load(bytes.to_vec()).expect("document loads");
+        assert_eq!(doc.page_count(), 1);
+        let page = doc.page(0).expect("page 0 exists");
+        assert_eq!(page.object_ref(), Some(refs.page));
+        assert_eq!(page.dict(), &page_dict(refs.pages, refs.content));
+        assert_eq!(page.content(&doc).expect("content decodes"), CONTENT);
+        doc
+    }
+
+    fn count_occurrences(haystack: &[u8], needle: &[u8]) -> usize {
+        haystack
+            .windows(needle.len())
+            .filter(|window| *window == needle)
+            .count()
+    }
+
+    #[test]
+    fn table_mode_minimal_document_loads() {
+        let (bytes, refs) = minimal_pdf(table_options());
+        assert!(bytes.starts_with(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n"));
+        assert!(bytes.ends_with(b"%%EOF"));
+        assert_eq!(count_occurrences(&bytes, b"xref\n0 5\n"), 1);
+        assert_eq!(count_occurrences(&bytes, b"0000000000 65535 f\r\n"), 1);
+        assert_eq!(count_occurrences(&bytes, b"trailer\n"), 1);
+        assert_minimal_loads(&bytes, &refs);
+    }
+
+    #[test]
+    fn table_mode_ignores_object_streams_option() {
+        let options = WriteOptions {
+            object_streams: true,
+            ..table_options()
+        };
+        let (bytes, refs) = minimal_pdf(options);
+        assert_eq!(count_occurrences(&bytes, b"/ObjStm"), 0);
+        assert_minimal_loads(&bytes, &refs);
+    }
+
+    #[test]
+    fn stream_mode_minimal_document_loads() {
+        let (bytes, refs) = minimal_pdf(stream_options());
+        assert!(bytes.starts_with(b"%PDF-1.5\n%\xE2\xE3\xCF\xD3\n"));
+        assert!(bytes.ends_with(b"%%EOF"));
+        assert_eq!(count_occurrences(&bytes, b"/ObjStm"), 0);
+        assert_eq!(count_occurrences(&bytes, b"/XRef"), 1);
+        assert_minimal_loads(&bytes, &refs);
+    }
+
+    #[test]
+    fn object_streams_pack_and_resolve() {
+        let (bytes, refs) = minimal_pdf(objstm_options());
+        assert_eq!(count_occurrences(&bytes, b"/ObjStm"), 1);
+        let doc = assert_minimal_loads(&bytes, &refs);
+        let root = doc
+            .resolve(&Object::Ref(refs.root))
+            .expect("catalog resolves");
+        let catalog = root.as_dict().expect("catalog is a dictionary");
+        assert_eq!(catalog.get_name("Type"), Some(&name("Catalog")));
+        assert_eq!(catalog.get_ref("Pages"), Some(refs.pages));
+    }
+
+    #[test]
+    fn object_streams_chunk_at_two_hundred() {
+        let options = WriteOptions {
+            compress: false,
+            ..objstm_options()
+        };
+        let mut w = Writer::new(options);
+        let content = w.put_stream(Dict::new(), CONTENT.to_vec());
+        let int_refs: Vec<ObjRef> = (0..205).map(|i| w.put(Object::Int(i))).collect();
+        let pages = w.reserve();
+        let page = w.put(Object::Dict(page_dict(pages, content)));
+        let mut tree = Dict::new();
+        tree.insert(name("Type"), Object::Name(name("Pages")));
+        tree.insert(name("Kids"), Object::Array(vec![Object::Ref(page)]));
+        tree.insert(name("Count"), Object::Int(1));
+        w.fill(pages, Object::Dict(tree))
+            .expect("pages slot is fillable");
+        let mut catalog = Dict::new();
+        catalog.insert(name("Type"), Object::Name(name("Catalog")));
+        catalog.insert(name("Pages"), Object::Ref(pages));
+        let root = w.put(Object::Dict(catalog));
+        let bytes = w.finish(root).expect("document finishes");
+        assert_eq!(count_occurrences(&bytes, b"/ObjStm"), 2);
+        let doc = Document::load(bytes).expect("document loads");
+        assert_eq!(
+            doc.resolve(&Object::Ref(int_refs[0])).expect("resolves"),
+            Object::Int(0)
+        );
+        assert_eq!(
+            doc.resolve(&Object::Ref(int_refs[204])).expect("resolves"),
+            Object::Int(204)
+        );
+        assert_eq!(doc.page_count(), 1);
+    }
+
+    #[test]
+    fn refs_ascend_from_one_in_call_order() {
+        let mut w = Writer::new(table_options());
+        assert_eq!(w.put(Object::Null), ObjRef { num: 1, gen: 0 });
+        assert_eq!(w.reserve(), ObjRef { num: 2, gen: 0 });
+        assert_eq!(
+            w.put_stream(Dict::new(), Vec::new()),
+            ObjRef { num: 3, gen: 0 }
+        );
+        assert_eq!(
+            w.put_stream_raw(Dict::new(), Vec::new()),
+            ObjRef { num: 4, gen: 0 }
+        );
+    }
+
+    #[test]
+    fn fill_twice_reports_already_filled() {
+        let mut w = Writer::new(table_options());
+        let r = w.reserve();
+        w.fill(r, Object::Int(1)).expect("first fill lands");
+        match w.fill(r, Object::Int(2)) {
+            Err(Error::AlreadyFilled(seen)) => assert_eq!(seen, r),
+            other => panic!("expected AlreadyFilled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fill_rejects_foreign_and_wrong_generation_refs() {
+        let mut w = Writer::new(table_options());
+        let r = w.reserve();
+        let unallocated = w.fill(ObjRef { num: 99, gen: 0 }, Object::Null);
+        assert!(matches!(unallocated, Err(Error::Other(msg)) if msg.contains("99")));
+        let zero = w.fill(ObjRef { num: 0, gen: 0 }, Object::Null);
+        assert!(matches!(zero, Err(Error::Other(msg)) if !msg.is_empty()));
+        let wrong_gen = w.fill(ObjRef { num: r.num, gen: 1 }, Object::Null);
+        assert!(matches!(wrong_gen, Err(Error::Other(msg)) if msg.contains("generation")));
+    }
+
+    #[test]
+    fn finish_with_unfilled_reserve_reports_the_ref() {
+        let mut w = Writer::new(table_options());
+        let root = w.put(Object::Dict(Dict::new()));
+        let reserved = w.reserve();
+        match w.finish(root) {
+            Err(Error::Unfilled(seen)) => assert_eq!(seen, reserved),
+            other => panic!("expected Unfilled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_stream_surfaces_from_finish() {
+        for options in [table_options(), objstm_options()] {
+            let mut w = Writer::new(options);
+            let root = w.put(Object::Array(vec![Object::Stream(Stream {
+                dict: Dict::new(),
+                data: b"x".to_vec(),
+            })]));
+            assert!(matches!(w.finish(root), Err(Error::NestedStream)));
+        }
+    }
+
+    #[test]
+    fn compressed_stream_round_trips() {
+        let options = WriteOptions {
+            compress: true,
+            ..table_options()
+        };
+        let data: Vec<u8> = b"q 0.5 0 0 0.5 36 36 cm Q\n".repeat(40);
+        let (bytes, refs) = skeleton(options, Dict::new(), data.clone(), false);
+        let doc = Document::load(bytes).expect("document loads");
+        let resolved = doc
+            .resolve(&Object::Ref(refs.content))
+            .expect("content stream resolves");
+        let stream = resolved.as_stream().expect("content is a stream");
+        assert_eq!(stream.dict.get_name("Filter"), Some(&name("FlateDecode")));
+        assert_eq!(
+            stream.dict.get_int("Length"),
+            Some(stream.data.len() as i64)
+        );
+        assert!(stream.data.len() < data.len());
+        assert_eq!(doc.stream_data(stream).expect("stream decodes"), data);
+    }
+
+    #[test]
+    fn preset_filter_is_not_recompressed() {
+        let options = WriteOptions {
+            compress: true,
+            ..table_options()
+        };
+        let payload = b"Hello writer";
+        let encoded: Vec<u8> = payload
+            .iter()
+            .flat_map(|b| format!("{b:02X}").into_bytes())
+            .chain(*b">")
+            .collect();
+        let mut dict = Dict::new();
+        dict.insert(name("Filter"), Object::Name(name("ASCIIHexDecode")));
+        let (bytes, refs) = skeleton(options, dict, encoded.clone(), false);
+        let doc = Document::load(bytes).expect("document loads");
+        let resolved = doc
+            .resolve(&Object::Ref(refs.content))
+            .expect("content stream resolves");
+        let stream = resolved.as_stream().expect("content is a stream");
+        assert_eq!(stream.data, encoded, "pre-filtered data stays untouched");
+        assert_eq!(
+            stream.dict.get_name("Filter"),
+            Some(&name("ASCIIHexDecode"))
+        );
+        assert_eq!(doc.stream_data(stream).expect("stream decodes"), payload);
+    }
+
+    #[test]
+    fn put_stream_raw_never_compresses() {
+        let options = WriteOptions {
+            compress: true,
+            ..table_options()
+        };
+        let (bytes, refs) = skeleton(options, Dict::new(), CONTENT.to_vec(), true);
+        let doc = Document::load(bytes).expect("document loads");
+        let resolved = doc
+            .resolve(&Object::Ref(refs.content))
+            .expect("content stream resolves");
+        let stream = resolved.as_stream().expect("content is a stream");
+        assert_eq!(stream.data, CONTENT);
+        assert!(stream.dict.get("Filter").is_none());
+        assert_eq!(stream.dict.get_int("Length"), Some(CONTENT.len() as i64));
+    }
+
+    #[test]
+    fn id_pair_is_present_and_identical() {
+        for options in [table_options(), stream_options(), objstm_options()] {
+            let (bytes, refs) = minimal_pdf(options);
+            assert_eq!(refs.root.gen, 0);
+            let xref = load_xref(&bytes).expect("xref loads");
+            let id = xref.trailer.get_array("ID").expect("/ID array present");
+            assert_eq!(id.len(), 2);
+            let first = id[0].as_str_bytes().expect("/ID entry is a string");
+            let second = id[1].as_str_bytes().expect("/ID entry is a string");
+            assert_eq!(first.len(), 16);
+            assert_eq!(first, second);
+        }
+    }
+
+    #[test]
+    fn output_is_deterministic() {
+        for options in [table_options(), stream_options(), objstm_options()] {
+            let (first, refs) = minimal_pdf(options);
+            let (second, again) = minimal_pdf(options);
+            assert_eq!(refs.content, again.content);
+            assert_eq!(first, second, "options {options:?} must be deterministic");
+        }
     }
 }

--- a/crates/pdfboss-write/src/writer.rs
+++ b/crates/pdfboss-write/src/writer.rs
@@ -1,0 +1,126 @@
+//! The object-level PDF writer: numbered objects in, finished file bytes
+//! out. Handles the header, stream `/Length` bookkeeping, optional Flate
+//! compression, object streams, both cross-reference styles, the trailer
+//! and a deterministic `/ID`.
+//!
+//! Determinism contract: the same sequence of calls with the same options
+//! produces byte-identical output. Nothing here reads clocks or RNGs; the
+//! `/ID` derives from a SHA-256 of the emitted body.
+
+use pdfboss_core::{Dict, ObjRef, Object};
+
+use crate::error::Result;
+
+/// Which cross-reference flavor `finish` emits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum XrefStyle {
+    /// A classic `xref` table with a `trailer` dictionary (readable by
+    /// PDF 1.0-era consumers).
+    Table,
+    /// A cross-reference stream (`/Type /XRef`, PDF 1.5+), the compact
+    /// modern form.
+    #[default]
+    Stream,
+}
+
+/// Options governing file emission.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WriteOptions {
+    /// Cross-reference flavor. Object streams require [`XrefStyle::Stream`].
+    pub xref: XrefStyle,
+    /// Flate-compress stream data that carries no filter of its own.
+    pub compress: bool,
+    /// Pack non-stream objects into object streams (only effective with
+    /// [`XrefStyle::Stream`]).
+    pub object_streams: bool,
+    /// PDF version written in the header.
+    pub version: (u8, u8),
+}
+
+impl Default for WriteOptions {
+    fn default() -> WriteOptions {
+        WriteOptions {
+            xref: XrefStyle::Stream,
+            compress: true,
+            object_streams: true,
+            version: (1, 7),
+        }
+    }
+}
+
+/// Accumulates numbered objects and serializes them into a complete PDF
+/// file. Objects are numbered in the order they are first claimed
+/// (`put`, `put_stream`, or `reserve`), starting at 1, generation 0.
+#[derive(Debug)]
+pub struct Writer {
+    options: WriteOptions,
+    slots: Vec<Slot>,
+    info: Option<ObjRef>,
+}
+
+/// One numbered object: reserved, or holding its body.
+#[derive(Debug)]
+enum Slot {
+    Reserved,
+    Filled(Object),
+}
+
+impl Writer {
+    /// Creates a writer with the given options.
+    pub fn new(options: WriteOptions) -> Writer {
+        Writer {
+            options,
+            slots: Vec::new(),
+            info: None,
+        }
+    }
+
+    /// Claims an object number now to be filled later — for cycles like
+    /// the page tree, where children point at a parent not yet built.
+    pub fn reserve(&mut self) -> ObjRef {
+        todo!("reserve slot {}", self.slots.len())
+    }
+
+    /// Adds a complete object and returns its reference.
+    pub fn put(&mut self, obj: Object) -> ObjRef {
+        let unused = (&mut self.slots, obj);
+        todo!("put object: {unused:?}")
+    }
+
+    /// Adds a stream object. `/Length` is computed on emission; when
+    /// [`WriteOptions::compress`] is set and `dict` names no `/Filter`,
+    /// the data is Flate-compressed and `/Filter /FlateDecode` added.
+    pub fn put_stream(&mut self, dict: Dict, data: Vec<u8>) -> ObjRef {
+        let unused = (&mut self.slots, dict, data);
+        todo!("put stream: {unused:?}")
+    }
+
+    /// Adds a stream object without touching its filters — for data that
+    /// is already encoded (e.g. a JPEG passed through as `/DCTDecode`,
+    /// with `/Filter` set by the caller). `/Length` is still computed.
+    pub fn put_stream_raw(&mut self, dict: Dict, data: Vec<u8>) -> ObjRef {
+        let unused = (&mut self.slots, dict, data);
+        todo!("put raw stream: {unused:?}")
+    }
+
+    /// Fills a previously [`reserve`](Writer::reserve)d object.
+    pub fn fill(&mut self, r: ObjRef, obj: Object) -> Result<()> {
+        let unused = (&mut self.slots, r, obj);
+        todo!("fill reserved: {unused:?}")
+    }
+
+    /// Registers the document information dictionary for the trailer.
+    pub fn set_info(&mut self, info: ObjRef) {
+        self.info = Some(info);
+    }
+
+    /// Serializes everything into a complete PDF file: header with binary
+    /// comment, all objects (packed into object streams where options
+    /// allow), the cross-reference, and the trailer with `root`, the
+    /// registered info dictionary, and a `/ID` pair derived from a
+    /// SHA-256 of the emitted body.
+    pub fn finish(self, root: ObjRef) -> Result<Vec<u8>> {
+        let unused = (self.options, self.info, root);
+        todo!("finish file: {unused:?}")
+    }
+}

--- a/crates/pdfboss-write/src/writer.rs
+++ b/crates/pdfboss-write/src/writer.rs
@@ -11,10 +11,12 @@ use std::io::Write;
 
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
-use pdfboss_core::{Dict, Name, ObjRef, Object, Stream};
+use pdfboss_core::crypt::Sha256;
+use pdfboss_core::{block_on, Dict, Name, ObjRef, Object, Stream};
 
 use crate::error::{Error, Result};
 use crate::ser::{serialize_dict, serialize_object};
+use crate::sink::{AsyncByteSink, Immediate};
 
 /// Which cross-reference flavor `finish` emits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -147,6 +149,25 @@ impl Writer {
     /// registered info dictionary, and a `/ID` pair derived from a
     /// SHA-256 of the emitted body.
     pub fn finish(self, root: ObjRef) -> Result<Vec<u8>> {
+        block_on(self.finish_into_with(root, Vec::new()))
+    }
+
+    /// [`Writer::finish`] streaming into a [`std::io::Write`]: the same
+    /// bytes, delivered in bounded chunks, so the whole file never sits in
+    /// one buffer. Unlike `finish`, an error can leave a prefix of the
+    /// file already written to `out`. No flush is performed.
+    pub fn finish_into(self, root: ObjRef, out: impl Write) -> Result<()> {
+        block_on(self.finish_into_with(root, Immediate(out)))?;
+        Ok(())
+    }
+
+    /// [`Writer::finish`] streaming into any [`AsyncByteSink`] — the
+    /// asynchronous twin of [`Writer::finish_into`], and the one emission
+    /// implementation all three finishes drive. Bytes arrive in bounded
+    /// chunks (per header, object and cross-reference section; a stream's
+    /// data is its own chunk). An error can leave a prefix of the file
+    /// already written. Hands the sink back unflushed.
+    pub async fn finish_into_with<S: AsyncByteSink>(self, root: ObjRef, sink: S) -> Result<S> {
         let Writer {
             options,
             slots,
@@ -164,10 +185,45 @@ impl Writer {
                 Slot::Filled(obj) => bodies.push(obj),
             }
         }
+        let mut emit = Emit::new(sink);
         match options.xref {
-            XrefStyle::Table => finish_table(options, &bodies, root, info),
-            XrefStyle::Stream => finish_stream(options, &bodies, root, info),
+            XrefStyle::Table => emit_table(options, &bodies, root, info, &mut emit).await?,
+            XrefStyle::Stream => emit_stream(options, &bodies, root, info, &mut emit).await?,
         }
+        Ok(emit.sink)
+    }
+}
+
+/// Counts and hashes every byte on its way to the sink: cross-reference
+/// offsets come from `count` and the `/ID` digest from `hasher`, so
+/// emission never needs the finished file in one buffer.
+struct Emit<S> {
+    sink: S,
+    count: usize,
+    hasher: Sha256,
+}
+
+impl<S: AsyncByteSink> Emit<S> {
+    fn new(sink: S) -> Emit<S> {
+        Emit {
+            sink,
+            count: 0,
+            hasher: Sha256::new(),
+        }
+    }
+
+    async fn write(&mut self, bytes: &[u8]) -> Result<()> {
+        self.hasher.update(bytes);
+        self.count += bytes.len();
+        self.sink.write_all(bytes).await
+    }
+
+    /// The `/ID` array at this point of emission: two identical 16-byte
+    /// strings from a SHA-256 of every byte written so far.
+    fn file_id(&self) -> Object {
+        let digest = self.hasher.clone().finalize();
+        let id = Object::String(digest[..16].to_vec());
+        Object::Array(vec![id.clone(), id])
     }
 }
 
@@ -184,31 +240,33 @@ enum Row {
 
 /// Emits the classic-table flavor: bodies, `xref` table, `trailer`
 /// dictionary, `startxref` and `%%EOF`.
-fn finish_table(
+async fn emit_table<S: AsyncByteSink>(
     options: WriteOptions,
     bodies: &[Object],
     root: ObjRef,
     info: Option<ObjRef>,
-) -> Result<Vec<u8>> {
-    let mut out = Vec::new();
-    write_header(&mut out, options.version);
+    emit: &mut Emit<S>,
+) -> Result<()> {
+    let mut head = Vec::new();
+    write_header(&mut head, options.version);
+    emit.write(&head).await?;
     let mut offsets = Vec::with_capacity(bodies.len());
     for (index, body) in bodies.iter().enumerate() {
-        offsets.push(out.len());
-        write_indirect(&mut out, index as u32 + 1, body)?;
+        offsets.push(emit.count);
+        write_indirect(emit, index as u32 + 1, body).await?;
     }
-    let id = file_id(&out);
-    let xref_off = out.len();
-    out.extend_from_slice(format!("xref\n0 {}\n", bodies.len() + 1).as_bytes());
-    out.extend_from_slice(b"0000000000 65535 f\r\n");
+    let id = emit.file_id();
+    let xref_off = emit.count;
+    let mut section = format!("xref\n0 {}\n", bodies.len() + 1).into_bytes();
+    section.extend_from_slice(b"0000000000 65535 f\r\n");
     for offset in offsets {
-        out.extend_from_slice(format!("{offset:010} 00000 n\r\n").as_bytes());
+        section.extend_from_slice(format!("{offset:010} 00000 n\r\n").as_bytes());
     }
-    out.extend_from_slice(b"trailer\n");
+    section.extend_from_slice(b"trailer\n");
     let trailer = trailer_dict(bodies.len() as i64 + 1, root, info, id);
-    serialize_dict(&trailer, &mut out)?;
-    out.extend_from_slice(format!("\nstartxref\n{xref_off}\n%%EOF").as_bytes());
-    Ok(out)
+    serialize_dict(&trailer, &mut section)?;
+    section.extend_from_slice(format!("\nstartxref\n{xref_off}\n%%EOF").as_bytes());
+    emit.write(&section).await
 }
 
 /// Emits the cross-reference-stream flavor: bodies (non-stream objects
@@ -216,14 +274,16 @@ fn finish_table(
 /// stream as the last object, `startxref` and `%%EOF`. Object numbering is
 /// dense from 0 through the xref stream itself, so `/Index` is never
 /// needed.
-fn finish_stream(
+async fn emit_stream<S: AsyncByteSink>(
     options: WriteOptions,
     bodies: &[Object],
     root: ObjRef,
     info: Option<ObjRef>,
-) -> Result<Vec<u8>> {
-    let mut out = Vec::new();
-    write_header(&mut out, options.version);
+    emit: &mut Emit<S>,
+) -> Result<()> {
+    let mut head = Vec::new();
+    write_header(&mut head, options.version);
+    emit.write(&head).await?;
     let user_count = bodies.len() as u32;
 
     let packed: Vec<u32> = if options.object_streams {
@@ -252,8 +312,8 @@ fn finish_stream(
         if matches!(rows[index], Row::Packed { .. }) {
             continue;
         }
-        rows[index] = Row::Top(field_offset(out.len())?);
-        write_indirect(&mut out, index as u32 + 1, body)?;
+        rows[index] = Row::Top(field_offset(emit.count)?);
+        write_indirect(emit, index as u32 + 1, body).await?;
     }
 
     let mut container_offsets = Vec::with_capacity(chunks.len());
@@ -263,17 +323,13 @@ fn finish_stream(
             .map(|&num| (num, &bodies[num as usize - 1]))
             .collect();
         let container = build_objstm(&pairs, options.compress)?;
-        container_offsets.push(field_offset(out.len())?);
-        write_indirect(
-            &mut out,
-            user_count + c as u32 + 1,
-            &Object::Stream(container),
-        )?;
+        container_offsets.push(field_offset(emit.count)?);
+        write_indirect(emit, user_count + c as u32 + 1, &Object::Stream(container)).await?;
     }
 
     let xref_num = user_count + chunks.len() as u32 + 1;
-    let id = file_id(&out);
-    let xref_off = field_offset(out.len())?;
+    let id = emit.file_id();
+    let xref_off = field_offset(emit.count)?;
 
     let mut data = Vec::with_capacity(7 * (xref_num as usize + 1));
     push_row(&mut data, 0, 0, 65535);
@@ -295,9 +351,9 @@ fn finish_stream(
         Object::Array(vec![Object::Int(1), Object::Int(4), Object::Int(2)]),
     );
     let data = compress_into(&mut dict, data, options.compress);
-    write_indirect(&mut out, xref_num, &Object::Stream(Stream { dict, data }))?;
-    out.extend_from_slice(format!("startxref\n{xref_off}\n%%EOF").as_bytes());
-    Ok(out)
+    write_indirect(emit, xref_num, &Object::Stream(Stream { dict, data })).await?;
+    emit.write(format!("startxref\n{xref_off}\n%%EOF").as_bytes())
+        .await
 }
 
 /// `%PDF-M.m` plus the binary comment marking the file as 8-bit data.
@@ -309,22 +365,30 @@ fn write_header(out: &mut Vec<u8>, version: (u8, u8)) {
 /// Emits `num 0 obj` through `endobj`. Every top-level `Object::Stream` —
 /// however it entered the writer — is framed as a stream with a direct
 /// `/Length` of its stored byte count; everything else serializes through
-/// [`crate::ser`].
-fn write_indirect(out: &mut Vec<u8>, num: u32, obj: &Object) -> Result<()> {
-    out.extend_from_slice(format!("{num} 0 obj\n").as_bytes());
+/// [`crate::ser`]. A stream's data goes to the sink as its own chunk,
+/// borrowed rather than copied; everything else is one chunk per object.
+async fn write_indirect<S: AsyncByteSink>(
+    emit: &mut Emit<S>,
+    num: u32,
+    obj: &Object,
+) -> Result<()> {
+    let mut lead = format!("{num} 0 obj\n").into_bytes();
     match obj {
         Object::Stream(s) => {
             let mut dict = s.dict.clone();
             dict.insert(literal("Length"), Object::Int(s.data.len() as i64));
-            serialize_dict(&dict, out)?;
-            out.extend_from_slice(b"\nstream\n");
-            out.extend_from_slice(&s.data);
-            out.extend_from_slice(b"\nendstream");
+            serialize_dict(&dict, &mut lead)?;
+            lead.extend_from_slice(b"\nstream\n");
+            emit.write(&lead).await?;
+            emit.write(&s.data).await?;
+            emit.write(b"\nendstream\nendobj\n").await
         }
-        direct => serialize_object(direct, out)?,
+        direct => {
+            serialize_object(direct, &mut lead)?;
+            lead.extend_from_slice(b"\nendobj\n");
+            emit.write(&lead).await
+        }
     }
-    out.extend_from_slice(b"\nendobj\n");
-    Ok(())
 }
 
 /// Serializes one object-stream container from `(num, body)` pairs: `2·N`
@@ -358,14 +422,6 @@ fn trailer_dict(size: i64, root: ObjRef, info: Option<ObjRef>, id: Object) -> Di
     }
     trailer.insert(literal("ID"), id);
     trailer
-}
-
-/// The `/ID` array: two identical 16-byte strings from a SHA-256 of every
-/// byte emitted before the cross-reference.
-fn file_id(emitted: &[u8]) -> Object {
-    let digest = pdfboss_core::crypt::sha256(emitted);
-    let id = Object::String(digest[..16].to_vec());
-    Object::Array(vec![id.clone(), id])
 }
 
 /// Flate-compresses `data` and records `/Filter /FlateDecode` in `dict`
@@ -468,14 +524,14 @@ mod tests {
         page
     }
 
-    /// Builds a one-page document around the given content stream, going
-    /// through `put_stream_raw` when `raw` is set.
-    fn skeleton(
+    /// Builds a one-page document around the given content stream without
+    /// finishing it, going through `put_stream_raw` when `raw` is set.
+    fn build(
         options: WriteOptions,
         content_dict: Dict,
         content_data: Vec<u8>,
         raw: bool,
-    ) -> (Vec<u8>, Refs) {
+    ) -> (Writer, Refs) {
         let mut w = Writer::new(options);
         let content = if raw {
             w.put_stream_raw(content_dict, content_data)
@@ -494,9 +550,8 @@ mod tests {
         catalog.insert(name("Type"), Object::Name(name("Catalog")));
         catalog.insert(name("Pages"), Object::Ref(pages));
         let root = w.put(Object::Dict(catalog));
-        let bytes = w.finish(root).expect("minimal document finishes");
         (
-            bytes,
+            w,
             Refs {
                 content,
                 pages,
@@ -504,6 +559,18 @@ mod tests {
                 root,
             },
         )
+    }
+
+    /// [`build`], finished into bytes.
+    fn skeleton(
+        options: WriteOptions,
+        content_dict: Dict,
+        content_data: Vec<u8>,
+        raw: bool,
+    ) -> (Vec<u8>, Refs) {
+        let (w, refs) = build(options, content_dict, content_data, raw);
+        let bytes = w.finish(refs.root).expect("minimal document finishes");
+        (bytes, refs)
     }
 
     fn minimal_pdf(options: WriteOptions) -> (Vec<u8>, Refs) {
@@ -757,6 +824,98 @@ mod tests {
             let (second, again) = minimal_pdf(options);
             assert_eq!(refs.content, again.content);
             assert_eq!(first, second, "options {options:?} must be deterministic");
+        }
+    }
+
+    #[test]
+    fn finish_into_matches_finish() {
+        for options in [table_options(), stream_options(), objstm_options()] {
+            let (bytes, _) = minimal_pdf(options);
+            let (w, refs) = build(options, Dict::new(), CONTENT.to_vec(), false);
+            let mut out = Vec::new();
+            w.finish_into(refs.root, &mut out)
+                .expect("finish_into succeeds");
+            assert_eq!(out, bytes, "options {options:?}");
+        }
+    }
+
+    #[test]
+    fn finish_into_with_matches_finish() {
+        for options in [table_options(), stream_options(), objstm_options()] {
+            let (bytes, _) = minimal_pdf(options);
+            let (w, refs) = build(options, Dict::new(), CONTENT.to_vec(), false);
+            let sink = pdfboss_core::block_on(w.finish_into_with(refs.root, Vec::new()))
+                .expect("finish_into_with succeeds");
+            assert_eq!(sink, bytes, "options {options:?}");
+        }
+    }
+
+    /// Records every chunk it is handed, so tests can see how emission
+    /// arrives — the write happens eagerly, the future is already complete.
+    struct Recording {
+        chunks: Vec<Vec<u8>>,
+    }
+
+    impl crate::sink::AsyncByteSink for Recording {
+        fn write_all<'a>(
+            &'a mut self,
+            buf: &'a [u8],
+        ) -> pdfboss_core::source::BoxFuture<'a, Result<()>> {
+            self.chunks.push(buf.to_vec());
+            Box::pin(std::future::ready(Ok(())))
+        }
+    }
+
+    /// Emission must actually stream: many bounded chunks, never one
+    /// whole-file buffer — and their concatenation must be the `finish`
+    /// bytes exactly.
+    #[test]
+    fn emission_arrives_in_bounded_chunks() {
+        for options in [table_options(), stream_options(), objstm_options()] {
+            let (bytes, _) = minimal_pdf(options);
+            let (w, refs) = build(options, Dict::new(), CONTENT.to_vec(), false);
+            let sink = pdfboss_core::block_on(
+                w.finish_into_with(refs.root, Recording { chunks: Vec::new() }),
+            )
+            .expect("finish_into_with succeeds");
+            assert_eq!(sink.chunks.concat(), bytes, "options {options:?}");
+            assert!(
+                sink.chunks.len() > 3,
+                "options {options:?}: emission must arrive in many chunks, got {}",
+                sink.chunks.len()
+            );
+            assert!(
+                sink.chunks.iter().all(|chunk| chunk.len() < bytes.len()),
+                "options {options:?}: no chunk may be the whole file"
+            );
+        }
+    }
+
+    /// The emission future over an owned sink must be `Send + 'static`,
+    /// so it can cross a runtime's `spawn` — the write-side counterpart of
+    /// the source module's by-value rule.
+    #[test]
+    fn finish_into_with_over_an_owned_sink_is_spawnable() {
+        fn assert_send_static<F: std::future::Future + Send + 'static>(_: &F) {}
+
+        let (w, refs) = build(stream_options(), Dict::new(), CONTENT.to_vec(), false);
+        let future = w.finish_into_with(refs.root, Vec::new());
+        assert_send_static(&future);
+        let bytes = pdfboss_core::block_on(future).expect("emission succeeds");
+        assert!(bytes.ends_with(b"%%EOF"));
+    }
+
+    /// An unfilled reserve must surface from the streaming finishes too,
+    /// before any byte reaches the sink.
+    #[test]
+    fn finish_into_with_reports_unfilled_reserves() {
+        let mut w = Writer::new(table_options());
+        let root = w.put(Object::Dict(Dict::new()));
+        let reserved = w.reserve();
+        let sink = Recording { chunks: Vec::new() };
+        match pdfboss_core::block_on(w.finish_into_with(root, sink)) {
+            Err(Error::Unfilled(seen)) => assert_eq!(seen, reserved),
+            other => panic!("expected Unfilled, got {:?}", other.map(|s| s.chunks.len())),
         }
     }
 }

--- a/crates/pdfboss-write/tests/roundtrip.rs
+++ b/crates/pdfboss-write/tests/roundtrip.rs
@@ -1,0 +1,260 @@
+//! Oracle round-trip suite: documents built with `pdfboss-write` are read
+//! back through `pdfboss-core`, extracted with `pdfboss-output` and
+//! rasterized with `pdfboss-render`, so the writer is verified against the
+//! toolkit's own readers rather than against expected byte dumps.
+
+use pdfboss_core::{Document, Name, Rect};
+use pdfboss_output::extract_text;
+use pdfboss_render::{render_page_reporting, RenderOptions};
+use pdfboss_write::{
+    Color, Date, Error, ImageData, Metadata, Page, PageSize, Pdf, Standard14, WriteOptions,
+    XrefStyle,
+};
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
+
+#[test]
+fn hello_single_page_round_trips() {
+    let mut page = Page::new(PageSize::A4);
+    page.canvas
+        .text("Hello, world!", 72.0, 770.0, Standard14::Helvetica, 24.0)
+        .unwrap();
+    let bytes = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    assert_eq!(doc.page_count(), 1);
+    let loaded = doc.page(0).unwrap();
+    assert_eq!(loaded.media_box, Rect::new(0.0, 0.0, 595.28, 841.89));
+    let text = extract_text(&doc, &loaded).unwrap();
+    assert!(text.contains("Hello, world!"), "extracted: {text:?}");
+}
+
+#[test]
+fn metadata_and_multipage_round_trip() {
+    let mut second = Page::new(PageSize::A5);
+    second.rotation = 90;
+    let pdf = Pdf {
+        metadata: Some(Metadata {
+            title: Some("Résumé".into()),
+            author: Some("pdfboss".into()),
+            creation_date: Some(Date {
+                year: 2026,
+                month: 8,
+                day: 27,
+                hour: 12,
+                minute: 30,
+                second: 15,
+                utc_offset_minutes: 0,
+            }),
+            ..Metadata::default()
+        }),
+        pages: vec![Page::new(PageSize::A4), second, Page::new(PageSize::Letter)],
+        options: WriteOptions::default(),
+    };
+    let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
+    assert_eq!(doc.page_count(), 3);
+    let meta = doc.metadata();
+    assert_eq!(meta.title.as_deref(), Some("Résumé"));
+    assert_eq!(meta.author.as_deref(), Some("pdfboss"));
+    assert_eq!(meta.creation_date.as_deref(), Some("D:20260827123015Z"));
+    let first = doc.page(0).unwrap();
+    assert_eq!(first.media_box, Rect::new(0.0, 0.0, 595.28, 841.89));
+    assert_eq!(first.rotate, 0);
+    let rotated = doc.page(1).unwrap();
+    assert_eq!(rotated.media_box, Rect::new(0.0, 0.0, 419.53, 595.28));
+    assert_eq!(rotated.rotate, 90);
+    assert_eq!(
+        doc.page(2).unwrap().media_box,
+        Rect::new(0.0, 0.0, 612.0, 792.0)
+    );
+}
+
+#[test]
+fn all_none_metadata_writes_no_info() {
+    let pdf = Pdf {
+        metadata: Some(Metadata::default()),
+        pages: vec![Page::new(PageSize::A4)],
+        ..Pdf::default()
+    };
+    let bytes = pdf.to_bytes().unwrap();
+    assert!(!contains(&bytes, b"/Info"));
+    let doc = Document::load(bytes).unwrap();
+    assert_eq!(doc.metadata(), pdfboss_core::document::Metadata::default());
+}
+
+#[test]
+fn non_quarter_rotation_is_an_error() {
+    let mut page = Page::new(PageSize::A4);
+    page.rotation = 45;
+    let outcome = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes();
+    match outcome {
+        Err(Error::Other(msg)) => assert!(msg.contains("45"), "{msg}"),
+        other => panic!("expected Error::Other naming the rotation, got {other:?}"),
+    }
+}
+
+#[test]
+fn shapes_and_image_render_without_skips() {
+    let mut page = Page::new(PageSize::Custom {
+        width: 200.0,
+        height: 200.0,
+    });
+    page.canvas.set_fill(Color::Rgb(1.0, 0.0, 0.0));
+    page.canvas.rect(20.0, 20.0, 60.0, 60.0);
+    page.canvas.fill();
+    let gradient: Vec<u8> = (0..256).map(|value| value as u8).collect();
+    let handle = page
+        .canvas
+        .add_image(ImageData::gray8(16, 16, gradient).unwrap());
+    page.canvas.draw_image(handle, 120.0, 120.0, 60.0, 60.0);
+    let bytes = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let loaded = doc.page(0).unwrap();
+    let (pix, report) =
+        render_page_reporting(&doc, &loaded, 1.0, &RenderOptions::default()).unwrap();
+    assert!(report.is_empty(), "skipped content: {:?}", report.summary());
+    assert_eq!((pix.width, pix.height), (200, 200));
+    let sample = |x: usize, y: usize| {
+        let at = (y * pix.width as usize + x) * 4;
+        (pix.data[at], pix.data[at + 1], pix.data[at + 2])
+    };
+    assert_eq!(sample(5, 5), (255, 255, 255));
+    assert_eq!(sample(100, 100), (255, 255, 255));
+    let (r, g, b) = sample(50, 150);
+    assert!(
+        r >= 250 && g <= 5 && b <= 5,
+        "rect region painted ({r}, {g}, {b}), expected red"
+    );
+    let (ir, ig, ib) = sample(150, 50);
+    assert!(ir < 250, "image region stayed white: ({ir}, {ig}, {ib})");
+}
+
+fn tiny_jpeg(width: u16, height: u16) -> Vec<u8> {
+    let components = 3u8;
+    let mut out: Vec<u8> = vec![0xFF, 0xD8, 0xFF, 0xC0];
+    out.extend_from_slice(&(8 + 3 * u16::from(components)).to_be_bytes());
+    out.push(8);
+    out.extend_from_slice(&height.to_be_bytes());
+    out.extend_from_slice(&width.to_be_bytes());
+    out.push(components);
+    for id in 0..components {
+        out.extend_from_slice(&[id + 1, 0x11, 0]);
+    }
+    out.extend_from_slice(&[0xFF, 0xD9]);
+    out
+}
+
+#[test]
+fn jpeg_passthrough_keeps_dct_stream() {
+    let jpeg = tiny_jpeg(5, 7);
+    let mut page = Page::new(PageSize::A4);
+    let handle = page.canvas.add_image(ImageData::jpeg(&jpeg).unwrap());
+    page.canvas.draw_image(handle, 100.0, 100.0, 50.0, 70.0);
+    let bytes = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let loaded = doc.page(0).unwrap();
+    let xobjects = doc
+        .resolve(loaded.resources.get("XObject").expect("XObject resource"))
+        .unwrap();
+    let entry = xobjects.as_dict().unwrap().get("Im1").expect("Im1 entry");
+    let resolved = doc.resolve(entry).unwrap();
+    let stream = resolved.as_stream().unwrap();
+    assert_eq!(
+        stream.dict.get_name("Filter"),
+        Some(&Name("DCTDecode".into()))
+    );
+    assert_eq!(stream.dict.get_int("Width"), Some(5));
+    assert_eq!(stream.dict.get_int("Height"), Some(7));
+    assert_eq!(stream.data, jpeg);
+}
+
+fn two_page_document() -> Pdf {
+    let mut first = Page::new(PageSize::A4);
+    first
+        .canvas
+        .text("Determinism", 72.0, 700.0, Standard14::TimesRoman, 14.0)
+        .unwrap();
+    first.canvas.set_fill(Color::Gray(0.25));
+    first.canvas.rect(10.0, 10.0, 40.0, 40.0);
+    first.canvas.fill();
+    let mut second = Page::new(PageSize::A5.landscape());
+    let raster: Vec<u8> = (0..16u8).map(|value| value * 16).collect();
+    let handle = second
+        .canvas
+        .add_image(ImageData::gray8(4, 4, raster).unwrap());
+    second.canvas.draw_image(handle, 20.0, 20.0, 80.0, 80.0);
+    second
+        .canvas
+        .text("Page two", 30.0, 200.0, Standard14::Helvetica, 12.0)
+        .unwrap();
+    Pdf {
+        metadata: Some(Metadata {
+            title: Some("Determinism".into()),
+            ..Metadata::default()
+        }),
+        pages: vec![first, second],
+        options: WriteOptions::default(),
+    }
+}
+
+#[test]
+fn identical_documents_serialize_byte_identically() {
+    assert_eq!(
+        two_page_document().to_bytes().unwrap(),
+        two_page_document().to_bytes().unwrap()
+    );
+}
+
+#[test]
+fn both_xref_styles_load() {
+    for xref in [XrefStyle::Table, XrefStyle::Stream] {
+        let mut page = Page::new(PageSize::A4);
+        page.canvas
+            .text("Xref", 72.0, 700.0, Standard14::Courier, 10.0)
+            .unwrap();
+        let bytes = Pdf {
+            pages: vec![page],
+            options: WriteOptions {
+                xref,
+                ..WriteOptions::default()
+            },
+            ..Pdf::default()
+        }
+        .to_bytes()
+        .unwrap();
+        match xref {
+            XrefStyle::Table => {
+                assert!(contains(&bytes, b"\nxref\n"));
+                assert!(contains(&bytes, b"trailer"));
+                assert!(!contains(&bytes, b"/ObjStm"));
+            }
+            XrefStyle::Stream => assert!(contains(&bytes, b"/ObjStm")),
+        }
+        let doc = Document::load(bytes).unwrap();
+        assert_eq!(doc.page_count(), 1);
+        let loaded = doc.page(0).unwrap();
+        assert!(extract_text(&doc, &loaded).unwrap().contains("Xref"));
+    }
+}


### PR DESCRIPTION
pdfboss gains the other direction: a creation suite. This lands phases 1+2 of the write design — the COS writer and the canvas/content layer — plus sans-io async write parity and a `pdfboss create` CLI family.

## What

- **`pdfboss-write` (new crate)**
  - `ser`: COS object serialization — sorted dict keys, exponent-free reals, `#xx` name escaping, literal/hex strings; deterministic byte-for-byte.
  - `Writer`: `reserve`/`put`/`put_stream`/`fill`/`finish` — classic xref tables and xref streams, object-stream packing, Flate via zlib-rs, `/ID` from a SHA-256 of the emitted body. Same calls, same bytes, every time.
  - `content`: serializes the same `Op` IR the reader parses — **every variant round-trips through `parse_content`**, inline images included.
  - `Canvas`: paths, shapes, state, clipping, text, images; resource naming contract consumed by assembly.
  - `Standard14` enum: the fourteen base fonts with WinAnsi encoding and AFM widths (new `win_ansi_glyph_name` helper in `pdfboss-encoding`). Unencodable characters are hard errors — the writer never silently corrupts text.
  - Images: PNG (alpha → `/SMask`, palette/16-bit normalized), JPEG DCT passthrough (SOF-sniffed), raw gray/RGB/1-bit rasters.
  - `Pdf`/`Page` assembly: metadata (`/Info`, UTF-16BE where needed), page tree, cross-page font dedup.
- **Async parity (sans-io)**: emission written once over an `AsyncByteSink` seam mirroring `source.rs` — running-count offsets, incremental SHA-256 (`pdfboss_core::crypt::Sha256`, new), so streaming needs no whole-file buffer. `finish`/`finish_into`/`finish_into_with` and `Pdf::to_bytes`/`write_into`/`write_into_with` are byte-identical; `TokioSink` lives in `pdfboss-aio` behind a default-off `write` feature.
- **CLI**: `pdfboss create blank|text|images` — text with AFM-metric word wrap and pagination, images with magic-byte sniffing and fit-contain placement.

## Verification

- 2,073 workspace tests green (120 in `pdfboss-write`), `cargo clippy --workspace --all-targets -- -D warnings` and `-p pdfboss-aio --all-features` clean, rustdoc `-D warnings` clean.
- The reader is the oracle: every created fixture is re-opened with `Document`, text re-extracted (character-exact), and re-rendered with `pdfboss-render` asserting an empty skip report and expected pixels.
- Byte-equality pinned across all three emission paths in three option sets, plus a chunk-recording sink proving streaming emission.
- End-to-end: `create text` output renders correctly (`--fonts full`; Standard-14 is never embedded, by design) and `create images` round-trips a PNG onto A4.
- Adversarial review workflow (5 lenses → 2 refuters per finding) ran over the full diff; the 5 confirmed findings are fixed in-branch with RED-verified tests (degenerate JPEG dims, zero-page docs, NUL names, 10-digit xref-table offset cap, `/ID` content-hash pin).
- Known gap: `create text --font symbol|zapf-dingbats` always errors (their encoding tables come with a later phase) — honest error, but the two CLI variants could be dropped instead; reviewer's call.

## Notes

- The bundled Core-14 AFM widths predate the Euro: `€` encodes (0x80) but `text_width` errors honestly on the missing metric.
- RC4/AES-128 on write stays a non-goal; encryption-on-write arrives with P4 as AES-256 (R6) only.
