### PR TITLE
perf(text): resolve a resource category dictionary once per walk, not once per operator

### DIFF
--- a/crates/pdfboss-text/src/extract.rs
+++ b/crates/pdfboss-text/src/extract.rs
@@ -5,8 +5,8 @@ use crate::font::Font;
 use crate::{Ruling, TextSpan};
 use pdfboss_core::content::{parse_content, Op, TextItem};
 use pdfboss_core::{
-    content_stream_data_with, page_content_with, AsyncObjectSource, Dict, Matrix, Name, ObjRef,
-    Object, OcState, Page, Point, Rect,
+    content_stream_data_with, page_content_with, AsyncObjectSource, Dict, FastMap, Matrix, Name,
+    ObjRef, Object, OcState, Page, Point, Rect,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -213,6 +213,7 @@ pub async fn page_spans_and_rulings_with<S: AsyncObjectSource>(
         loaded: HashMap::new(),
         shared: fonts,
         oc,
+        categories: FastMap::default(),
     };
     let root = Frame::new(
         ops.into(),
@@ -610,6 +611,35 @@ struct Executor<'a, S> {
     /// The document's optional-content visibility; `None` extracts every
     /// layer.
     oc: Option<&'a OcState>,
+    /// Resolved resource-category dictionaries, keyed by the resource
+    /// dictionary's allocation address plus a category slot. Resolving a
+    /// category hands out a deep clone of the whole dictionary, and `gs`
+    /// and `Do` used to pay that per operator — a third of a form-heavy
+    /// corpus extraction pass. `None` remembers a category the dictionary
+    /// does not carry (or that is not a dictionary). The held [`Arc`] keeps
+    /// the resource dictionary's allocation alive, so the address cannot be
+    /// reused while its entry exists. See [`MAX_CATEGORY_CACHE`].
+    categories: FastMap<(usize, u8), ResolvedCategory>,
+}
+
+/// One memoized resource category: the resource dictionary whose allocation
+/// the entry pins (its address is the cache key) and its resolved category
+/// dictionary, or `None` for a remembered absence.
+type ResolvedCategory = (Arc<Dict>, Option<Arc<Dict>>);
+
+/// Upper bound on memoized (resource dictionary, category) pairs per page
+/// walk; past it, lookups resolve uncached, so a hostile file minting
+/// resource dictionaries per form invocation caps the memo's memory.
+const MAX_CATEGORY_CACHE: usize = 4096;
+
+/// The memo slot for a resource category name, [`None`] for a category no
+/// caller looks up hot (left uncached rather than given an open-ended key).
+fn category_slot(category: &str) -> Option<u8> {
+    match category {
+        "ExtGState" => Some(0),
+        "XObject" => Some(1),
+        _ => None,
+    }
 }
 
 impl<S: AsyncObjectSource> Executor<'_, S> {
@@ -621,12 +651,37 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
     /// renderer's `find_res`; the two crates must agree on which resource a
     /// name refers to, or the same file extracts different text than it
     /// paints.
-    async fn find_res(&self, chain: &[Arc<Dict>], category: &str, name: &str) -> Option<Object> {
+    async fn find_res(
+        &mut self,
+        chain: &[Arc<Dict>],
+        category: &str,
+        name: &str,
+    ) -> Option<Object> {
+        let slot = category_slot(category);
         for res in chain {
-            let Some(cat) = res.get(category) else {
-                continue;
+            let key = (Arc::as_ptr(res) as usize, slot.unwrap_or(0));
+            let remembered = slot.and_then(|_| {
+                self.categories
+                    .get(&key)
+                    .map(|(_, category)| category.clone())
+            });
+            let resolved = match remembered {
+                Some(dict) => dict,
+                None => {
+                    let dict = match res.get(category) {
+                        Some(cat) => match self.src.resolve(cat).await {
+                            Ok(Object::Dict(d)) => Some(Arc::new(d)),
+                            _ => None,
+                        },
+                        None => None,
+                    };
+                    if slot.is_some() && self.categories.len() < MAX_CATEGORY_CACHE {
+                        self.categories.insert(key, (Arc::clone(res), dict.clone()));
+                    }
+                    dict
+                }
             };
-            let Ok(Object::Dict(dict)) = self.src.resolve(cat).await else {
+            let Some(dict) = resolved else {
                 continue;
             };
             if let Some(value) = dict.get(name) {
@@ -798,7 +853,7 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
     /// Negative values are ignored, matching the renderer; non-finite ones
     /// too, because an infinite line width would otherwise silently drop
     /// every later stroked ruling at the segment gate.
-    async fn ext_gstate_line_width(&self, chain: &[Arc<Dict>], name: &str) -> Option<f32> {
+    async fn ext_gstate_line_width(&mut self, chain: &[Arc<Dict>], name: &str) -> Option<f32> {
         let resolved = self.find_res(chain, "ExtGState", name).await?;
         let dict = resolved.as_dict()?;
         let lw = self.src.resolve(dict.get("LW")?).await.ok()?.as_f64()? as f32;

--- a/crates/pdfboss-text/src/lib.rs
+++ b/crates/pdfboss-text/src/lib.rs
@@ -992,6 +992,45 @@ mod tests {
         );
     }
 
+    /// Repeated `gs` operators naming resources from one indirect
+    /// `/ExtGState` category dictionary resolve that dictionary once per
+    /// page walk, not once per operator — resolving hands out a deep clone
+    /// of the whole category dictionary, which measured as a third of a
+    /// form-heavy corpus extraction pass.
+    #[test]
+    fn a_resource_category_resolves_once_per_walk() {
+        let mut b = PdfBuilder::new();
+        b.object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        b.object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        b.object(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /ExtGState 5 0 R >> /Contents 4 0 R >>",
+        );
+        b.stream(
+            4,
+            "",
+            b"/G1 gs 10 10 m 100 10 l S \
+              /G1 gs 10 20 m 100 20 l S \
+              /G1 gs 10 30 m 100 30 l S",
+        );
+        b.object(5, "<< /G1 << /LW 2 >> >>");
+        let doc = Document::load(b.build(1)).unwrap();
+        let page = doc.page(0).unwrap();
+        let counting = Counting::new(&doc);
+        let (_, rulings, report) = block_on(extract_spans_and_rulings_reporting_with(
+            &counting, &page, None,
+        ))
+        .unwrap();
+        assert!(report.is_complete(), "unexpected skips: {report:?}");
+        assert_eq!(rulings.len(), 3, "all three strokes extract");
+        assert_eq!(
+            counting.resolutions(5),
+            1,
+            "one category dictionary resolution per page walk"
+        );
+    }
+
     /// A two-page document whose pages bind the same font dictionary: with
     /// one [`FontCache`] passed to both extractions the dictionary is
     /// fetched once, and the spans are exactly the uncached call's.


### PR DESCRIPTION
Re-profiling extraction at 0.21.1 for the campaign's next wave found the
planned lever (content lexing, ~19% of a form-heavy pass) outranked by one
the earlier 200-doc profile had underweighted: on the 049 corpus,
`find_res` was 65.9% of the text executor's walk — roughly a third of the
whole extraction pass. Inside it: 60% in `Document::resolve` deep-cloning
the named category's dictionary out of the object cache (hashbrown
`clone_from_impl`), 35% dropping those clones. The `gs` and `Do` operators
paid that per occurrence — the third instance of the same disease the clip
cache and the ICC cache fixed on the render side.

The text executor now memoizes the resolved category dictionary per
(resource dictionary allocation, category slot): resolved once per walk
behind an `Arc`, absences remembered, each entry pinning its resource
dictionary's allocation so the address key cannot alias (the same
discipline as the render caches). The memo is capped at 4096 entries, and
categories no caller looks up hot stay uncached rather than getting an
open-ended key. Resource-name shadowing is untouched: lookups still walk
the chain innermost-first, per dictionary.

Byte-identical by construction — the memo skips repeated resolution of the
same object, no math changes. Verified: text output identical across the
259-file 049 corpus and the 3,910-file pdf_oxide corpus (per-document
sha256 oracles).

Verification

- Counting test written first and watched fail: three `gs` operators
  resolved the indirect `/ExtGState` category dictionary three times; now
  once per page walk.
- Full workspace suite green; clippy in both `substitute-fonts` states,
  fmt, `cargo doc` clean.

Measurement (pre-registered target: 049-corpus text extraction, 16
interleaved paired rounds 0.21.1 vs this branch, keep iff >=14/16 wins AND
median > 3x the A/A-null median; pdf_oxide corpus as 8-round control —
`find_res` is only ~3% there; machine gated >=85% idle)

- 049 target: keep=YES — 16/16 wins, median +26.1% (2.690s -> 1.987s, x1.354), threshold 2.40% (3x null median 0.80%) cleared 10.9x
- A/A null floor: median |e| = 0.80% (one outlier round at 29.8%)
- pdf_oxide control: 8/8 wins, median +1.1% — the small positive expected where find_res is ~3% of the pass
- per-file sweep: best -97.2% (one pathological file, 646ms -> 18ms), -73%/-66% next; 8 of 259 files regress 9-15% against both of two independent baseline passes (per-file A/A noise p90 = 6.9%). Profiled the worst: its find_res under this branch is 0.3% of the pass — the slowdown is code-layout fallout from the changed async state machine on files whose time sits in layout, not added work from the memo
