### PR TITLE
perf(render): sweep a repeating glyph's coverage once per baseline, replay it per occurrence

### DIFF
--- a/crates/pdfboss-render/src/executor.rs
+++ b/crates/pdfboss-render/src/executor.rs
@@ -20,7 +20,9 @@ use crate::color::{self, ColorSpace};
 use crate::glyph::{GlyphFallback, GlyphFont};
 use crate::image::{self, DrawParams};
 use crate::path::{PathBuilder, Subpath};
-use crate::raster::{fill_path, BlendMode, FillRule, Mask, RasterScratch};
+use crate::raster::{
+    capture_spans, fill_path, fill_spans, BlendMode, FillRule, Mask, RasterScratch, SpanSet,
+};
 use crate::shading::{load_functions, Functions, Shading, MAX_COMPS};
 use crate::stroke::stroke_path;
 #[cfg(feature = "substitute-fonts")]
@@ -511,6 +513,8 @@ pub(crate) async fn render_page_reporting_with<S: AsyncObjectSource>(
         clip_cache: FastMap::default(),
         charproc_cache: FastMap::default(),
         pattern_cache: FastMap::default(),
+        glyph_spans: FastMap::default(),
+        glyph_seen: FastMap::default(),
         report,
     };
     let root = Frame::new(
@@ -535,6 +539,25 @@ const INVISIBLE_ANNOTS: i64 = (1 << 1) | (1 << 5);
 /// honestly; past the cap a glyph re-parses uncached, bounding memory
 /// against a hostile file minting CharProcs.
 const MAX_CHARPROC_CACHE: usize = 1024;
+
+/// Upper bound on distinct captured glyph span sets kept per page render.
+/// Body text holds a page's distinct (outline, baseline-fraction) pairs in
+/// the hundreds; past the cap a glyph still paints correctly through the
+/// direct fill, so a hostile file minting endless sizes or baselines only
+/// loses the reuse, never correctness. Each entry is glyph-sized (a few
+/// hundred spans), so the cap also bounds the cache's memory.
+const MAX_GLYPH_SPAN_CACHE: usize = 4096;
+
+/// One captured glyph in [`Executor::glyph_spans`]: the outline whose
+/// allocation the entry pins (its address is the cache key) and the span
+/// set swept from it.
+type CapturedGlyph = (Arc<Vec<Subpath>>, Arc<SpanSet>);
+
+/// Upper bound on once-sighted keys remembered per page render
+/// ([`Executor::glyph_seen`]); past it, further first sights paint direct
+/// and are not recorded, so a hostile file minting endless keys caps the
+/// set's memory at a few hundred kilobytes.
+const MAX_GLYPH_SEEN: usize = 1 << 16;
 
 /// Executes parsed content operators against a shared pixmap; forms and
 /// Type3 CharProcs run as frames on [`Executor::run`]'s explicit stack.
@@ -591,6 +614,26 @@ struct Executor<'a, S> {
     /// names through a reference — see [`CachedPattern`] and
     /// [`MAX_PATTERN_CACHE`].
     pattern_cache: FastMap<pdfboss_core::ObjRef, CachedPattern>,
+    /// Captured glyph coverage spans, keyed by the flattened outline's
+    /// allocation address plus the exact bits of the device offset's
+    /// fractional y — the pair that determines the sweep's output, since
+    /// text on one baseline repeats its fractional y while fractional x
+    /// almost never repeats (measured 69.5% key repeats corpus-wide against
+    /// 4.9% with fractional x in the key). The held [`Arc`] keeps the
+    /// outline allocation alive, so the address cannot be reused by another
+    /// outline while its entry exists. See [`MAX_GLYPH_SPAN_CACHE`].
+    glyph_spans: FastMap<(usize, u32), CapturedGlyph>,
+    /// How often each span-cache key has been sighted before admission.
+    /// Admission to [`Executor::glyph_spans`] waits for the third sight: a
+    /// capture costs a second coverage accumulation plus allocations, which
+    /// a key seen once or twice can never pay back (measured 60-67%
+    /// per-file regressions capturing on first sight, still 10-22% on
+    /// second — page headers and folios repeat a glyph only once or twice
+    /// per page render), while body text repeats far past three. A stale
+    /// count (its outline dropped, the address reused) only admits a
+    /// genuine first sight early — the capture always sweeps the outline
+    /// actually being painted. See [`MAX_GLYPH_SEEN`].
+    glyph_seen: FastMap<(usize, u32), u8>,
     /// Content this render dropped rather than painted, accumulated across
     /// the page (forms and Type3 CharProcs included, since they run through
     /// the same [`Executor`]).
@@ -1731,24 +1774,86 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
     }
 
     /// Paints a cached, origin-relative flattened glyph outline at device
-    /// origin `(dx, dy)` in color `fill`, reusing [`Executor::glyph_blit`] so
-    /// a page of text paints without a fresh polygon allocation per glyph.
-    /// The fill is anti-aliased, nonzero-rule, alpha- and clip-scaled exactly
-    /// as a direct `fill_path` on the untranslated glyph would be.
-    fn blit_glyph(&mut self, cached: &[Subpath], dx: f32, dy: f32, fill: [u8; 4], gs: &GState) {
-        for (i, src) in cached.iter().enumerate() {
-            if i == self.glyph_blit.len() {
-                self.glyph_blit.push(Subpath {
-                    points: Vec::new(),
-                    closed: src.closed,
-                });
-            }
-            let dst = &mut self.glyph_blit[i];
-            dst.points.clear();
-            dst.points
-                .extend(src.points.iter().map(|p| Point::new(p.x + dx, p.y + dy)));
-            dst.closed = src.closed;
+    /// origin `(dx, dy)` in color `fill`. The fill is anti-aliased,
+    /// nonzero-rule, alpha- and clip-scaled through the same row painting a
+    /// direct `fill_path` uses.
+    ///
+    /// The outline's coverage is swept once per repeating (outline,
+    /// fractional-y) pair and replayed from [`Executor::glyph_spans`] for
+    /// every further occurrence — text on a baseline shares its fractional
+    /// y, so a line of body text sweeps each distinct glyph's edges once.
+    /// Admission waits for a key's third sight: most keys on irregular or
+    /// rotated text never repeat, and one or two repeats cannot pay a capture
+    /// back (measured 60-67% and 10-22% per-file regressions on first- and
+    /// second-sight admission), so early sights paint the direct fused way and
+    /// only count in [`Executor::glyph_seen`].
+    fn blit_glyph(
+        &mut self,
+        cached: &Arc<Vec<Subpath>>,
+        dx: f32,
+        dy: f32,
+        fill: [u8; 4],
+        gs: &GState,
+    ) {
+        let iy = dy.floor();
+        let fy = dy - iy;
+        let key = (Arc::as_ptr(cached) as usize, fy.to_bits());
+        if let Some((_, set)) = self.glyph_spans.get(&key) {
+            let set = Arc::clone(set);
+            fill_spans(
+                &mut self.pix,
+                &mut self.raster,
+                &set,
+                dx,
+                iy as i64,
+                fill,
+                gs.fill_alpha,
+                effective_mask(gs).as_deref(),
+                gs.blend_mode,
+            );
+            return;
         }
+        let sightings = match self.glyph_seen.get_mut(&key) {
+            Some(count) => {
+                *count = count.saturating_add(1);
+                *count
+            }
+            None => {
+                if self.glyph_seen.len() < MAX_GLYPH_SEEN {
+                    self.glyph_seen.insert(key, 1);
+                }
+                1
+            }
+        };
+        if sightings >= 3 && self.glyph_spans.len() < MAX_GLYPH_SPAN_CACHE {
+            self.translate_into_blit_scratch(cached, 0.0, fy);
+            let captured = capture_spans(
+                &mut self.raster,
+                &self.glyph_blit[..cached.len()],
+                FillRule::NonZero,
+            );
+            // `None` means a capture bound tripped (geometry taller or
+            // busier than any honest glyph); the direct fill below handles
+            // it, kept proportional by the page bounds.
+            if let Some(set) = captured {
+                let set = Arc::new(set);
+                self.glyph_spans
+                    .insert(key, (Arc::clone(cached), Arc::clone(&set)));
+                fill_spans(
+                    &mut self.pix,
+                    &mut self.raster,
+                    &set,
+                    dx,
+                    iy as i64,
+                    fill,
+                    gs.fill_alpha,
+                    effective_mask(gs).as_deref(),
+                    gs.blend_mode,
+                );
+                return;
+            }
+        }
+        self.translate_into_blit_scratch(cached, dx, dy);
         fill_path(
             &mut self.pix,
             &mut self.raster,
@@ -1759,6 +1864,25 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
             effective_mask(gs).as_deref(),
             gs.blend_mode,
         );
+    }
+
+    /// Copies `cached` translated by `(tx, ty)` into the reused
+    /// [`Executor::glyph_blit`] scratch, so glyph painting never allocates a
+    /// fresh polygon set per occurrence.
+    fn translate_into_blit_scratch(&mut self, cached: &[Subpath], tx: f32, ty: f32) {
+        for (i, src) in cached.iter().enumerate() {
+            if i == self.glyph_blit.len() {
+                self.glyph_blit.push(Subpath {
+                    points: Vec::new(),
+                    closed: src.closed,
+                });
+            }
+            let dst = &mut self.glyph_blit[i];
+            dst.points.clear();
+            dst.points
+                .extend(src.points.iter().map(|p| Point::new(p.x + tx, p.y + ty)));
+            dst.closed = src.closed;
+        }
     }
 
     /// Paints `code` from the font's per-glyph fallback face (see
@@ -6925,6 +7049,72 @@ mod render_cache_tests {
             pages.push(pix);
         }
         (counting.resolutions.load(Ordering::Relaxed), pages)
+    }
+
+    /// Two pages that each show the same glyph three times on one baseline
+    /// (the first two overprinted), with different early positions: the
+    /// third occurrence is a span-cache replay on both pages (admission
+    /// happens on the third sight), captured from the same canonical
+    /// fractional frame, so the replayed region must be bit-identical
+    /// regardless of where the earlier occurrences sat.
+    #[test]
+    fn a_span_replay_paints_identically_regardless_of_history() {
+        fn font_page_doc(contents: &[u8]) -> Vec<u8> {
+            let mut b = PdfBuilder::new();
+            b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+            b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+            b.object(
+                3,
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+                 /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+            );
+            b.stream(4, "", contents);
+            b.object(
+                5,
+                "<< /Type /Font /Subtype /TrueType /BaseFont /Shared \
+                 /FirstChar 65 /Widths [500] /Encoding /WinAnsiEncoding \
+                 /FontDescriptor 6 0 R >>",
+            );
+            b.object(
+                6,
+                "<< /Type /FontDescriptor /FontName /Shared /Flags 32 \
+                 /FontFile2 7 0 R >>",
+            );
+            b.stream(7, "", &crate::truetype::tests::build_font());
+            b.build(1)
+        }
+        fn render(doc: &[u8]) -> Pixmap {
+            let doc = Document::load(doc.to_vec()).expect("load");
+            let page = doc.page(0).expect("page");
+            let (pix, report) = block_on(render_page_reporting_with(
+                &Immediate(&doc),
+                &page,
+                1.0,
+                &RenderOptions::default(),
+            ))
+            .expect("render");
+            assert!(report.warnings().is_empty(), "unexpected skips: {report:?}");
+            pix
+        }
+        let near = render(&font_page_doc(
+            b"BT /F0 100 Tf 10 80 Td (A) Tj 0 0 Td (A) Tj 110 0 Td (A) Tj ET",
+        ));
+        let far = render(&font_page_doc(
+            b"BT /F0 100 Tf 15 80 Td (A) Tj 0 0 Td (A) Tj 105 0 Td (A) Tj ET",
+        ));
+        let mut painted = false;
+        for y in 0..200usize {
+            for x in 115..200usize {
+                let off = (y * 200 + x) * 4;
+                assert_eq!(
+                    &near.data[off..off + 4],
+                    &far.data[off..off + 4],
+                    "pixel ({x}, {y}) differs between two replays of one capture"
+                );
+                painted |= far.data[off + 3] != 0;
+            }
+        }
+        assert!(painted, "the compared region holds the second glyph");
     }
 
     /// Repeated `cs` operators naming the same `ICCBased` stream decode and

--- a/crates/pdfboss-render/src/raster.rs
+++ b/crates/pdfboss-render/src/raster.rs
@@ -415,6 +415,194 @@ fn sweep_rows<F: FnMut(u32, &[f32], usize, usize)>(
     }
 }
 
+/// Anti-aliased coverage of one path, captured as per-subsample span lists
+/// instead of painted pixels, so a glyph repeated along a baseline sweeps
+/// its edges once: a repeat replays the recorded spans shifted by its own
+/// device offset, skipping edge preparation, the active-edge walk, per-
+/// crossing interpolation and the per-subsample sort. Coordinates are the
+/// swept geometry's own (unclamped by any page); the pixel-row index `r`
+/// maps to device row `y0 + r + iy` at fill time.
+#[derive(Debug, Default)]
+pub(crate) struct SpanSet {
+    /// Topmost pixel row the geometry touches, in its own frame.
+    y0: i64,
+    /// Number of pixel rows captured.
+    rows: usize,
+    /// Prefix offsets into `spans`, one slot per `(row, subsample)` pair
+    /// plus a terminator: row `r`, subsample `s` owns
+    /// `spans[offs[r * SUBSAMPLES + s]..offs[r * SUBSAMPLES + s + 1]]`.
+    offs: Vec<u32>,
+    /// `(x0, x1)` span endpoints, each contributing one subsample's weight.
+    spans: Vec<(f32, f32)>,
+}
+
+impl SpanSet {
+    /// How many spans the capture recorded — the cache's size measure.
+    pub(crate) fn span_count(&self) -> usize {
+        self.spans.len()
+    }
+}
+
+/// Row-count and span-count bounds on a capture: geometry taller or busier
+/// than any honest glyph refuses to be captured (the caller falls back to a
+/// direct fill, which page bounds keep proportional), so a hostile stream
+/// cannot mint an arbitrarily large [`SpanSet`].
+const MAX_CAPTURE_ROWS: i64 = 8192;
+const MAX_CAPTURE_SPANS: usize = 1 << 16;
+
+/// Sweeps `polys` under `rule` with the same edge preparation, activation
+/// order, crossing sort and winding pairing as [`fill_path`]'s rasterizer,
+/// recording the resulting spans instead of painting them. No page clamps
+/// apply: the capture is in the geometry's own frame, and [`fill_spans`]
+/// clamps to the page it paints — analytic coverage distributes per column,
+/// so clamping late lands on the same in-page values a clamped sweep
+/// produces. `None` means the geometry exceeded a capture bound.
+pub(crate) fn capture_spans(
+    scratch: &mut RasterScratch,
+    polys: &[Subpath],
+    rule: FillRule,
+) -> Option<SpanSet> {
+    let RasterScratch {
+        edges,
+        active,
+        crossings,
+        ..
+    } = scratch;
+    prepare_edges(edges, polys);
+    if edges.is_empty() {
+        return Some(SpanSet::default());
+    }
+    let mut ymin = f32::MAX;
+    let mut ymax = f32::MIN;
+    for e in edges.iter() {
+        ymin = ymin.min(e.y0);
+        ymax = ymax.max(e.y1);
+    }
+    if !ymin.is_finite() || !ymax.is_finite() {
+        return None;
+    }
+    let row_start = ymin.floor() as i64;
+    let row_end = ymax.ceil() as i64;
+    let rows = row_end.saturating_sub(row_start);
+    if rows <= 0 || rows > MAX_CAPTURE_ROWS {
+        return None;
+    }
+    let rows = rows as usize;
+    let mut set = SpanSet {
+        y0: row_start,
+        rows,
+        offs: Vec::with_capacity(rows * SUBSAMPLES as usize + 1),
+        spans: Vec::new(),
+    };
+    set.offs.push(0);
+    active.clear();
+    let mut next = 0usize;
+    for r in 0..rows {
+        let y = row_start + r as i64;
+        for s in 0..SUBSAMPLES {
+            let ys = y as f32 + (s as f32 + 0.5) / SUBSAMPLES as f32;
+            while next < edges.len() && edges[next].y0 <= ys {
+                active.push(next);
+                next += 1;
+            }
+            active.retain(|&i| edges[i].y1 > ys);
+            crossings.clear();
+            for &i in active.iter() {
+                crossings.push((edges[i].x_at(ys), edges[i].dir));
+            }
+            if crossings.len() >= 2 {
+                crossings.sort_by(|a, b| a.0.total_cmp(&b.0));
+                let mut wind = 0i32;
+                let mut span_start = 0.0f32;
+                for &(x, dir) in crossings.iter() {
+                    let was_inside = inside(wind, rule);
+                    wind += dir;
+                    let is_inside = inside(wind, rule);
+                    if !was_inside && is_inside {
+                        span_start = x;
+                    } else if was_inside && !is_inside && x > span_start {
+                        // A zero-width span adds no coverage, so only real
+                        // extents are recorded.
+                        set.spans.push((span_start, x));
+                    }
+                }
+            }
+            if set.spans.len() > MAX_CAPTURE_SPANS {
+                return None;
+            }
+            set.offs.push(set.spans.len() as u32);
+        }
+    }
+    Some(set)
+}
+
+/// Paints a captured [`SpanSet`] onto `pix` at horizontal offset `dx` and
+/// integer row offset `iy`, with the color, alpha, clip and blend semantics
+/// of [`fill_path`] — the coverage accumulation and row painting are the
+/// same code paths, so a capture-and-fill of a path is bit-identical to a
+/// direct fill of it.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn fill_spans(
+    pix: &mut Pixmap,
+    scratch: &mut RasterScratch,
+    set: &SpanSet,
+    dx: f32,
+    iy: i64,
+    rgba: [u8; 4],
+    alpha: f32,
+    clip: Option<&Mask>,
+    blend: BlendMode,
+) {
+    let alpha = if alpha.is_finite() {
+        alpha.clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+    let base_a = rgba[3] as f32 / 255.0 * alpha;
+    if base_a <= 0.0 || pix.width == 0 || pix.height == 0 {
+        return;
+    }
+    let rgb = [rgba[0], rgba[1], rgba[2]];
+    let full = pix.width as usize;
+    if scratch.row.len() < full {
+        scratch.row.resize(full, 0.0);
+    }
+    let row = &mut scratch.row[..full];
+    let weight = 1.0 / SUBSAMPLES as f32;
+    let subs = SUBSAMPLES as usize;
+    for r in 0..set.rows {
+        let page_y = set.y0 + r as i64 + iy;
+        if page_y < 0 || page_y >= pix.height as i64 {
+            continue;
+        }
+        let mut dirty_lo = full;
+        let mut dirty_hi = 0usize;
+        for s in 0..subs {
+            let slot = r * subs + s;
+            let from = set.offs[slot] as usize;
+            let to = set.offs[slot + 1] as usize;
+            for &(x0, x1) in &set.spans[from..to] {
+                add_span(row, x0 + dx, x1 + dx, weight, &mut dirty_lo, &mut dirty_hi);
+            }
+        }
+        if dirty_lo < dirty_hi {
+            paint_row(
+                pix,
+                page_y as u32,
+                row,
+                dirty_lo,
+                dirty_hi,
+                clip,
+                base_a,
+                rgb,
+                blend,
+            );
+            // Restore the all-zero invariant `RasterScratch::row` promises.
+            row[dirty_lo..dirty_hi].iter_mut().for_each(|c| *c = 0.0);
+        }
+    }
+}
+
 /// Whether a winding count is "inside" under `rule`.
 fn inside(wind: i32, rule: FillRule) -> bool {
     match rule {
@@ -643,49 +831,61 @@ pub(crate) fn fill_path(
         return;
     }
     let rgb = [rgba[0], rgba[1], rgba[2]];
-    let w = pix.width as usize;
     prepare_edges(&mut scratch.edges, polys);
-    sweep_rows(
-        scratch,
-        pix.width,
-        pix.height,
-        rule,
-        |y, row, mut lo, mut hi| {
-            let mask_row = match clip {
-                None => None,
-                Some(m) => {
-                    // Pixels outside the mask's stored bbox read coverage 0, so
-                    // the fill cannot touch them; narrow the span to the overlap
-                    // and hand the pixel loop the mask bytes for what remains.
-                    if y < m.y0 || y - m.y0 >= m.bbox_h {
-                        return;
-                    }
-                    let mx0 = m.x0 as usize;
-                    lo = lo.max(mx0);
-                    hi = hi.min(mx0 + m.bbox_w as usize);
-                    if hi <= lo {
-                        return;
-                    }
-                    if m.opaque {
-                        // Every byte in range is 255 and scaling by 255/255.0
-                        // == 1.0 is exactly the identity, so the clip reduces
-                        // to the bbox narrowing above.
-                        None
-                    } else {
-                        let base = (y - m.y0) as usize * m.bbox_w as usize;
-                        Some(&m.data[base + lo - mx0..base + hi - mx0])
-                    }
-                }
-            };
-            let base = (y as usize * w + lo) * 4;
-            let dst_row = &mut pix.data[base..base + (hi - lo) * 4];
-            if blend == BlendMode::Normal {
-                blend_row::<true>(dst_row, &row[lo..hi], mask_row, base_a, rgb, blend);
-            } else {
-                blend_row::<false>(dst_row, &row[lo..hi], mask_row, base_a, rgb, blend);
+    sweep_rows(scratch, pix.width, pix.height, rule, |y, row, lo, hi| {
+        paint_row(pix, y, row, lo, hi, clip, base_a, rgb, blend)
+    });
+}
+
+/// Paints one coverage row's `[lo, hi)` columns onto `pix` at row `y`,
+/// narrowing to the clip mask's stored bbox and dispatching to the blend
+/// loop — the single row-painting path behind both [`fill_path`] and
+/// [`fill_spans`].
+#[allow(clippy::too_many_arguments)]
+fn paint_row(
+    pix: &mut Pixmap,
+    y: u32,
+    row: &[f32],
+    mut lo: usize,
+    mut hi: usize,
+    clip: Option<&Mask>,
+    base_a: f32,
+    rgb: [u8; 3],
+    blend: BlendMode,
+) {
+    let mask_row = match clip {
+        None => None,
+        Some(m) => {
+            // Pixels outside the mask's stored bbox read coverage 0, so
+            // the fill cannot touch them; narrow the span to the overlap
+            // and hand the pixel loop the mask bytes for what remains.
+            if y < m.y0 || y - m.y0 >= m.bbox_h {
+                return;
             }
-        },
-    );
+            let mx0 = m.x0 as usize;
+            lo = lo.max(mx0);
+            hi = hi.min(mx0 + m.bbox_w as usize);
+            if hi <= lo {
+                return;
+            }
+            if m.opaque {
+                // Every byte in range is 255 and scaling by 255/255.0
+                // == 1.0 is exactly the identity, so the clip reduces
+                // to the bbox narrowing above.
+                None
+            } else {
+                let base = (y - m.y0) as usize * m.bbox_w as usize;
+                Some(&m.data[base + lo - mx0..base + hi - mx0])
+            }
+        }
+    };
+    let base = (y as usize * pix.width as usize + lo) * 4;
+    let dst_row = &mut pix.data[base..base + (hi - lo) * 4];
+    if blend == BlendMode::Normal {
+        blend_row::<true>(dst_row, &row[lo..hi], mask_row, base_a, rgb, blend);
+    } else {
+        blend_row::<false>(dst_row, &row[lo..hi], mask_row, base_a, rgb, blend);
+    }
 }
 
 /// Paints one emitted coverage row into `dst_row` (4 bytes per pixel).
@@ -1622,5 +1822,169 @@ mod stage_times {
             }
         }
         println!("fill (40 big):      {:?}/page", t0.elapsed() / reps);
+    }
+}
+
+#[cfg(test)]
+mod span_tests {
+    use super::*;
+    use pdfboss_core::geom::Point;
+
+    /// A self-intersecting star on subpixel coordinates: exercises the
+    /// nonzero winding rule, coincident-crossing ordering and fractional
+    /// coverage at every edge.
+    fn star(cx: f32, cy: f32, r: f32) -> Subpath {
+        Subpath {
+            points: (0..5)
+                .map(|i| {
+                    let a = (i * 2) as f32 / 5.0 * std::f32::consts::TAU - 0.37;
+                    Point::new(cx + r * a.cos(), cy + r * a.sin())
+                })
+                .collect(),
+            closed: true,
+        }
+    }
+
+    fn subpixel_rect(x0: f32, y0: f32, x1: f32, y1: f32) -> Subpath {
+        Subpath {
+            points: vec![
+                Point::new(x0, y0),
+                Point::new(x1, y0),
+                Point::new(x1, y1),
+                Point::new(x0, y1),
+            ],
+            closed: true,
+        }
+    }
+
+    const INK: [u8; 4] = [30, 60, 200, 255];
+
+    fn direct(polys: &[Subpath], alpha: f32, clip: Option<&Mask>, blend: BlendMode) -> Pixmap {
+        let mut pix = Pixmap::new(24, 24);
+        fill_path(
+            &mut pix,
+            &mut RasterScratch::default(),
+            polys,
+            FillRule::NonZero,
+            INK,
+            alpha,
+            clip,
+            blend,
+        );
+        pix
+    }
+
+    fn replayed(polys: &[Subpath], alpha: f32, clip: Option<&Mask>, blend: BlendMode) -> Pixmap {
+        let mut scratch = RasterScratch::default();
+        let set = capture_spans(&mut scratch, polys, FillRule::NonZero).expect("captured");
+        let mut pix = Pixmap::new(24, 24);
+        fill_spans(
+            &mut pix,
+            &mut scratch,
+            &set,
+            0.0,
+            0,
+            INK,
+            alpha,
+            clip,
+            blend,
+        );
+        pix
+    }
+
+    /// Capturing a path's spans and replaying them at offset zero paints
+    /// exactly the pixels a direct fill paints.
+    #[test]
+    fn captured_spans_rebuild_the_exact_coverage() {
+        let polys = [star(11.3, 12.7, 9.4), subpixel_rect(1.2, 1.7, 5.8, 4.3)];
+        let a = direct(&polys, 1.0, None, BlendMode::Normal);
+        let b = replayed(&polys, 1.0, None, BlendMode::Normal);
+        assert!(a.data.iter().any(|&v| v != 0), "the direct fill painted");
+        assert_eq!(a.data, b.data);
+    }
+
+    /// Alpha scaling, a coverage clip and a non-normal blend mode reach the
+    /// replay through the same row-painting path as a direct fill.
+    #[test]
+    fn span_fill_applies_alpha_clip_and_blend_like_fill_path() {
+        let polys = [star(11.3, 12.7, 9.4)];
+        let clip = Mask::from_path(
+            24,
+            24,
+            &mut RasterScratch::default(),
+            &[subpixel_rect(3.4, 2.2, 19.7, 21.3)],
+            FillRule::NonZero,
+        );
+        let a = direct(&polys, 0.6, Some(&clip), BlendMode::Multiply);
+        let b = replayed(&polys, 0.6, Some(&clip), BlendMode::Multiply);
+        assert!(a.data.iter().any(|&v| v != 0), "the direct fill painted");
+        assert_eq!(a.data, b.data);
+    }
+
+    /// A replay shifted by integer offsets clamps to the page exactly like a
+    /// direct fill of the same translated rectangle: a rectangle's vertical
+    /// edges interpolate to their stored x, so translating the geometry and
+    /// translating the spans round identically and the comparison is exact.
+    #[test]
+    fn span_fill_shifts_and_clips_to_the_page_like_a_direct_fill() {
+        let rect = subpixel_rect(2.3, 2.6, 9.7, 8.4);
+        let translated = subpixel_rect(2.3 + 16.0, 2.6 + 19.0, 9.7 + 16.0, 8.4 + 19.0);
+        let a = direct(&[translated], 1.0, None, BlendMode::Normal);
+        let mut scratch = RasterScratch::default();
+        let set = capture_spans(&mut scratch, &[rect], FillRule::NonZero).expect("captured");
+        let mut b = Pixmap::new(24, 24);
+        fill_spans(
+            &mut b,
+            &mut scratch,
+            &set,
+            16.0,
+            19,
+            INK,
+            1.0,
+            None,
+            BlendMode::Normal,
+        );
+        assert!(a.data.iter().any(|&v| v != 0), "the direct fill painted");
+        assert_eq!(a.data, b.data);
+    }
+
+    /// Rows shifted entirely off the page are skipped, not wrapped or
+    /// painted at clamped rows.
+    #[test]
+    fn span_fill_skips_rows_off_the_page() {
+        let rect = subpixel_rect(2.3, 2.6, 9.7, 8.4);
+        let mut scratch = RasterScratch::default();
+        let set = capture_spans(&mut scratch, &[rect], FillRule::NonZero).expect("captured");
+        let mut pix = Pixmap::new(24, 24);
+        fill_spans(
+            &mut pix,
+            &mut scratch,
+            &set,
+            0.0,
+            -100,
+            INK,
+            1.0,
+            None,
+            BlendMode::Normal,
+        );
+        assert!(
+            pix.data.iter().all(|&v| v == 0),
+            "everything above the page"
+        );
+        fill_spans(
+            &mut pix,
+            &mut scratch,
+            &set,
+            0.0,
+            100,
+            INK,
+            1.0,
+            None,
+            BlendMode::Normal,
+        );
+        assert!(
+            pix.data.iter().all(|&v| v == 0),
+            "everything below the page"
+        );
     }
 }


### PR DESCRIPTION
Stacked on #96. The mixed-corpus profile put 16.7% of render CPU in
`show_text` → `blit_glyph` → `fill_path`: every occurrence of a glyph
re-swept its edges from scratch — edge preparation, the active-edge walk,
per-crossing interpolation and a per-subsample sort — although body text
repeats a small alphabet on shared baselines.

A pre-implementation scout measured which cache key actually repeats on the
corpus: (outline, transform, fract-x, fract-y) repeats only 4.9% of the time
(fractional x positions almost never recur), while (outline, transform,
fract-y) repeats 69.5% — fractional y is constant along a baseline. So the
cache stores per-subsample coverage *spans*: `capture_spans` sweeps a glyph
once in its baseline's fractional frame, and repeats replay the recorded
spans at their own horizontal offset. Replayed and direct fills share one
row painter (`paint_row`), so alpha, clip and blend semantics cannot
diverge.

Admission waits for a key's third sight. A capture costs a second coverage
accumulation plus allocations, and per-file measurement showed keys sighted
once or twice never pay that back: first-sight admission regressed
fractional-y-churning files 60-67% (confirmed by profile: every occurrence
paid capture plus replay), second-sight still left 10-22% regressions on
pages whose headers and folios repeat a glyph only twice per page render.
With third-sight admission the per-file spread over the mixed corpus is
+5.8% worst against wins to -20.3% (7 of 38 files above +2%, all within a
few points of the per-file noise floor). Geometry a capture bound refuses
(taller or busier than any honest glyph) falls back to the direct fill; the
span cache is per page render, capped, and each entry pins its outline's
allocation so the address key cannot alias.

Pixel-exactness trade, approved by the user before implementation: replayed
occurrences paint in the baseline's fractional frame instead of their
absolute one, which moves anti-aliased glyph edges at float-rounding level.
Measured over the 888-page mixed corpus against v0.20.0: 0.0021% of pixels
changed, none by more than 16/255. Scanned pages are byte-identical. The
render pixel oracle is re-baselined; two replays of one capture paint
bit-identically by construction, proven through the public render path.

Verification

- `capture_spans` + `fill_spans` replay is bit-identical to a direct
  `fill_path`: self-intersecting star and subpixel rects, with alpha, a
  coverage clip, Multiply blend, integer-offset page clamping and off-page
  rows.
- A replay paints identically regardless of where earlier occurrences sat
  (two three-occurrence pages with different early positions, shared region
  compared pixel-for-pixel).
- Full workspace suite green; clippy in both `substitute-fonts` states,
  fmt, `cargo doc` clean; pytest 131 passed against the built wheel.
- In-repo snapshots are untouched because every fixture places text at
  small integer coordinates, where the float adds are exact and the two
  frames coincide.

Measurement (pre-registered target: the 14 certified 049 files with >=2000
glyph blits/page, chosen from blit counts before any timing; 16 interleaved
paired rounds wave-1 vs wave-2, keep iff >=14/16 wins AND median > 3x the
A/A-null median; mixed corpus and scan book as 8-round no-regression
controls; machine gated >=85% idle)

- glyph-dense target (first-variant binaries, completed run): keep=YES —
  15/16 wins, median +10.3% (3.009s -> 2.711s), threshold 2.22% (3x null
  median 0.74%)
- mixed corpus control: 8/8 wins, median +7.5%
- scan control: median -0.2%, inside the null floor (the book paints no
  outline glyphs; its pages are byte-identical)
- campaign scoreboard, frozen v0.20.0 vs this branch, mixed corpus: 8/8
  wins, median +27.3% (8.00s -> 5.82s), x1.374 compounded with #96
- per-file spread with the FINAL (third-sight) binaries, best-of-3 per
  side: worst +5.8%, best -20.3%, 7 of 38 files above +2%
- A machine restart wiped the in-flight confirmation rerun of the full
  paired protocol on the final binaries (the third-sight change strictly
  reduces capture work relative to the measured variant; its partial rounds
  showed the target ahead every round). The rerun will be posted here
  before merge.
