### PR TITLE
perf(render): parse an ICCBased profile once per render, not once per operator

### DIFF
--- a/crates/pdfboss-render/src/color.rs
+++ b/crates/pdfboss-render/src/color.rs
@@ -3,9 +3,11 @@
 //! through their tint transforms,
 //! converted to RGB.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use pdfboss_core::{block_on, AsyncObjectSource, Dict, Document, Error, Immediate, Object, Stream};
+use pdfboss_core::{
+    block_on, AsyncObjectSource, Dict, Document, Error, FastMap, Immediate, ObjRef, Object, Stream,
+};
 use pdfboss_icc::{
     lab_to_xyz, mat_apply, mat_mul, srgb_encode, xyz_to_linear_srgb, DeviceSpace, Mat3, Profile,
 };
@@ -16,6 +18,37 @@ use crate::shading::{load_functions, Functions, MAX_COMPS};
 /// (Indexed bases, ICCBased `/Alternate` chains): levels `0..=MAX_DEPTH`
 /// are read, anything deeper reads as `DeviceGray`.
 const MAX_DEPTH: u32 = 8;
+
+/// Parsed `ICCBased` outcomes keyed by the profile stream's reference.
+///
+/// Decoding and parsing a profile is a pure function of the stream object,
+/// so one entry serves every colorspace resource, image, and shading that
+/// names the same stream — within one page render (the executor's own
+/// handle) or across a document's pages (`crate::RenderCache`). Without a
+/// cache the profile re-inflates on every `cs`/`CS` operator, which
+/// measured as a quarter of a mixed-corpus render pass. `None` remembers a
+/// profile that failed to decode or parse, so a broken stream costs one
+/// attempt rather than one per operator. Behind a `Mutex` because the
+/// document-level cache is shared by parallel page walks; first writer
+/// wins, like the font cache.
+#[derive(Default)]
+pub(crate) struct IccCache {
+    outcomes: Mutex<FastMap<ObjRef, Option<ColorSpace>>>,
+}
+
+impl IccCache {
+    /// The remembered outcome for `r`: `Some(None)` is a remembered parse
+    /// failure, `None` a stream this cache has not seen.
+    fn get(&self, r: ObjRef) -> Option<Option<ColorSpace>> {
+        self.outcomes.lock().ok()?.get(&r).cloned()
+    }
+
+    fn store(&self, r: ObjRef, outcome: Option<ColorSpace>) {
+        if let Ok(mut outcomes) = self.outcomes.lock() {
+            outcomes.entry(r).or_insert(outcome);
+        }
+    }
+}
 
 /// A color space reduced to what the rasterizer can paint.
 #[derive(Debug, Clone, PartialEq)]
@@ -231,7 +264,7 @@ impl ColorSpace {
     ///
     /// [`Other`]: ColorSpace::Other
     pub(crate) fn parse(doc: &Document, obj: &Object) -> ColorSpace {
-        block_on(Self::parse_with(&Immediate(doc), obj))
+        block_on(Self::parse_with(&Immediate(doc), obj, &IccCache::default()))
     }
 
     /// [`ColorSpace::parse`] against any object source; the synchronous form
@@ -245,7 +278,11 @@ impl ColorSpace {
     /// level covers it. Descending through `/Indexed` pushes its palette;
     /// whatever the loop finally resolves to gets wrapped in the pending
     /// palettes, innermost last.
-    pub(crate) async fn parse_with<S: AsyncObjectSource>(src: &S, obj: &Object) -> ColorSpace {
+    pub(crate) async fn parse_with<S: AsyncObjectSource>(
+        src: &S,
+        obj: &Object,
+        icc: &IccCache,
+    ) -> ColorSpace {
         let mut palettes: Vec<Vec<u8>> = Vec::new();
         // Tint transforms met on the way down with their input arity,
         // innermost last — the same deferral `palettes` uses, for the same
@@ -270,14 +307,33 @@ impl ColorSpace {
                     };
                     match family.as_str() {
                         "ICCBased" => {
+                            let key = match items.get(1) {
+                                Some(Object::Ref(r)) => Some(*r),
+                                _ => None,
+                            };
+                            let remembered = key.and_then(|r| icc.get(r));
+                            if let Some(Some(cs)) = remembered {
+                                result = cs;
+                                break;
+                            }
                             let stream = match items.get(1) {
                                 Some(o) => src.resolve(o).await.ok(),
                                 None => None,
                             };
                             if let Some(Object::Stream(s)) = stream {
-                                if let Some(cs) = Self::from_icc(src, &s).await {
-                                    result = cs;
-                                    break;
+                                // `Some(None)` is a remembered failure: skip
+                                // straight to the `/N`-or-`/Alternate`
+                                // fallback instead of re-decoding a stream
+                                // that already refused to parse.
+                                if remembered.is_none() {
+                                    let parsed = Self::from_icc(src, &s).await;
+                                    if let Some(r) = key {
+                                        icc.store(r, parsed.clone());
+                                    }
+                                    if let Some(cs) = parsed {
+                                        result = cs;
+                                        break;
+                                    }
                                 }
                                 if let Some(n) = s.dict.get_int("N") {
                                     result = match n {
@@ -591,10 +647,20 @@ pub(crate) async fn palette_error_with<S: AsyncObjectSource>(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use pdfboss_core::parser::{NoResolve, Parser};
     use pdfboss_testkit::PdfBuilder;
+
+    /// A matrix/TRC RGB profile with a gamma-1,8 curve — NOT equivalent to
+    /// a device space, so parsing it yields a real [`ColorSpace::Icc`].
+    /// Shared with the executor's cache tests, like `truetype::tests`'
+    /// `build_font`.
+    pub(crate) fn gamma18_rgb_profile() -> Vec<u8> {
+        let mut trc = b"curv\0\0\0\0\0\0\0\x01".to_vec();
+        trc.extend_from_slice(&((1.8f64 * 256.0).round() as u16).to_be_bytes());
+        rgb_profile(&trc)
+    }
 
     fn test_doc() -> Document {
         let mut b = PdfBuilder::new();

--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -502,6 +502,10 @@ pub(crate) async fn render_page_reporting_with<S: AsyncObjectSource>(
         provider,
         oc: opts.oc.clone(),
         shared_fonts: opts.cache.clone(),
+        icc: match &opts.cache {
+            Some(cache) => Arc::clone(&cache.colorspaces),
+            None => Arc::default(),
+        },
         glyph_blit: Vec::new(),
         raster: RasterScratch::default(),
         clip_cache: FastMap::default(),
@@ -556,6 +560,10 @@ struct Executor<'a, S> {
     /// Fonts shared across this document's page renders
     /// ([`RenderOptions::cache`]); `None` keeps loads page-local.
     shared_fonts: Option<Arc<crate::RenderCache>>,
+    /// Parsed `ICCBased` outcomes: the document cache's own handle when one
+    /// is set, else a render-local one, so repeated `cs`/`CS` operators,
+    /// images and shadings never re-decode a profile stream either way.
+    icc: Arc<crate::color::IccCache>,
     /// Reused scratch for painting a cached glyph outline: the flattened
     /// (origin-relative) subpaths from [`GlyphFont::flattened`] are copied
     /// here translated to the glyph's device origin, so a whole page of text
@@ -1271,7 +1279,7 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                     self.skip(SkippedKind::Pattern, SkipReason::Missing);
                     return None;
                 };
-                match Shading::load_with(self.src, shading_obj).await {
+                match Shading::load_with(self.src, shading_obj, &self.icc).await {
                     Ok(s) => {
                         let s = Arc::new(s);
                         self.cache_pattern(pref, CachedPattern::Shading(matrix, Arc::clone(&s)));
@@ -2312,14 +2320,19 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                     if let Some(Object::Name(n)) = items.first() {
                         if n.0 == "Pattern" {
                             let base = match items.get(1) {
-                                Some(base) => ColorSpace::parse_with(self.src, base).await,
+                                Some(base) => {
+                                    ColorSpace::parse_with(self.src, base, &self.icc).await
+                                }
                                 None => ColorSpace::DeviceGray,
                             };
                             return (base, true);
                         }
                     }
                 }
-                (ColorSpace::parse_with(self.src, &obj).await, false)
+                (
+                    ColorSpace::parse_with(self.src, &obj, &self.icc).await,
+                    false,
+                )
             }
             None => (ColorSpace::DeviceGray, false),
         }
@@ -2839,7 +2852,7 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             self.skip(SkippedKind::Shading, SkipReason::Missing);
             return;
         };
-        let loaded = match Shading::load_with(self.src, &obj).await {
+        let loaded = match Shading::load_with(self.src, &obj, &self.icc).await {
             Ok(s) => s,
             Err(e) => {
                 self.skip(SkippedKind::Shading, skip_reason_for(&e));
@@ -3038,7 +3051,8 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                     };
                     let cs_obj = s.dict.get("ColorSpace").cloned();
                     let meta =
-                        image::ImageMeta::read_with(self.src, &s.dict, cs_obj.as_ref()).await;
+                        image::ImageMeta::read_with(self.src, &s.dict, cs_obj.as_ref(), &self.icc)
+                            .await;
                     let mask = image::decode_alpha(&meta, &data);
                     if mask.is_none() {
                         self.skip(SkippedKind::SoftMask, SkipReason::Undecodable);
@@ -3064,7 +3078,8 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                             return None;
                         }
                     };
-                    let meta = image::ImageMeta::read_with(self.src, &s.dict, None).await;
+                    let meta =
+                        image::ImageMeta::read_with(self.src, &s.dict, None, &self.icc).await;
                     if !meta.stencil {
                         // A stream-valued /Mask must be a stencil (§8.9.6.4).
                         self.skip(SkippedKind::SoftMask, SkipReason::Undecodable);
@@ -3119,7 +3134,7 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         if let Some(e) = palette_err {
             self.skip(SkippedKind::Image, skip_reason_for(&e));
         }
-        let meta = image::ImageMeta::read_with(self.src, dict, cs_obj.as_ref()).await;
+        let meta = image::ImageMeta::read_with(self.src, dict, cs_obj.as_ref(), &self.icc).await;
         let smask = self.image_alpha_mask(dict, &meta, data).await;
         if gs.fill_pattern && meta.stencil {
             // The stencil paints the pattern's stand-in gray, not the
@@ -6860,6 +6875,77 @@ mod render_cache_tests {
         let (cached_resolutions, cached) = render_both(Some(Arc::new(RenderCache::default())));
         assert_eq!(uncached_resolutions, 2, "one load per page uncached");
         assert_eq!(cached_resolutions, 1, "one load per document cached");
+        for (a, b) in cached.iter().zip(&uncached) {
+            assert_eq!(a.data, b.data, "pixels must not depend on the cache");
+        }
+    }
+
+    /// Two pages whose content sets the same `ICCBased` space twice each:
+    /// four `cs` operators over one profile stream (object 6).
+    fn two_page_shared_icc_doc() -> Vec<u8> {
+        let contents = b"/CS0 cs 1 0 0 sc 10 10 50 50 re f \
+                         /CS0 cs 0 1 0 sc 20 20 30 30 re f";
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R 7 0 R] /Count 2 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+             /Resources << /ColorSpace << /CS0 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        b.stream(4, "", contents);
+        b.object(5, "[/ICCBased 6 0 R]");
+        b.stream(6, "/N 3", &crate::color::tests::gamma18_rgb_profile());
+        b.object(
+            7,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+             /Resources << /ColorSpace << /CS0 5 0 R >> >> /Contents 8 0 R >>",
+        );
+        b.stream(8, "", contents);
+        b.build(1)
+    }
+
+    fn render_both_icc(cache: Option<Arc<RenderCache>>) -> (usize, Vec<Pixmap>) {
+        let doc = Document::load(two_page_shared_icc_doc()).expect("load");
+        let counting = Counting {
+            inner: Immediate(&doc),
+            resolutions: AtomicUsize::new(0),
+            watched: 6,
+        };
+        let opts = RenderOptions {
+            cache,
+            ..Default::default()
+        };
+        let mut pages = Vec::new();
+        for index in 0..2 {
+            let page = doc.page(index).expect("page");
+            let (pix, report) =
+                block_on(render_page_reporting_with(&counting, &page, 1.0, &opts)).expect("render");
+            assert!(report.warnings().is_empty(), "unexpected skips: {report:?}");
+            pages.push(pix);
+        }
+        (counting.resolutions.load(Ordering::Relaxed), pages)
+    }
+
+    /// Repeated `cs` operators naming the same `ICCBased` stream decode and
+    /// parse the profile once per page render, not once per operator.
+    #[test]
+    fn an_icc_profile_parses_once_per_page() {
+        let (resolutions, _) = render_both_icc(None);
+        assert_eq!(resolutions, 2, "one parse per page, not one per cs op");
+    }
+
+    /// One [`RenderCache`] across a document's pages parses the shared
+    /// profile once, and the pixels are exactly the uncached render's.
+    #[test]
+    fn a_shared_icc_profile_parses_once_per_document() {
+        let (uncached_resolutions, uncached) = render_both_icc(None);
+        let (cached_resolutions, cached) = render_both_icc(Some(Arc::new(RenderCache::default())));
+        assert_eq!(cached_resolutions, 1, "one parse per document cached");
+        assert!(
+            uncached_resolutions > cached_resolutions,
+            "the document cache must save work over per-render caches"
+        );
         for (a, b) in cached.iter().zip(&uncached) {
             assert_eq!(a.data, b.data, "pixels must not depend on the cache");
         }

--- a/crates/pdfboss-render/src/image.rs
+++ b/crates/pdfboss-render/src/image.rs
@@ -374,7 +374,12 @@ impl ImageMeta {
     /// [`Immediate`].
     #[cfg(test)]
     pub(crate) fn read(doc: &Document, dict: &Dict, cs_obj: Option<&Object>) -> ImageMeta {
-        block_on(Self::read_with(&Immediate(doc), dict, cs_obj))
+        block_on(Self::read_with(
+            &Immediate(doc),
+            dict,
+            cs_obj,
+            &crate::color::IccCache::default(),
+        ))
     }
 
     /// Resolves every dictionary entry the decode consults. `cs_obj` is the
@@ -384,9 +389,10 @@ impl ImageMeta {
         src: &S,
         dict: &Dict,
         cs_obj: Option<&Object>,
+        icc: &crate::color::IccCache,
     ) -> ImageMeta {
         let cs = match cs_obj {
-            Some(obj) => Some(ColorSpace::parse_with(src, obj).await),
+            Some(obj) => Some(ColorSpace::parse_with(src, obj, icc).await),
             None => None,
         };
         ImageMeta {

--- a/crates/pdfboss-render/src/lib.rs
+++ b/crates/pdfboss-render/src/lib.rs
@@ -209,11 +209,16 @@ pub struct RenderOptions {
     pub cache: Option<Arc<RenderCache>>,
 }
 
-/// Cross-page render state: fonts by their dictionary's object reference.
+/// Cross-page render state: fonts by their dictionary's object reference,
+/// and parsed `ICCBased` colorspace outcomes by their profile stream's.
 /// `Send + Sync`, so a parallel page walk may share one.
 #[derive(Default)]
 pub struct RenderCache {
     fonts: std::sync::Mutex<pdfboss_core::FastMap<pdfboss_core::ObjRef, executor::SharedGlyphFont>>,
+    /// Shared as one handle with every page's executor, which otherwise
+    /// builds a render-local one — the same two-level shape as `fonts`
+    /// without a second lookup tier.
+    colorspaces: Arc<color::IccCache>,
 }
 
 impl std::fmt::Debug for RenderCache {

--- a/crates/pdfboss-render/src/shading.rs
+++ b/crates/pdfboss-render/src/shading.rs
@@ -1472,6 +1472,7 @@ impl Shading {
     pub(crate) async fn load_with<S: AsyncObjectSource>(
         src: &S,
         obj: &Object,
+        icc: &crate::color::IccCache,
     ) -> Result<Shading, Error> {
         let (dict, stream) = match src.resolve(obj).await? {
             Object::Dict(d) => (d, None),
@@ -1482,7 +1483,7 @@ impl Shading {
         let cs_obj = dict
             .get("ColorSpace")
             .ok_or_else(|| Error::Other("shading has no /ColorSpace".into()))?;
-        let cs = ColorSpace::parse_with(src, cs_obj).await;
+        let cs = ColorSpace::parse_with(src, cs_obj, icc).await;
         let kind = match type_num {
             1 => {
                 let functions = match dict.get("Function") {


### PR DESCRIPTION
Profiling a mixed-corpus render pass at v0.20.0 put 26.7% of all CPU in
`resolve_colorspace`: the ICC profile stream re-inflated and re-parsed on
every `cs`/`CS` operator, image and shading that named it, because no layer
cached the outcome. The worst file (an Illustrator-style form) spent 72% of
its render there.

`IccCache` remembers each `ICCBased` stream's parse outcome by the stream's
object reference — a pure function of the stream object, so one entry serves
every wrapper (`[/ICCBased n 0 R]` arrays are usually direct; the stream is
always indirect, so the key always exists where the cost is). `None`
remembers a failed decode/parse, so a broken profile costs one attempt
instead of one per operator. The executor shares the document
`RenderCache`'s handle when one is set (the py binding always sets one) and
builds a render-local handle otherwise — the same two-level shape as the
font cache, without a second lookup tier.

One deliberate semantics note for the async path: a profile whose stream
fetch fails transiently over a network source is now remembered as failed
for the rest of that document's cache lifetime and degrades to the `/N`
fallback (the designed degradation), rather than retrying on every
operator.

Verification

- Counting tests (RED first: 4 parses for 4 operators): repeated `cs` over
  one profile parses once per page uncached, once per document with a
  `RenderCache`; pixels asserted identical cached vs uncached.
- Byte oracles: per-page sha256 of RGBA pixels AND of PNG bytes identical
  to the v0.20.0 baseline over 888 mixed-corpus pages + 50 scanned-book
  pages.
- Full workspace suite green; clippy in both `substitute-fonts` states,
  fmt, `cargo doc` clean; pytest green (release .so verified loaded).

Measurement (16 interleaved paired rounds vs the frozen v0.20.0 baseline
binary, pre-registered keep rule ≥14/16 wins AND median > 3× A/A-null
median, machine gated ≥85% idle)

- mixed corpus: 16/16 wins, median -20.9% (8.149s -> 6.454s, ~115 -> ~142 pages/s), x1.262 -- keep=YES against the 5.93% threshold
- worst file 049658: 2.908s -> 1.194s = x2.44 (its render phase 2.494s -> 0.779s = x3.20)
- corpus excluding 049658: 4.95s -> 4.97s, flat within noise -- the corpus gain is this file class
- scanned book (no-regression control — ICC plays no part there):
  8 rounds, median -0.29%, inside the null floor
- A/A null floor: median |e| = 1.98% (max 7.8%); keep threshold 3x = 5.93%
