### PR TITLE
docs: mdBook user guide, Pages deploy, README refresh

### DIFF
--- a/.github/workflows/book.yaml
+++ b/.github/workflows/book.yaml
@@ -1,0 +1,44 @@
+name: book
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/book.yaml"
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: "0.4.52"
+      - run: mdbook build docs
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book
+
+  deploy:
+    name: deploy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 
 # Local working documents: plans and specs stay untracked.
 docs/superpowers/
+
+# mdBook build output; the source lives in docs/src.
+docs/book/

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ imgs = doc[0].extract_images()             # embedded images: .data (PNG), .widt
 <details>
 <summary><strong>More: explorer subcommands, async Python, Rust</strong></summary>
 
-Explorer subcommands. Each accepts a local path or an `http(s)://` URL, fetched in ranges and never downloaded whole:
+Explorer subcommands. Each except `obj` accepts a local path or an `http(s)://` URL, fetched in ranges and never downloaded whole:
 
 ```bash
 pdfboss json    report.pdf                    # dump the document as a JSON value tree

--- a/README.md
+++ b/README.md
@@ -1,20 +1,39 @@
 <h1 align="center">pdfboss</h1>
 
 <p align="center">
-  <strong>A PDF engine written from scratch in Rust: parse, extract text, rasterize to PNG. One core, a CLI, and pythonic bindings.</strong>
+  <strong>A PDF engine written from scratch in Rust: parse, extract text and images, rasterize to PNG, create PDFs. One core, a CLI, and pythonic bindings.</strong>
 </p>
 
 <p align="center">
   <a href="https://github.com/4thel00z/pdfboss/actions/workflows/ci.yaml"><img src="https://github.com/4thel00z/pdfboss/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
   <a href="https://github.com/4thel00z/pdfboss/actions/workflows/python-ci.yml"><img src="https://github.com/4thel00z/pdfboss/actions/workflows/python-ci.yml/badge.svg" alt="python-ci"></a>
+  <a href="https://4thel00z.github.io/pdfboss/"><img src="https://img.shields.io/badge/docs-book-blue?logo=mdbook&logoColor=white" alt="Documentation"></a>
   <a href="https://pypi.org/project/pdfboss/"><img src="https://img.shields.io/pypi/v/pdfboss?logo=pypi&logoColor=white" alt="PyPI"></a>
   <img src="https://img.shields.io/badge/rust-2021-000000?logo=rust&logoColor=white" alt="Rust 2021">
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="MIT OR Apache-2.0"></a>
 </p>
 
+<p align="center">
+  <a href="https://4thel00z.github.io/pdfboss/">Docs</a> ·
+  <a href="https://pypi.org/project/pdfboss/">PyPI</a> ·
+  <a href="https://crates.io/crates/pdfboss-cli">crates.io</a> ·
+  <a href="#benchmarks">Benchmarks</a>
+</p>
+
 ---
 
 Reading a PDF should not require a C library. pdfboss is a clean-room reader built from the ISO 32000 specification: safe Rust, no C dependencies, no bindings to another engine, one core behind the CLI and the native Python extension. It is a **lenient reader** — real-world files are damaged, so it reconstructs broken cross-reference tables, tolerates wrong stream lengths, and skips garbage operators instead of refusing.
+
+## Highlights
+
+- **Clean-room engine** — implemented from the ISO 32000 specification in safe Rust: no C dependencies, no bindings to another engine.
+- **Fastest text extraction measured** — 6,700 pages/s over a 40-file real-world corpus, about 15× the C-backed PyMuPDF ([benchmarks](#benchmarks)).
+- **Its own codecs** — JPEG 2000, JBIG2, CCITT and ICC are decoded in-tree, implemented from their specifications, not linked in.
+- **Embedded-image extraction** — every image a page draws, at native size, alpha applied, from the CLI, Python and Rust ([example](#extract-embedded-images)).
+- **PDF creation** — document structs, a canvas painter and a COS writer with deterministic output, plus `pdfboss create` ([example](#create-pdfs)).
+- **Async, range-fetching I/O** — documents open over files or `http(s)://` URLs and fetch only the byte ranges they need, never the whole file.
+- **Lenient, and it says so** — broken cross-references are reconstructed and unreadable content is skipped, with every dropped or approximated item reported.
+- **Terminal explorer** — `pdfboss tui`: element tree, object inspector, hex view, page and Markdown previews.
 
 ## Install
 
@@ -30,7 +49,7 @@ pdfboss info    report.pdf                 # version, page count, sizes, metadat
 pdfboss text    report.pdf --page 2        # extract text (omit --page for all)
 pdfboss md      report.pdf                 # markdown: headings, lists, tables from layout
 pdfboss render  report.pdf --page 1 -o page.png --scale 2.0
-pdfboss images  report.pdf -o out/         # extract embedded images as native-size PNGs
+pdfboss images  report.pdf                 # extract embedded images as native-size PNGs
 pdfboss tui     report.pdf                 # interactive terminal explorer
 pdfboss create blank  -o out.pdf --pages 3    # new PDF: empty pages
 pdfboss create text   notes.txt -o out.pdf    # new PDF: word-wrapped text
@@ -70,25 +89,108 @@ for element in doc.elements():             # lazy: physical + logical, byte span
 # Async access over files or http(s) URLs, without reading the whole document.
 doc = await pdfboss.AsyncDocument.open_url("https://example.com/report.pdf")
 async for element in doc.elements():
-    print(element.kind, element.value)
+    print(element.kind, element.value())
 ```
 
-Rust — the library crates are on crates.io (`cargo add pdfboss-core pdfboss-text pdfboss-output pdfboss-render pdfboss-aio pdfboss-tui`):
+Rust — the library crates are on crates.io (`cargo add pdfboss-core pdfboss-text pdfboss-output pdfboss-render pdfboss-write pdfboss-aio pdfboss-tui`):
 
-```rust
+```rust,no_run
 use pdfboss_core::Document;
 
-let doc = Document::open("report.pdf")?;
-let page = doc.page(0)?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    let page = doc.page(0)?;
 
-let text = pdfboss_output::extract_text(&doc, &page)?;
-let markdown = pdfboss_output::extract_markdown(&doc)?;
-let pixmap = pdfboss_render::render_page(&doc, &page, 2.0)?;
-pixmap.save_png("page.png")?;
-let images = pdfboss_render::extract_page_images(&doc, &page)?; // native-size RGBA pixmaps
+    let text = pdfboss_output::extract_text(&doc, &page)?;
+    let markdown = pdfboss_output::extract_markdown(&doc)?;
+    println!("{text}\n{markdown}");
+
+    let pixmap = pdfboss_render::render_page(&doc, &page, 2.0)?;
+    pixmap.save_png("page.png")?;
+
+    let images = pdfboss_render::extract_page_images(&doc, &page)?;
+    println!("{} embedded images", images.len());
+    Ok(())
+}
 ```
 
 </details>
+
+## Extract embedded images
+
+`pdfboss images`, `Page.extract_images()` and `pdfboss_render::extract_page_images` decode every image a page draws — inline images included — at the image's own pixel dimensions, in drawing order, with `/SMask` alpha applied. An image drawn twice appears twice, and stencil masks (`/ImageMask true`) paint a fill color rather than carrying pixels of their own, so they are skipped.
+
+Real pages draw one-pixel strips and spacers; a size filter keeps the pictures:
+
+```python
+import pdfboss
+
+doc = pdfboss.Document("report.pdf")
+for index in range(len(doc)):
+    for n, image in enumerate(doc[index].extract_images()):
+        if image.width < 64 or image.height < 64:
+            continue
+        with open(f"page-{index}-img-{n}.png", "wb") as out:
+            out.write(image.data)
+```
+
+The same walk from Rust, one `Pixmap` per image:
+
+```rust,no_run
+use pdfboss_core::Document;
+use pdfboss_render::extract_page_images;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    for index in 0..doc.page_count() {
+        let page = doc.page(index)?;
+        for (n, image) in extract_page_images(&doc, &page)?.iter().enumerate() {
+            if image.width < 64 || image.height < 64 {
+                continue;
+            }
+            image.save_png(format!("page-{index}-img-{n}.png"))?;
+        }
+    }
+    Ok(())
+}
+```
+
+## Create PDFs
+
+`pdfboss-write` is the write-side twin of the reader: plain structs compose the document (`Pdf`, `Page`, `PageSize`), a `Canvas` paints content, and a COS-level writer serializes it. Output is deterministic — the same input produces byte-identical files, and the crate never reads clocks or randomness, so dates appear only when supplied.
+
+```rust,no_run
+use pdfboss_write::{Color, ImageData, Page, PageSize, Pdf, Standard14};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut page = Page::new(PageSize::A4);
+    let canvas = &mut page.canvas;
+
+    canvas.text("Quarterly report", 72.0, 760.0, Standard14::HelveticaBold, 24.0)?;
+
+    canvas.set_fill(Color::Rgb(0.13, 0.45, 0.85));
+    canvas.rect(72.0, 744.0, 451.0, 4.0);
+    canvas.fill();
+
+    let chart = canvas.add_image(ImageData::png(&std::fs::read("chart.png")?)?);
+    canvas.draw_image(chart, 72.0, 480.0, 320.0, 240.0);
+
+    let pdf = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    };
+    pdf.save("report.pdf")?;
+    Ok(())
+}
+```
+
+The CLI covers the common shapes as one-liners:
+
+```bash
+pdfboss create blank  -o blank.pdf --pages 3 --size letter
+pdfboss create text   notes.txt -o notes.pdf --font times-roman --font-size 12
+pdfboss create images scan1.png photo.jpg -o scans.pdf
+```
 
 ## Benchmarks
 
@@ -190,7 +292,7 @@ Reproduce with [`benchmarks/bench_scans.py`](benchmarks/README.md).
 
 ## What's inside
 
-Ten crates, one implementation: a from-scratch core with its own JPEG 2000, JBIG2, CCITT and ICC codecs, an anti-aliased rasterizer, layout analysis to plain text and Markdown, async range-fetching I/O, a CLI and TUI, and PyO3 bindings.
+Twelve crates, one implementation: a from-scratch core with its own JPEG 2000, JBIG2, CCITT and ICC codecs, an anti-aliased rasterizer, layout analysis to plain text and Markdown, a deterministic PDF writer, async range-fetching I/O, a CLI and TUI, and PyO3 bindings.
 
 <details>
 <summary><strong>Crate map</strong></summary>
@@ -199,13 +301,15 @@ Ten crates, one implementation: a from-scratch core with its own JPEG 2000, JBIG
 |---|---|
 | `pdfboss-core` | Tokenizer, object model, stream filters, cross-references, object streams, document & page tree, content-stream operators |
 | `pdfboss-text` | Simple and CID/Type0 fonts, standard encodings, `ToUnicode` CMaps, positional text spans |
+| `pdfboss-encoding` | Shared font encoding tables and glyph-name mappings (ISO 32000 Appendix D) |
 | `pdfboss-output` | Layout analysis over those spans (lines, columns, headings, lists, tables, repeated page headers), rendered as plain text or Markdown |
 | `pdfboss-jpx` | JPEG 2000 decoder for `JPXDecode` image streams, implemented from ITU-T T.800 |
 | `pdfboss-icc` | ICC profile parser and colour transform to sRGB, implemented from ICC.1:2010 |
-| `pdfboss-render` | Anti-aliased vector rasterizer (paths, fills, strokes, clipping, color, images, glyph outlines) to RGBA/PNG |
+| `pdfboss-render` | Anti-aliased vector rasterizer (paths, fills, strokes, clipping, color, images, glyph outlines) to RGBA/PNG, plus embedded-image extraction |
+| `pdfboss-write` | PDF creation: COS object writer, content canvas and document assembly, deterministic output |
 | `pdfboss-aio` | Async I/O: range-fetching document access over files or HTTP, without reading the whole file |
 | `pdfboss-cli` | The `pdfboss` command-line tool |
-| `pdfboss-tui` | Interactive terminal explorer (`pdfboss tui`), built on `pdfboss-aio` |
+| `pdfboss-tui` | Interactive terminal explorer (`pdfboss tui`): element tree, object inspector, hex view, page and Markdown previews — built on `pdfboss-aio` |
 | `pdfboss-py` | PyO3 extension module (`pdfboss._pdfboss`) built with maturin |
 
 </details>
@@ -240,6 +344,10 @@ Optional content groups (PDF layers, ISO 32000 §8.11) are honored per the docum
 
 </details>
 
+## Documentation
+
+The [pdfboss book](https://4thel00z.github.io/pdfboss/) covers installation, guides for every surface (text, Markdown, styled spans, rendering, image extraction, creation, async and remote documents, the explorer, encryption) and CLI/Python/Rust reference chapters. It is built with mdBook from [`docs/`](docs/) and deployed through GitHub Pages. Per-crate Rust API documentation is on [docs.rs](https://docs.rs/pdfboss-core).
+
 ## Development
 
 ```bash
@@ -247,6 +355,7 @@ cargo test --workspace          # Rust test suite
 cargo clippy --workspace --all-targets -- -D warnings
 maturin develop                 # build the Python extension into your venv
 pytest                          # Python integration tests
+mdbook serve docs               # live-preview the documentation book
 ```
 
 ## License

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,13 @@
+[book]
+title = "pdfboss"
+description = "A PDF engine written from scratch in Rust: parse, extract text and Markdown, rasterize to PNG, extract images, create PDFs."
+authors = ["4thel00z"]
+language = "en"
+src = "src"
+
+[output.html]
+git-repository-url = "https://github.com/4thel00z/pdfboss"
+edit-url-template = "https://github.com/4thel00z/pdfboss/edit/main/docs/{path}"
+
+[output.html.playground]
+runnable = false

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,27 @@
+# Summary
+
+[Introduction](introduction.md)
+
+# Getting started
+
+- [Installation](installation.md)
+- [Quickstart](quickstart.md)
+
+# Guide
+
+- [Extracting text](guide/text.md)
+- [Markdown output](guide/markdown.md)
+- [Styled spans](guide/spans.md)
+- [Rendering pages](guide/rendering.md)
+- [Extracting images](guide/images.md)
+- [Creating PDFs](guide/creating.md)
+- [Async and remote documents](guide/async.md)
+- [Exploring PDF internals](guide/explorer.md)
+- [Encrypted documents](guide/encryption.md)
+
+# Reference
+
+- [CLI reference](reference/cli.md)
+- [Python API](reference/python.md)
+- [Rust crates](reference/rust.md)
+- [Limitations](reference/limitations.md)

--- a/docs/src/guide/async.md
+++ b/docs/src/guide/async.md
@@ -1,0 +1,128 @@
+# Async and remote documents
+
+`AsyncDocument` opens a PDF without reading the whole file. The open flow fetches only what it needs — the header, the cross-reference chain and the page tree — and every later operation fetches only the byte ranges it touches. The file backend reads windows of the file on demand; the HTTP backend turns each read into a `Range` request, so a document on a server can be paged through without downloading it. A server that ignores `Range` and answers `200` with the full body cannot be range-read: the open fails (in Python, a `PdfError` reading `http: server does not support Range requests`) instead of falling back to a full download.
+
+## Python
+
+Three constructors, all coroutines. Each takes `password=` for encrypted files (see [Encrypted documents](./encryption.md)):
+
+| Constructor | Source |
+|---|---|
+| `AsyncDocument.open(path)` | A local file, read in ranges |
+| `AsyncDocument.open_url(url)` | An http(s) URL, fetched via `Range` requests |
+| `AsyncDocument.from_bytes(data)` | Bytes already in memory |
+
+What is sync and what is a coroutine follows from what the open flow already parsed. `page_count`, `version`, `len(doc)` and page access — `doc[i]`, `doc.page(i)` and every `AsyncPage` geometry property — are plain sync attributes: the xref chain and the page tree were parsed at open, so nothing there needs I/O. Everything that must read more of the file is a coroutine: `extract_text`, `extract_markdown`, `render_pages`, `metadata`, `get_object` on the document, and `extract_text`, `extract_markdown`, `render`, `render_reporting`, `extract_images` and `spans` on a page.
+
+Coroutines are driven by one shared multi-thread tokio runtime behind the asyncio loop. `render_pages` fans pages across the machine's cores as tokio tasks, so the loop stays free while pages rasterize.
+
+```python
+import asyncio
+
+import pdfboss
+
+
+async def main() -> None:
+    doc = await pdfboss.AsyncDocument.open("report.pdf")
+    print(doc.page_count, doc.version)
+
+    text = await doc.extract_text()
+    metadata = await doc.metadata()
+    png = await doc[0].render(scale=2.0)
+
+    async for span in doc.spans(pages=[0]):
+        print(span.text, span.font_name)
+
+
+asyncio.run(main())
+```
+
+`doc.elements()` and `doc.spans()` return async iterators, consumed with `async for`, with the same ordering and salvage semantics as their sync twins — see [Exploring PDF internals](./explorer.md) and [Styled spans](./spans.md).
+
+A remote document differs only in the constructor:
+
+```python
+import asyncio
+
+import pdfboss
+
+
+async def main() -> None:
+    doc = await pdfboss.AsyncDocument.open_url("https://example.com/report.pdf")
+    print(doc.page_count)
+    print(await doc.extract_markdown())
+
+
+asyncio.run(main())
+```
+
+## Rust
+
+`pdfboss_aio::AsyncDocument` has the same constructors: `open`/`open_with_password`, `from_bytes`/`from_bytes_with_password` and — behind the crate's `http` feature — `open_url`/`open_url_with_password`. `with_backend` opens a document over any byte source you build yourself.
+
+```rust,no_run
+use pdfboss_aio::AsyncDocument;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = AsyncDocument::open_url("https://example.com/report.pdf").await?;
+    println!("{} pages", doc.page_count());
+
+    let metadata = doc.metadata().await?;
+    println!("{:?}", metadata.title);
+    Ok(())
+}
+```
+
+### Backends
+
+A document reads through the `Backend` trait: `len()` and `read_at(offset, buf)`, both returning boxed futures so the trait is object-safe and a document can hold `Arc<dyn Backend>`. Four implementations ship with the crate:
+
+- `MemBackend` — bytes fully resident in memory; `from_bytes` uses it directly, with no cache.
+- `FileBackend` — positioned reads (`pread`-style, no shared cursor) run on tokio's blocking thread pool, so disk I/O never stalls the async runtime. The length is captured once at open; the file is treated as immutable while the backend lives.
+- `HttpBackend` (feature `http`) — the length comes from a `HEAD` request's `Content-Length`; each read is a `GET` with a `Range: bytes=` header. A `200` answer where `206` was asked for yields `Error::RangeUnsupported`, and a response body is collected only up to the requested size, so a buggy or hostile server cannot balloon memory.
+- `CachedBackend` — a chunked LRU read cache over any backend: many small reads become few chunk-sized fetches, and hot chunks stay resident up to a byte budget. Defaults: 64 KiB chunks, 32 MiB total.
+
+`open` and `open_url` wrap their backend in a `CachedBackend` automatically. `from_bytes` stays uncached, and `with_backend` adds nothing, so a composition of your own is used exactly as given:
+
+```rust,no_run
+use pdfboss_aio::{AsyncDocument, CachedBackend, FileBackend};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let backend = FileBackend::open("report.pdf").await?;
+    let cached = CachedBackend::with_capacity(backend, 128 * 1024, 64 * 1024 * 1024);
+    let doc = AsyncDocument::with_backend(cached).await?;
+    println!("{} pages", doc.page_count());
+    Ok(())
+}
+```
+
+### The sync crates over an async document
+
+The extraction and rendering crates are written sans-I/O. Each entry point is implemented as a `*_with` function generic over `pdfboss_core::AsyncObjectSource`; the sync signature is that same implementation run over an immediate, no-I/O source. `AsyncDocument` implements `AsyncObjectSource`, so `pdfboss_output::extract_text_with`, `pdfboss_output::extract_page_markdown_with`, `pdfboss_render::render_page_reporting_with` and `pdfboss_render::extract_page_images_with` all run over range-fetching reads unchanged. The document is an `Arc` handle: cloning one to hand to an entry point by value costs two atomic increments.
+
+```rust,no_run
+use pdfboss_aio::AsyncDocument;
+use pdfboss_output::extract_text_with;
+use pdfboss_render::extract_page_images_with;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = AsyncDocument::open("report.pdf").await?;
+    println!("{} pages", doc.page_count());
+
+    let page = doc.page(0)?;
+    let oc = doc.oc_state().await;
+    let text = extract_text_with(doc.clone(), &page, oc.as_ref()).await?;
+    println!("{text}");
+
+    let images = extract_page_images_with(doc.clone(), &page).await?;
+    for (index, image) in images.iter().enumerate() {
+        image.save_png(format!("image-{index}.png"))?;
+    }
+    Ok(())
+}
+```
+
+The `oc` parameter carries the document's optional-content visibility (`doc.oc_state().await`); text and markdown extraction use it to exclude layers the document's default configuration turns off, exactly as the sync entry points do. What the extracted images contain — drawing order, native size, `/SMask` alpha — is described in [Extracting images](./images.md); the sync Rust and Python surfaces are in [Rust crates](../reference/rust.md) and [Python API](../reference/python.md).

--- a/docs/src/guide/creating.md
+++ b/docs/src/guide/creating.md
@@ -1,0 +1,243 @@
+# Creating PDFs
+
+The write side of pdfboss is the `pdfboss-write` Rust crate plus the `pdfboss create` CLI. There is no Python creation API — Python reads PDFs, it does not write them. Everything the writer emits uses the same content-stream IR the reader parses, so a created file round-trips through the rest of the toolkit.
+
+## The document model
+
+A document is plain data: `Pdf { metadata, pages, options }`. The fields are the composition — pages appear in the output in the order of the `Vec`, singleton slots are `Option`s, and `Default` fills everything optional. Each `Page { size, rotation, canvas }` carries its own painted content.
+
+```rust,no_run
+use pdfboss_write::{Page, PageSize, Pdf, Standard14};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut page = Page::new(PageSize::A4);
+    page.canvas
+        .text("Hello from pdfboss", 72.0, 770.0, Standard14::Helvetica, 24.0)?;
+    let pdf = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    };
+    pdf.save("hello.pdf")?;
+    Ok(())
+}
+```
+
+Coordinates are PDF user space: the origin is the bottom-left corner of the page, y grows upward, and one unit is 1/72 inch (a point). `PageSize` offers `A3` (841.89 × 1190.55), `A4` (595.28 × 841.89, the default), `A5` (419.53 × 595.28), `Letter` (612 × 792), `Legal` (612 × 1008) and `Custom { width, height }`; `dimensions()` returns the pair, and `landscape()` swaps it into a `Custom`. `rotation` is a clockwise view rotation in degrees.
+
+Serialization validates rather than guesses: a document with zero pages is an error, and so is a rotation that is not a multiple of 90.
+
+## Canvas
+
+`Canvas` is an imperative painter. Path construction (`move_to`, `line_to`, `curve_to`, `close`) is separate from painting (`fill`, `fill_even_odd`, `stroke`, `close_stroke`, `fill_stroke`, `end_path`), exactly as in PDF content streams. Convenience shapes append complete subpaths: `rect`, `circle` and `ellipse` (four Bézier arcs), and `polygon` over a slice of `pdfboss_core::Point` (fewer than three points appends nothing).
+
+Graphics state follows the same operators: `save`/`restore` push and pop, `transform` concatenates a `pdfboss_core::Matrix` onto the CTM, and `set_line_width`, `set_line_cap`, `set_line_join`, `set_miter_limit` and `set_dash` control stroking. `clip` and `clip_even_odd` intersect the clip region with the current path and consume it. Colors are device colors — `Color::Gray(g)`, `Color::Rgb(r, g, b)`, `Color::Cmyk(c, m, y, k)`, components in `0.0..=1.0`, with `Color::BLACK` and `Color::WHITE` constants — set independently for fill (`set_fill`) and stroke (`set_stroke`). For anything the methods do not cover, `op` pushes a raw `pdfboss_core::content::Op`.
+
+### Text
+
+`canvas.text(text, x, y, font, size)` shows one line with its baseline origin at `(x, y)`. The faces are the fourteen standard fonts every conforming reader provides, as `Standard14` variants: `Helvetica`, `HelveticaBold`, `HelveticaOblique`, `HelveticaBoldOblique`, `TimesRoman`, `TimesBold`, `TimesItalic`, `TimesBoldItalic`, `Courier`, `CourierBold`, `CourierOblique`, `CourierBoldOblique`, `Symbol`, `ZapfDingbats`. No font program is embedded — readers carry these faces.
+
+The twelve text faces encode as WinAnsi. A character outside the encoding is an error, never silently dropped or replaced, and the error is raised before any operator is pushed, leaving the canvas untouched. `Symbol` and `ZapfDingbats` have no encoding tables, so every character is an encoding error in those faces. The library does not wrap or lay out text — one call is one line; `Standard14::text_width(text, size)` returns a string's width from the AFM metrics (bare advance widths, no kerning) for callers doing their own layout.
+
+Fonts are deduplicated document-wide: each distinct face gets one font object, in first-use order, no matter how many pages use it.
+
+### Images
+
+`ImageData` imports or wraps pixels; `add_image` registers it on a canvas and `draw_image(handle, x, y, width, height)` paints it into an axis-aligned box:
+
+- `ImageData::png(&bytes)` — decodes a PNG: truecolor and grayscale (16-bit reduced to 8), palette expanded, alpha split into a soft mask.
+- `ImageData::jpeg(&bytes)` — baseline or progressive JPEG by passthrough: the original bytes are embedded as `/DCTDecode`, dimensions sniffed from the SOF marker. Grayscale and three-component images only.
+- `ImageData::rgb8(w, h, data)`, `gray8(w, h, data)` — 8-bit rasters, `data` length checked against the dimensions.
+- `ImageData::mono(w, h, data)` — 1-bit rasters, rows packed MSB-first and byte-padded; a set bit is black.
+
+Images are embedded per page with no cross-page deduplication — the same raster drawn on two pages is stored twice.
+
+## A complete page
+
+One page with shapes, text in two faces, and a generated raster:
+
+```rust,no_run
+use pdfboss_core::Point;
+use pdfboss_write::{Color, Date, ImageData, Metadata, Page, PageSize, Pdf, Standard14};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut page = Page::new(PageSize::A4);
+    let canvas = &mut page.canvas;
+
+    // A stroked frame with a dash pattern.
+    canvas.set_stroke(Color::Gray(0.3));
+    canvas.set_line_width(1.5);
+    canvas.set_dash(&[6.0, 3.0], 0.0);
+    canvas.rect(36.0, 36.0, 523.28, 769.89);
+    canvas.stroke();
+    canvas.set_dash(&[], 0.0);
+
+    // Filled shapes: a rectangle, a circle, a triangle.
+    canvas.set_fill(Color::Rgb(0.85, 0.2, 0.2));
+    canvas.rect(72.0, 600.0, 120.0, 80.0);
+    canvas.fill();
+    canvas.set_fill(Color::Rgb(0.2, 0.5, 0.85));
+    canvas.circle(280.0, 640.0, 45.0);
+    canvas.fill();
+    canvas.set_fill(Color::Cmyk(0.6, 0.0, 0.9, 0.1));
+    canvas.polygon(&[
+        Point::new(380.0, 600.0),
+        Point::new(500.0, 600.0),
+        Point::new(440.0, 690.0),
+    ]);
+    canvas.fill();
+
+    // Text in two of the fourteen standard faces.
+    canvas.set_fill(Color::BLACK);
+    canvas.text("Quarterly report", 72.0, 540.0, Standard14::HelveticaBold, 28.0)?;
+    canvas.text(
+        "Generated with pdfboss-write.",
+        72.0,
+        510.0,
+        Standard14::TimesRoman,
+        12.0,
+    )?;
+
+    // A generated raster, embedded and drawn at 200 x 100 pt.
+    let mut pixels = Vec::with_capacity(64 * 32 * 3);
+    for y in 0..32u32 {
+        for x in 0..64u32 {
+            pixels.extend([(x * 4) as u8, (y * 8) as u8, 128]);
+        }
+    }
+    let gradient = ImageData::rgb8(64, 32, pixels)?;
+    let handle = canvas.add_image(gradient);
+    canvas.draw_image(handle, 72.0, 380.0, 200.0, 100.0);
+
+    let pdf = Pdf {
+        metadata: Some(Metadata {
+            title: Some("Quarterly report".into()),
+            author: Some("pdfboss".into()),
+            creation_date: Some(Date {
+                year: 2026,
+                month: 8,
+                day: 27,
+                hour: 12,
+                minute: 0,
+                second: 0,
+                utc_offset_minutes: 0,
+            }),
+            ..Metadata::default()
+        }),
+        pages: vec![page],
+        ..Pdf::default()
+    };
+    pdf.save("report.pdf")?;
+    Ok(())
+}
+```
+
+To embed an existing file instead of a generated raster: `ImageData::png(&std::fs::read("photo.png")?)?`.
+
+## Metadata and dates
+
+`Metadata` fills the document information dictionary: `title`, `author`, `subject`, `keywords`, `creator`, `producer`, `creation_date`, `modification_date` — every field an `Option`, and an all-`None` value writes no dictionary at all. Dates are explicit `Date { year, month, day, hour, minute, second, utc_offset_minutes }` values; the writer never reads a clock, so dates appear in output only when supplied. Nothing in the crate reads clocks or randomness — the file identifier derives from a hash of the emitted body — so the same input produces byte-identical output.
+
+## Writing the file
+
+Four paths produce the same bytes:
+
+- `pdf.save(path)` — serialize and write to a file.
+- `pdf.to_bytes()` — the whole file as one `Vec<u8>`.
+- `pdf.write_into(impl std::io::Write)` — the same bytes streamed in bounded chunks. An error can leave a prefix of the file already written, and no flush is performed — flush a buffered writer yourself.
+- `pdf.write_into_with(sink).await` — the asynchronous twin over any `AsyncByteSink`; it hands the sink back unflushed. `Vec<u8>` is a sink, and `Immediate` presents any `std::io::Write` as one.
+
+```rust,no_run
+use pdfboss_write::{Page, PageSize, Pdf, Standard14};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut page = Page::new(PageSize::A4);
+    page.canvas
+        .text("Asynchronous emission", 72.0, 770.0, Standard14::Helvetica, 14.0)?;
+    let pdf = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    };
+    let bytes = pdf.write_into_with(Vec::new()).await?;
+    tokio::fs::write("async.pdf", &bytes).await?;
+    Ok(())
+}
+```
+
+`Pdf::options` is a `WriteOptions` controlling file emission. `xref` picks the cross-reference flavor: `XrefStyle::Stream` (the default) emits a compact PDF 1.5+ cross-reference stream, `XrefStyle::Table` a classic `xref` table with a `trailer` dictionary readable by PDF 1.0-era consumers. `compress` Flate-compresses stream data that carries no filter of its own (JPEG passthrough keeps its `/DCTDecode` and is never recompressed). `object_streams` packs non-stream objects into object streams, effective only with `XrefStyle::Stream`. `version` is the header version. The defaults are `Stream`, compressed, object streams on, version 1.7. For maximum compatibility:
+
+```rust,no_run
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+use pdfboss_write::{Page, PageSize, Pdf, Standard14, WriteOptions, XrefStyle};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut page = Page::new(PageSize::Letter);
+    page.canvas
+        .text("Classic xref table", 72.0, 700.0, Standard14::Courier, 12.0)?;
+    let pdf = Pdf {
+        pages: vec![page],
+        options: WriteOptions {
+            xref: XrefStyle::Table,
+            compress: false,
+            object_streams: false,
+            version: (1, 4),
+        },
+        ..Pdf::default()
+    };
+    let mut out = BufWriter::new(File::create("classic.pdf")?);
+    pdf.write_into(&mut out)?;
+    out.flush()?;
+    Ok(())
+}
+```
+
+## CLI
+
+`pdfboss create` covers the three common cases without writing Rust. Blank pages, with `--pages`, `--size` (`a3`, `a4`, `a5`, `letter`, `legal`) and `--landscape`:
+
+```bash
+pdfboss create blank --out blank.pdf --pages 3 --size a5 --landscape
+```
+
+A UTF-8 text file, word-wrapped into pages — `--font` takes any of the fourteen standard faces, plus `--font-size` and `--margin` in points:
+
+```bash
+pdfboss create text notes.txt --out notes.pdf --font times-roman --font-size 12
+```
+
+One page per input image (PNG or JPEG, detected by content); without `--size`, each page matches its image at 72 dpi:
+
+```bash
+pdfboss create images photo.png --out photos.pdf
+```
+
+Each result can be checked immediately with `pdfboss info`, which reports the version, page count and page sizes. The full flag reference is in the [CLI reference](../reference/cli.md).
+
+## Round trip
+
+The writer and the reader are two halves of the same engine: generated content streams parse with `pdfboss_core::content` like any other PDF, so a created document reads back without leaving the process.
+
+```rust,no_run
+use pdfboss_write::{Page, PageSize, Pdf, Standard14};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut page = Page::new(PageSize::A4);
+    page.canvas
+        .text("Round trip", 72.0, 770.0, Standard14::Helvetica, 18.0)?;
+    let pdf = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    };
+    let bytes = pdf.to_bytes()?;
+
+    let doc = pdfboss_core::Document::load(bytes)?;
+    let first = doc.page(0)?;
+    let text = pdfboss_output::extract_text(&doc, &first)?;
+    println!("{text}");
+    Ok(())
+}
+```
+
+This prints `Round trip`. The same holds across tools: `pdfboss info` reads back the metadata, [`pdfboss text`](./text.md) extracts the drawn strings, and [`pdfboss render`](./rendering.md) rasterizes the page. One render detail: the standard fourteen faces carry no embedded font program, and rendering paints embedded programs by default — pass `--fonts full` to substitute bundled faces and see the text in the raster.

--- a/docs/src/guide/encryption.md
+++ b/docs/src/guide/encryption.md
@@ -1,0 +1,127 @@
+# Encrypted documents
+
+pdfboss opens files encrypted with the PDF Standard security handler: RC4
+(40–128-bit, `/V` 1–2, and `/V` 4 with crypt filter `V2`), AES-128 (`/V` 4,
+crypt filter `AESV2`) and AES-256 (`/V` 5, crypt filter `AESV3`). Either the user password or the owner
+password opens the document, and both unlock the same full content. A file
+protected only by an owner password has an empty user password and opens
+transparently, with no password at all.
+
+Non-ASCII passwords are tried UTF-8 encoded and, for the legacy RC4/AES-128
+revisions, Latin-1 encoded as well, covering both encodings real files use.
+
+## Checking whether a file needs a password
+
+`pdfboss info` never fails on an encrypted file — whether the file needs a
+password is the very question being asked:
+
+```bash
+pdfboss info locked.pdf
+```
+
+```text
+version:   1.7
+encrypted: true
+pages:     unknown
+```
+
+`encrypted: true` means the file did not open with the password supplied (by
+default, none). A file that opens — because it is unencrypted, protected only
+by an owner password, or because `--password` carried the right value —
+reports `encrypted: false` along with the full page and metadata listing:
+
+```bash
+pdfboss info --password hunter2 locked.pdf
+```
+
+```text
+version:   1.7
+encrypted: false
+pages:     1
+  page 1: 612 x 792 pt
+```
+
+## CLI
+
+Every subcommand that reads a PDF takes `--password` — `info`, `text`, `md`,
+`render`, `images`, `obj`, `tui`, `json`, `hex` and `q` — accepted as either
+the user or the owner password:
+
+```bash
+pdfboss text --password hunter2 locked.pdf
+```
+
+Apart from `info`, a command given no password (or a wrong one) for a
+password-protected file prints an error and exits nonzero.
+
+## Python
+
+`Document` takes a `password` keyword, and raises `PdfError` when the file
+needs a password it was not given (or the given one is wrong):
+
+```python
+import pdfboss
+
+try:
+    doc = pdfboss.Document("locked.pdf")
+except pdfboss.PdfError:
+    doc = pdfboss.Document("locked.pdf", password="hunter2")
+print(doc.extract_text())
+```
+
+The same keyword exists on the `data=` form of the constructor and on all
+three async constructors — `AsyncDocument.open`, `AsyncDocument.open_url` and
+`AsyncDocument.from_bytes` (see
+[Async and remote documents](./async.md)):
+
+```python
+import asyncio
+
+import pdfboss
+
+async def main() -> None:
+    doc = await pdfboss.AsyncDocument.open("locked.pdf", password="hunter2")
+    print(doc.page_count)
+
+asyncio.run(main())
+```
+
+## Rust
+
+`Document::open` (and `Document::load` for bytes in memory) handles the
+empty-user-password case on its own and returns `Error::Encrypted` when a
+real password is needed; `open_with_password`/`load_with_password` take one:
+
+```rust,no_run
+use pdfboss_core::{Document, Error};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = match Document::open("report.pdf") {
+        Err(Error::Encrypted) => Document::open_with_password("report.pdf", "hunter2")?,
+        other => other?,
+    };
+    println!("{} pages", doc.page_count());
+    Ok(())
+}
+```
+
+A wrong password also comes back as `Error::Encrypted`. The async document
+mirrors the sync surface with `AsyncDocument::open_with_password`,
+`open_url_with_password` and `from_bytes_with_password`:
+
+```rust,no_run
+use pdfboss_aio::AsyncDocument;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = AsyncDocument::open_with_password("report.pdf", "hunter2").await?;
+    println!("{} pages", doc.page_count());
+    Ok(())
+}
+```
+
+Once a document is open, every operation — [text](./text.md),
+[markdown](./markdown.md), [rendering](./rendering.md),
+[images](./images.md) — works exactly as on an unencrypted file; decryption
+happens transparently underneath. Full option listings live in the
+[CLI reference](../reference/cli.md).

--- a/docs/src/guide/explorer.md
+++ b/docs/src/guide/explorer.md
@@ -1,0 +1,156 @@
+# Exploring PDF internals
+
+A PDF is two structures at once: a physical file — header, numbered objects, cross-reference sections, trailer — and the logical document those objects encode — pages, fonts, images, annotations. pdfboss exposes both as one lazy stream of elements, reachable from Python, and from the CLI as a JSON tree, jq queries, hexdumps and an interactive terminal explorer.
+
+## The element model
+
+A walk yields the physical elements first, in file order, each with its byte span in the file:
+
+| kind | What it is |
+|---|---|
+| `header` | The `%PDF-1.x` marker |
+| `object` | One indirect object (`N G obj … endobj`); `ref` carries `(num, gen)` |
+| `xref` | One cross-reference section, table or stream |
+| `trailer` | The trailer dictionary |
+| `startxref` | The `startxref` pointer |
+| `eof` | The `%%EOF` marker |
+
+Then the logical elements, in document order:
+
+| kind | What it is |
+|---|---|
+| `page` | One page; `page` carries the 0-based index |
+| `font`, `image`, `annotation` | A page's resources, under that page's index |
+| `content_op` | One content-stream operator; the span is the range within the page's decoded content stream |
+
+Parsing is lazy: nothing is located, parsed or decoded before it is yielded. Iteration salvages: an element that cannot be parsed raises for that item alone, and the walk continues past it.
+
+## Python
+
+`Document.elements()` returns a lazy iterator; each step releases the GIL while the next element is parsed. Keyword arguments select the layers: `physical=` and `logical=` toggle the two passes, `pages=` restricts logical elements to the 0-based pages given, and `content_ops=True` adds the (high-volume) per-page operators.
+
+```python
+import pdfboss
+
+doc = pdfboss.Document("report.pdf")
+
+for element in doc.elements(logical=False):
+    print(element.kind, element.span, element.ref)
+```
+
+Each `Element` carries `kind`, `span` (byte range, where applicable), `ref` (the `(num, gen)` object reference, where applicable) and `page` (0-based index for logical elements). `value()` converts the element lazily to plain Python data: dicts, lists, `str`, `bytes`, numbers, `bool`, `None`; PDF names become `str`, streams become `{"dict": ..., "length": n}`, references become `{"ref": (num, gen)}`.
+
+```python
+import pdfboss
+
+doc = pdfboss.Document("report.pdf")
+
+for element in doc.elements(physical=False, pages=[0]):
+    if element.kind != "font":
+        continue
+    print(element.value())
+```
+
+A `for` loop stops at the first raising element, so a walk that must survive damage drives the iterator explicitly — a per-item `PdfError` leaves the iterator usable:
+
+```python
+import pdfboss
+
+doc = pdfboss.Document("report.pdf")
+
+elements = doc.elements()
+while True:
+    try:
+        element = next(elements)
+    except StopIteration:
+        break
+    except pdfboss.PdfError as err:
+        print("unreadable element:", err)
+        continue
+    print(element.kind)
+```
+
+`AsyncDocument.elements()` is the async twin — same arguments, same ordering, same salvage semantics, consumed with `async for` ([Async and remote documents](./async.md)).
+
+## CLI
+
+Four subcommands plus the terminal explorer. `json`, `q`, `hex` and `tui` accept a local path or an http(s) URL — a URL is fetched in ranges and never downloaded whole; `obj` takes a local path. Full flag listings are in the [CLI reference](../reference/cli.md).
+
+### json — the document as a JSON value tree
+
+```bash
+pdfboss json report.pdf > report.json
+```
+
+The tree's top-level keys are `header`, `objects` (keyed `"N G"`), `pages`, `xref`, `trailer` and `startxref`. Physical entries carry a `_span` byte range; indirect references appear as `{"_r": [num, gen]}`. `--layout` adds a top-level `layout` array — per page, the inferred blocks: headings, paragraphs, lists, tables. `--pages` restricts the logical layer, `--no-logical` skips it, `--content-ops` adds per-page operators, and `--raw`/`--decode` embed stream data as base64 (still encoded, or decoded).
+
+### q — jq programs over the same tree
+
+```bash
+pdfboss q report.pdf '. | keys'
+pdfboss q report.pdf '[.pages[].fonts[].base_font] | unique'
+pdfboss q report.pdf '.objects["2 0"]'
+```
+
+The second one answers "which fonts does this document use" in one line:
+
+```text
+[
+  "BAMEDE+StoneSans-Bold",
+  "BAMFAO+StoneSerif-Italic",
+  ...
+  "Helvetica",
+  "Helvetica-Bold"
+]
+```
+
+`-r` prints string results raw, and `--hex` hexdumps any result that carries a `_span` instead of printing its JSON — a query language for choosing what to dump.
+
+### hex — the bytes themselves
+
+```bash
+pdfboss hex report.pdf obj:2              # one object's bytes
+pdfboss hex report.pdf trailer            # or: header, xref:0, range:0x100-0x140
+pdfboss hex report.pdf --annotate         # whole file, element boundaries labeled
+```
+
+```text
+000000aa  32 20 30 20 6f 62 6a 0d  3c 3c 20 0d 2f 50 72 6f  |2 0 obj.<< ./Pro|
+000000ba  63 53 65 74 20 5b 20 2f  50 44 46 20 2f 54 65 78  |cSet [ /PDF /Tex|
+```
+
+Selectors: `obj:N[,G]`, `header`, `xref:N` (sections indexed in chain order, newest first), `trailer`, `range:START-END` (offsets decimal or 0x-hex); without one, the whole file. `--annotate` prints a labeled boundary line as the dump crosses each element.
+
+### obj — one object, pretty-printed
+
+```bash
+pdfboss obj report.pdf 2
+```
+
+```text
+<<
+  /ColorSpace <<
+    /Cs5 122 0 R
+    ...
+  >>
+  /ExtGState <<
+    /GS1 148 0 R
+  >>
+  /Font <<
+    /F1 132 0 R
+    ...
+  >>
+  /ProcSet [/PDF /Text /ImageB /ImageC]
+  ...
+>>
+```
+
+### tui — the interactive explorer
+
+```bash
+pdfboss tui report.pdf
+```
+
+The screen splits into a tree pane on the left, an inspector above a hex pane on the right, and a status bar. The tree is the element model as a lazy hierarchy — Document → Pages (each with its Fonts, Images, Annotations and Contents) → Objects → Xref sections → Trailer — populated by background tasks as sections expand. The inspector pretty-prints the selection; `d` cycles it through raw bytes, decoded bytes and disassembled content operators for streams, and `Enter` jumps through any `N G R` reference under the cursor (`Backspace` goes back). `p` swaps the inspector for a rasterized page preview and `m` for the page's Markdown. The hex pane tracks the selection's bytes.
+
+`Tab` cycles focus, arrows or `j`/`k`/`h`/`l` move, `g`/`G` jump to top/bottom, `/` searches (with `n`/`N` for next/previous hit), `q` quits. Long operations — element streaming, hex fetches, search, preview rasterization — run off the event loop, so input never blocks, including over an HTTP-backed document.

--- a/docs/src/guide/images.md
+++ b/docs/src/guide/images.md
@@ -1,0 +1,175 @@
+# Extracting images
+
+pdfboss extracts the images a page draws — photographs, scans, logos, figures —
+each decoded at its own pixel dimensions and delivered as RGBA with alpha.
+Three surfaces expose it: the `pdfboss images` CLI command,
+`Page.extract_images` in Python, and `pdfboss_render::extract_page_images` in
+Rust. To rasterize a whole page to a single PNG instead, see
+[Rendering pages](./rendering.md).
+
+## What gets extracted
+
+Extraction walks the page's content stream and collects an image at every
+point where one is drawn:
+
+- **Occurrence-based.** The result reflects what the page draws, not what its
+  resources contain. An image drawn twice appears twice; an image XObject
+  listed in the resources but never drawn does not appear at all.
+- **Drawing order.** Images come back in the order the content draws them.
+- **Form XObjects are followed.** An image drawn inside a form — a reused
+  header graphic, a stamped figure — is reached through the form, to the same
+  bounded nesting depth the renderer uses, so a form that draws itself
+  terminates instead of recursing forever.
+- **Inline images are included.** `BI … ID … EI` sequences embedded directly
+  in the content stream extract like any image XObject.
+- **Stencil masks are skipped.** An image with `/ImageMask true` paints the
+  current fill color through a 1-bit stencil; it carries no pixels of its own,
+  so there is nothing to extract.
+- **`/SMask` becomes the alpha channel.** An image's soft mask is merged into
+  the output as straight (non-premultiplied) alpha.
+- **Native size.** Each image decodes at its own `/Width` × `/Height`, never
+  at render resolution or at the size it occupies on the page. A 3000 × 2000
+  photo scaled into a thumbnail box still comes out at 3000 × 2000.
+- **Optional content is not consulted.** An image inside a hidden `/OC` group
+  is still embedded in the file, so it still extracts.
+- **Lenient.** Content that cannot be read or decoded contributes nothing
+  rather than failing the call, matching how rendering skips what it cannot
+  draw.
+
+## Filtering small images
+
+There is no hidden minimum-size filter: every drawn image comes back,
+including one-pixel spacers and thin decorative strips. Each result carries
+its native width and height, so callers apply their own threshold — the
+synchronous Python and Rust examples below skip anything under 100 × 100
+pixels.
+
+## CLI
+
+`pdfboss images` writes every image the selected pages draw as a PNG named
+`page-N-image-M.png`, with both numbers 1-based and `M` counting in drawing
+order within the page:
+
+```bash
+mkdir images
+pdfboss images --page 6 -o images report.pdf
+```
+
+```text
+wrote images/page-6-image-1.png (137 x 178 px)
+wrote images/page-6-image-2.png (750 x 989 px)
+wrote images/page-6-image-3.png (132 x 177 px)
+wrote images/page-6-image-4.png (216 x 295 px)
+wrote images/page-6-image-5.png (144 x 168 px)
+wrote images/page-6-image-6.png (50 x 120 px)
+wrote images/page-6-image-7.png (165 x 211 px)
+wrote images/page-6-image-8.png (145 x 188 px)
+wrote images/page-6-image-9.png (165 x 206 px)
+extracted 9 images
+```
+
+Without `--page` every page is processed. `-o` names the output directory
+(default: the current directory); it must already exist. `--png-compression`
+trades encode time against file size — `none`, `fast`, `default` or `best`,
+all producing the same pixels. A page whose images cannot be decoded writes
+nothing for them and still exits 0.
+
+## Python
+
+`Page.extract_images` returns a list of `PageImage` objects, each holding the
+PNG-encoded pixels as `data` plus the native `width` and `height`. Saving
+every sufficiently large image in a document:
+
+```python
+from pathlib import Path
+
+import pdfboss
+
+doc = pdfboss.Document("report.pdf")
+out = Path("images")
+out.mkdir(exist_ok=True)
+for number, page in enumerate(doc, start=1):
+    for i, image in enumerate(page.extract_images(), start=1):
+        if image.width < 100 or image.height < 100:
+            continue
+        target = out / f"page-{number}-image-{i}.png"
+        target.write_bytes(image.data)
+        print(f"{target}: {image.width} x {image.height}")
+```
+
+The drawing-order index `i` is kept even for skipped images, so file names
+stay aligned with what `pdfboss images` would produce. `extract_images`
+accepts the same `compression` argument as `render` (`"none"`, `"fast"`,
+`"default"`, `"best"`).
+
+`AsyncPage.extract_images` is the async twin, with the same drawing-order,
+native-size and leniency semantics (see
+[Async and remote documents](./async.md)):
+
+```python
+import asyncio
+
+import pdfboss
+
+async def main() -> None:
+    doc = await pdfboss.AsyncDocument.open("report.pdf")
+    page = doc.page(0)
+    images = await page.extract_images()
+    print(f"page 1 draws {len(images)} images")
+
+asyncio.run(main())
+```
+
+## Rust
+
+`pdfboss_render::extract_page_images` returns `Vec<Pixmap>` — RGBA8 pixels
+with straight alpha, row-major from the top-left, with public `width`,
+`height` and `data` fields. `Pixmap::save_png` writes one to disk;
+`encode_png`/`encode_png_with` produce the bytes in memory. With
+`pdfboss-core` and `pdfboss-render` as dependencies:
+
+```rust,no_run
+use pdfboss_core::Document;
+use pdfboss_render::extract_page_images;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    let page = doc.page(0)?;
+    let images = extract_page_images(&doc, &page)?;
+    for (i, image) in images.iter().enumerate() {
+        if image.width < 100 || image.height < 100 {
+            continue;
+        }
+        image.save_png(format!("image-{}.png", i + 1))?;
+        println!("image-{}.png: {} x {}", i + 1, image.width, image.height);
+    }
+    Ok(())
+}
+```
+
+`extract_page_images_with` is the same walk over any
+`pdfboss_core::AsyncObjectSource`. `pdfboss_aio::AsyncDocument` implements
+that trait and is an `Arc` handle, so cloning one to pass by value is cheap
+(with `pdfboss-aio`, `pdfboss-render` and `tokio` as dependencies):
+
+```rust,no_run
+use pdfboss_aio::AsyncDocument;
+use pdfboss_render::extract_page_images_with;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = AsyncDocument::open("report.pdf").await?;
+    for index in 0..doc.page_count() {
+        let page = doc.page(index)?;
+        let images = extract_page_images_with(doc.clone(), &page).await?;
+        for (i, image) in images.iter().enumerate() {
+            image.save_png(format!("page-{}-image-{}.png", index + 1, i + 1))?;
+        }
+    }
+    Ok(())
+}
+```
+
+The async form works identically over a remote document opened with
+`AsyncDocument::open_url`, fetching only the byte ranges the images need.
+Full option listings live in the [CLI reference](../reference/cli.md).

--- a/docs/src/guide/markdown.md
+++ b/docs/src/guide/markdown.md
@@ -1,0 +1,125 @@
+# Markdown output
+
+Markdown output runs layout analysis over the same positioned spans that
+[plain text extraction](./text.md) flattens, and renders the result as CommonMark.
+The analysis infers:
+
+- **Headings** — ATX headings (`#` … `######`), ranked by font size. With
+  whole-document extraction the sizes are ranked against every page at once, so a
+  title page or a chapter opener — all of it larger than body text — is read as
+  headings rather than as its own idea of body size. Page-local extraction ranks
+  against that page alone; a page whose text is all one size has no heading to
+  find. Prefer document-wide extraction whenever the document is at hand.
+- **Lists** — bulleted and numbered. Bullets render as `- ` regardless of the
+  source glyph; numbered items keep their detected number as `n. `.
+- **Tables** — detected both from column gaps and from drawn borders, so bordered
+  grids and boxed lists without column gaps are found too. When a table's structure
+  is drawn as ruled lines, those borders decide the grid ahead of column occupancy.
+  Tables render as pipe tables while every cell stands in one column, and as HTML
+  tables as soon as a cell spans several.
+- **Two-column pages** — read column-major: the left column top to bottom, then the
+  right.
+- **Page headers, footers and page numbers** — a page's first or last line,
+  repeated near-verbatim at the same height on at least half the pages (three at
+  minimum), is tagged
+  as a running page header or footer; a line that is nothing but a page number is
+  tagged without any repetition required. Tagged lines are dropped from the
+  Markdown output.
+
+## CLI
+
+```bash
+pdfboss md report.pdf
+```
+
+`--page` extracts one page, 1-based; heading sizes are then ranked per page rather
+than across the document:
+
+```bash
+pdfboss md --page 4 report.pdf
+```
+
+Warnings for skipped content appear on stderr, exactly as for `pdfboss text` — see
+[lenient semantics](./text.md#lenient-semantics-and-reporting).
+
+## Before and after
+
+Page 4 of a physics report carries a cut-flow table. Plain text extraction flattens
+it into space-separated lines:
+
+```text
+Table 4: Muon RD Branch no. 1
+Cuts km2loose acc km2tight acc bipulkm2acc acc
+BADRUN 5189813 (-) 5189813 (-) - (-)
+ictime − cktbm 3324048 (-) 3324048 (-) - (-)
+icbit 3322245 (-) 3322245 (-) - (-)
+```
+
+`pdfboss md --page 4 report.pdf` recovers the grid (first rows shown):
+
+```text
+Table 4: Muon RD Branch no. 1
+
+| Cuts | km2loose acc | km2tight acc | bipulkm2acc acc |
+| --- | --- | --- | --- |
+| BADRUN | 5189813 (-) | 5189813 (-) | - (-) |
+| ictime − cktbm | 3324048 (-) | 3324048 (-) | - (-) |
+| icbit | 3322245 (-) | 3322245 (-) | - (-) |
+```
+
+## Python
+
+```python
+from pdfboss import Document
+
+doc = Document("report.pdf")
+
+markdown = doc.extract_markdown()       # whole document, headings ranked globally
+page_md = doc[3].extract_markdown()     # one page, headings ranked per page
+```
+
+`Document.extract_markdown` extracts the pages in parallel and releases the GIL,
+like `extract_text`.
+
+## Rust
+
+Whole document, with `pdfboss_output::extract_markdown`:
+
+```rust,no_run
+use pdfboss_core::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    let markdown = pdfboss_output::extract_markdown(&doc)?;
+    println!("{markdown}");
+    Ok(())
+}
+```
+
+One page, with `extract_page_markdown`:
+
+```rust,no_run
+use pdfboss_core::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    let page = doc.page(0)?;
+    let markdown = pdfboss_output::extract_page_markdown(&doc, &page)?;
+    println!("{markdown}");
+    Ok(())
+}
+```
+
+`extract_markdown_reporting` returns the Markdown together with one
+`ExtractReport` per page, in page order — the same accountability contract as text
+extraction: unreadable content costs its own text and nothing else, and the report
+says what was left out. See
+[lenient semantics](./text.md#lenient-semantics-and-reporting) for the report's
+shape. Asynchronous callers compose `extract_page_markdown_with` against any object
+source — see [Async and remote documents](./async.md).
+
+Emphasis survives into the output: bold and italic runs render as `**bold**` and
+`*italic*` inside paragraphs and list items. Headings drop emphasis markers — a
+heading is already the strongest thing on the page. Blocks are separated by a blank
+line, across page boundaries too, so the document reads as one continuous Markdown
+file. For the raw style information itself, see [Styled spans](./spans.md).

--- a/docs/src/guide/rendering.md
+++ b/docs/src/guide/rendering.md
@@ -1,0 +1,169 @@
+# Rendering pages
+
+pdfboss rasterizes pages to RGBA pixels with anti-aliasing and encodes them as
+PNG. The scale factor is the points-to-pixels ratio: at `1.0` one PDF point
+becomes one pixel, so a US Letter page renders to 612 × 792 pixels; at `2.0`
+to 1224 × 1584. The pixel size is `ceil(crop_w * scale) × ceil(crop_h *
+scale)` after page rotation, on a white background.
+
+This chapter is about rasterizing whole pages. To pull out the images a page
+*embeds*, at their native resolution, see [Extracting images](./images.md).
+
+## CLI
+
+```bash
+pdfboss render report.pdf --page 1
+pdfboss render report.pdf --page 1 --scale 2 -o page-1@2x.png
+```
+
+The first form writes `page-1.png` (`--page` is 1-based). Further flags:
+
+- `--fonts <FONTS>` — which fonts to paint: `embedded-only`, `all-embedded`
+  (default) or `full` (see the tiers below).
+- `--font-dir <FONT_DIR>` — a directory of substitute faces for `--fonts
+  full`, one file per `pdfboss_render::substitute::face_filename` (e.g. an
+  installed `pdfboss-fonts` package). Overrides the compiled-in OFL set.
+- `--png-compression <PNG_COMPRESSION>` — `none`, `fast`, `default` or
+  `best`.
+- `--password <PASSWORD>` — for encrypted files, covered in
+  [Encrypted documents](./encryption.md).
+
+Anything the render dropped is warned on stderr.
+
+## Font tiers
+
+Glyph painting is staged in tiers; each tier is a strict superset of the
+previous one.
+
+- **`embedded-only`** paints only embedded TrueType outlines — the fastest
+  tier, and TrueType only, not every embedded font.
+- **`all-embedded`** (the default) paints every embedded font program:
+  TrueType, CFF, Type1 and Type3.
+- **`full`** additionally substitutes a replacement face for non-embedded
+  simple fonts: from a directory you supply (`--font-dir`, `font_dir=`), or
+  from the compiled-in OFL Croscore set (Arimo/Tinos/Cousine,
+  metric-compatible with Helvetica/Times/Courier). In Python, `pip install
+  pdfboss[full]` installs those faces as the `pdfboss-fonts` package; with
+  neither `font_dir` nor that package available, `fonts="full"` raises
+  `ValueError`.
+
+Text a tier leaves unpainted still advances — through the PDF's own `/Widths`,
+or the Adobe Core-14 AFM tables for a standard-14 face — so everything painted
+around it stays where the page put it. `/Symbol` and `/ZapfDingbats` have no
+license-clean substitute and stay blank; see
+[Limitations](../reference/limitations.md).
+
+## Leniency and reporting
+
+Rendering never fails because one construct in a page would not read: content
+pdfboss cannot fetch, decode or parse is skipped and the rest of the page
+still rasterizes. The honest consequence is that a page can come back blank
+without an error. The reporting variants return what was dropped or
+approximated, one line per distinct loss — for example
+`"153 glyphs skipped: no glyph for code 9 in /MBIPWP+Times-Roman"` or
+`"6 annotations skipped: the resource is missing"`. An empty report means the
+page rasterized exactly as it describes itself.
+
+Two things are deliberately not reported, because they are configured behavior
+rather than a failure: text left unpainted by the requested font tier, and
+content in optional-content layers (PDF layers) the document's default
+configuration turns off — the latter is counted separately, on the report's
+`hidden` counter in Rust.
+
+## Python
+
+`Page.render` returns PNG bytes. `scale` must be positive and finite
+(`ValueError` otherwise).
+
+```python
+from pathlib import Path
+
+import pdfboss
+
+doc = pdfboss.Document("report.pdf")
+page = doc[0]
+png = page.render(scale=2.0)
+Path("page-1.png").write_bytes(png)
+```
+
+`render` accepts `fonts=` (`"embedded-only"`, `"all-embedded"`, `"full"`),
+`font_dir=` and `compression=` (`"none"`, `"fast"`, `"default"`, `"best"`),
+and releases the GIL while it runs. `Page.render_reporting` renders the same
+way and returns `(png, warnings)`:
+
+```python
+png, warnings = page.render_reporting()
+for line in warnings:
+    print(line)
+```
+
+`Document.render_pages` renders many pages fanned out across the machine's
+cores: every page by default, or the 0-based `pages` given, returned in the
+order given.
+
+```python
+pngs = doc.render_pages(scale=2.0)
+first_two_reversed = doc.render_pages(pages=[1, 0])
+```
+
+All three have async twins on `AsyncPage`/`AsyncDocument`, which also render
+documents opened over HTTP — see
+[Async and remote documents](./async.md).
+
+## PNG compression
+
+The compression level trades encode time against file size; every level
+produces the same pixels. `none` is fastest and largest, `fast` is very fast
+with a decent ratio, `default` balances the two, and `best` produces the
+smallest files, much slower. The level only touches the PNG encoder — pick it
+by whether you are writing throwaway intermediates or archiving.
+
+## Rust
+
+`pdfboss_render::render_page(doc, page, scale)` returns a `Pixmap`: `width`,
+`height`, and `data` holding `width * height * 4` RGBA bytes (straight alpha,
+row-major from the top-left). `Pixmap::save_png` writes it to a file;
+`encode_png`/`encode_png_with` return the bytes, the latter taking a
+`PngCompression` (`None`, `Fast`, `Balanced` — the level the other surfaces
+call `default` — or `Best`).
+
+`render_page_with_options` adds `RenderOptions`: `glyph_painting` selects the
+`GlyphPainting` tier (`EmbeddedTrueTypeOnly`, `AllEmbedded`, `Full`),
+`substitutes` says where the `Full` tier's replacement faces come from
+(`SubstituteSource::Builtin` for the compiled-in OFL set, behind the
+`substitute-fonts` Cargo feature, or `SubstituteSource::Dir(path)`; the
+default `SubstituteSource::None` substitutes nothing, so `Full` behaves like
+`AllEmbedded` until you opt in), and `cache` shares one `RenderCache` of
+loaded fonts across a whole-document walk. `render_page_reporting` returns the
+`RenderReport` alongside the pixels; `report.summary()` is a one-line count
+per kind, `report.warnings()` one line per distinct drop.
+
+```rust,no_run
+use pdfboss_core::Document;
+use pdfboss_render::{
+    render_page, render_page_reporting, GlyphPainting, PngCompression, RenderOptions,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    let page = doc.page(0)?;
+
+    let pixmap = render_page(&doc, &page, 2.0)?;
+    pixmap.save_png("page-1.png")?;
+
+    let opts = RenderOptions {
+        glyph_painting: GlyphPainting::EmbeddedTrueTypeOnly,
+        ..RenderOptions::default()
+    };
+    let (pixmap, report) = render_page_reporting(&doc, &page, 1.0, &opts)?;
+    if let Some(summary) = report.summary() {
+        eprintln!("{summary}");
+    }
+    for warning in report.warnings() {
+        eprintln!("{warning}");
+    }
+    let png = pixmap.encode_png_with(PngCompression::Best)?;
+    std::fs::write("page-1-small.png", png)?;
+    Ok(())
+}
+```

--- a/docs/src/guide/spans.md
+++ b/docs/src/guide/spans.md
@@ -1,0 +1,135 @@
+# Styled spans
+
+[Text extraction](./text.md) gives you a page as flowing plain text. Spans are
+the layer underneath: each span is one positioned run of text together with
+everything the file states about how it is shown — position, size, font,
+weight, color, visibility. Use spans when you need to know not just *what* a
+page says but *where* and *in what style*: finding headings, separating an OCR
+layer from printed text, or feeding a layout analysis of your own.
+
+## What a span carries
+
+| Property | Meaning |
+|---|---|
+| `text` | The decoded text. |
+| `x`, `y` | Device-space origin and baseline of the span. |
+| `end_x` | Device-space x after the last glyph's advance. |
+| `size` | Effective font size. |
+| `font` | Font resource name (e.g. `"F1"`). |
+| `font_name` | The font's `/BaseFont` name verbatim, subset prefix included (e.g. `"NZEVTB+Arial-BoldItalicMT"`); empty when the file names the font nowhere. |
+| `page` | 0-based index of the page the span came from. |
+| `bbox` | Device-space box `(x0, y0, x1, y1)`, y-up: origin to advance horizontally, the font's descent..ascent vertically. |
+| `bold`, `italic` | From FontDescriptor evidence, falling back to the `/BaseFont` name. |
+| `monospace`, `serif` | FontDescriptor `/Flags` FixedPitch and Serif. |
+| `underline`, `strikethrough` | A drawn ruling below the baseline / across the x-height band — see the caveat below. |
+| `rise` | The text rise (`Ts`) the span was shown under: positive above the baseline — a superscript/subscript signal. |
+| `vertical` | Writing mode 1: the text advances downward. |
+| `invisible` | Shown under render mode 3 or 7, which paint nothing. |
+| `color` | Fill color as RGB in `[0, 1]`; `None` for pattern fills. |
+
+Three of these deserve honesty up front:
+
+- **`underline` and `strikethrough` are read from the page's geometry.** PDF
+  has no underline attribute; a span is underlined when a drawn ruling sits
+  just below its baseline covering most of it. A table border hugging a cell's
+  text can read as an underline.
+- **`invisible` is the signature of an OCR text layer.** Scanned PDFs with a
+  text layer draw the page image and then show the recognized text under
+  render mode 3 or 7, which paint nothing. The text extracts normally — it is
+  just never painted.
+- **`color` is `None` for pattern fills**, which have no single color.
+
+## Python
+
+`Page.spans()` returns the page's spans in emission order. It releases the GIL
+while it runs and is lenient the same way text extraction is: unreadable
+content yields no spans rather than raising.
+
+```python
+import pdfboss
+
+doc = pdfboss.Document("report.pdf")
+for span in doc[0].spans():
+    if not span.bold:
+        continue
+    print(f"{span.size:5.1f}pt  {span.font_name:30s}  {span.text!r}")
+```
+
+`Document.spans()` iterates the whole document lazily, page by page: it
+buffers one page's spans at a time, extracts each page with the GIL released,
+and shares one font cache across the walk, so a font used on every page loads
+once. Pass `pages=[...]` (0-based) to restrict the walk, in the order given.
+
+Finding headings — bold text larger than the document's body size — is a
+document-level walk:
+
+```python
+from collections import Counter
+
+import pdfboss
+
+doc = pdfboss.Document("report.pdf")
+sizes: Counter[int] = Counter()
+bold = []
+for span in doc.spans():
+    sizes[round(span.size)] += len(span.text)
+    if span.bold:
+        bold.append(span)
+
+body = sizes.most_common(1)[0][0]
+for span in bold:
+    if span.size <= body:
+        continue
+    print(f"page {span.page + 1}: {span.size:.0f}pt {span.text}")
+```
+
+Detecting an OCR layer is a one-liner over `invisible`:
+
+```python
+spans = doc[0].spans()
+ocr = [span for span in spans if span.invisible]
+print(f"{len(ocr)} of {len(spans)} spans are invisible (an OCR text layer)")
+```
+
+Both have async twins — `await page.spans()` and `async for span in
+doc.spans()` — described in [Async and remote documents](./async.md).
+
+## Rust
+
+`pdfboss_text::extract_spans` returns a `Vec<TextSpan>` carrying the same
+fields as the Python `Span` (as plain struct fields: `text`, `x`, `y`,
+`end_x`, `size`, `font`, `font_name`, `page`, `bbox`, `bold`, `italic`,
+`monospace`, `serif`, `rise`, `vertical`, `invisible`, `color`, `underline`,
+`strikethrough`):
+
+```rust,no_run
+use pdfboss_core::Document;
+use pdfboss_text::extract_spans;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    for index in 0..doc.page_count() {
+        let page = doc.page(index)?;
+        for span in extract_spans(&doc, &page)? {
+            if !span.bold || span.size <= 12.0 {
+                continue;
+            }
+            println!("page {}: {:.0}pt {}", span.page + 1, span.size, span.text);
+        }
+    }
+    Ok(())
+}
+```
+
+The crate also offers `extract_spans_reporting` (an `ExtractReport` naming
+each stream that could not be read — an empty span list with an empty report
+really is an empty page), `extract_spans_reporting_cached` (one `FontCache`
+shared across a whole-document walk, the same trick `Document.spans()` uses),
+and `extract_spans_and_rulings_reporting`, which additionally returns the
+page's `Ruling` segments — the drawn lines the underline and strikethrough
+flags are derived from.
+
+Spans are the input to the layout analysis behind
+[Markdown output](./markdown.md); reach for that chapter when you want
+headings, lists and tables inferred for you rather than deriving them from
+spans yourself.

--- a/docs/src/guide/text.md
+++ b/docs/src/guide/text.md
@@ -1,0 +1,135 @@
+# Extracting text
+
+Text extraction turns a page's positioned glyphs back into readable text: spans are
+grouped into lines, lines are ordered top to bottom and joined with `\n`, and spaces
+are inserted at horizontal gaps. Whole-document extraction joins pages with a form
+feed (`\f`). For structured output — headings, lists, tables — see
+[Markdown output](./markdown.md); for the spans themselves, with fonts, sizes and
+positions, see [Styled spans](./spans.md).
+
+## CLI
+
+```bash
+pdfboss text report.pdf
+```
+
+prints every page, separated by form feeds. `--page` selects one page, 1-based:
+
+```bash
+pdfboss text --page 4 report.pdf
+```
+
+Content that cannot be read is reported on stderr, one warning per skipped stream,
+with the same 1-based page numbers:
+
+```text
+warning: page 17: skipped a form XObject (form limit exceeded)
+```
+
+stdout carries only the extracted text, so the output stays safe to pipe. Encrypted
+files take `--password` — see [Encrypted documents](./encryption.md).
+
+## Python
+
+```python
+from pdfboss import Document
+
+doc = Document("report.pdf")
+
+text = doc.extract_text()           # all pages, joined by "\f"
+page_text = doc[3].extract_text()   # one page (0-based index)
+```
+
+`Document.extract_text` fans the pages out across the machine's cores: each worker
+thread holds its own fork of the document (the immutable parsed core is shared, the
+caches are private), and one font cache serves every worker so each font loads once
+per document. Both calls release the GIL while they run, so other Python threads
+keep making progress during long extractions.
+
+## Rust
+
+Per page, with [`pdfboss_output::extract_text`](https://docs.rs/pdfboss-output):
+
+```rust,no_run
+use pdfboss_core::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    for i in 0..doc.page_count() {
+        let page = doc.page(i)?;
+        let text = pdfboss_output::extract_text(&doc, &page)?;
+        println!("{text}");
+    }
+    Ok(())
+}
+```
+
+For a whole document, `pdfboss_core::map_pages` runs a closure over every page in
+parallel and returns the results in page order. It fans out over
+`std::thread::available_parallelism()` threads, each holding its own document fork;
+workers pull page indexes from a shared counter, so pages of uneven cost cannot
+strand a fast core behind a slow stripe. Pass one `FontCache` to the `_cached`
+variant so fonts load once per document rather than once per page:
+
+```rust,no_run
+use pdfboss_core::{map_pages, Document};
+use pdfboss_output::FontCache;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    let fonts = FontCache::default();
+    let outcomes = map_pages(&doc, |doc, page| {
+        let (text, _) = pdfboss_output::extract_text_reporting_cached(doc, page, &fonts)?;
+        Ok(text)
+    });
+    let texts = outcomes.into_iter().collect::<Result<Vec<String>, _>>()?;
+    println!("{}", texts.join("\u{c}"));
+    Ok(())
+}
+```
+
+Asynchronous callers use `extract_text_with` against any object source — see
+[Async and remote documents](./async.md).
+
+## Lenient semantics and reporting
+
+Extraction is lenient the way rendering is: content that will not fetch, decode, or
+parse yields no text rather than an error, so one unreadable stream never costs the
+rest of the document. `extract_text_reporting` is what keeps that leniency
+accountable — it returns the text together with an `ExtractReport`:
+
+```rust,no_run
+use pdfboss_core::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    let page = doc.page(0)?;
+    let (text, report) = pdfboss_output::extract_text_reporting(&doc, &page)?;
+    for skip in &report.skipped {
+        eprintln!("skipped {} ({})", skip.kind, skip.cause);
+    }
+    println!("{text}");
+    Ok(())
+}
+```
+
+`report.skipped` names each stream that yielded no text — the kind (the page's own
+contents, a form XObject, an unresolvable XObject, a font's CMap encoding) and the
+cause (an unsupported filter, a stream that would not read, content that would not
+parse, a missing resource, an exhausted form nesting or invocation limit).
+`report.hidden` counts
+content the document's optional-content configuration turns off; that is configured
+behavior, not a loss, so `report.is_complete()` ignores it and is true exactly when
+nothing was left out. An empty text with an empty report really is an empty page.
+The CLI warnings above are this report, printed. Layers the document's default
+optional-content configuration disables are excluded from the text.
+
+## Encodings
+
+Character decoding covers `ToUnicode` CMaps, the WinAnsi, MacRoman and Standard
+simple-font encodings, and CID-keyed Type0 fonts: embedded `/Encoding` CMap streams
+parse, the predefined ISO 32000 CJK CMap set is compiled in (behind the
+`predefined-cmaps` feature, on by default in the CLI and the Python wheel), and when
+`/ToUnicode` is absent CIDs map to Unicode through the font's character collection.
+Glyph names resolve through the full Adobe Glyph List conventions, so ligatures
+(`fi`, `fl`, …) and small-caps variants decode to their proper Unicode text.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,0 +1,95 @@
+# Installation
+
+## Python
+
+```bash
+pip install pdfboss
+```
+
+Prebuilt abi3 wheels for CPython 3.12 and later; no Rust toolchain required.
+The wheel compiles in the predefined CJK CMap set, so CJK-coded documents
+extract out of the box.
+
+Rendering with `fonts="full"` substitutes replacement faces for fonts the PDF
+does not embed. Those faces ship as a separate package, pulled in by the
+`full` extra:
+
+```bash
+pip install "pdfboss[full]"
+```
+
+This installs `pdfboss-fonts` alongside the wheel. Without it, `fonts="full"`
+requires a `font_dir` argument pointing at faces of your own — see
+[Rendering pages](./guide/rendering.md).
+
+## CLI
+
+```bash
+cargo install pdfboss-cli
+```
+
+This installs the `pdfboss` binary. Two features are on by default:
+
+- `substitute-fonts` — bundles the OFL Croscore substitute faces (about 4 MB)
+  so `render` and `tui` can paint text for PDFs with non-embedded fonts out of
+  the box.
+- `predefined-cmaps` — compiles in the predefined CJK CMap set of ISO 32000
+  Table 118 (about 830 KB) so `text` reads Shift-JIS/EUC/Big5/GBK/UHC-coded
+  Type0 fonts.
+
+Opt out of both for a leaner binary:
+
+```bash
+cargo install pdfboss-cli --no-default-features
+```
+
+## Rust crates
+
+The library crates are on crates.io:
+
+```bash
+cargo add pdfboss-core pdfboss-text pdfboss-output pdfboss-render pdfboss-write pdfboss-aio
+```
+
+| Crate | Responsibility |
+|---|---|
+| `pdfboss-core` | Parsing, object model, stream filters, document and page tree |
+| `pdfboss-text` | Fonts, encodings, positional text spans |
+| `pdfboss-output` | Layout analysis to plain text and Markdown |
+| `pdfboss-render` | Rasterization to RGBA pixmaps and PNG, embedded-image extraction |
+| `pdfboss-write` | PDF creation |
+| `pdfboss-aio` | Async, range-fetching document access |
+
+Add only what you use — `pdfboss-core` alone parses; the others build on it.
+
+The library crates keep their optional features off by default:
+
+- `pdfboss-render` `substitute-fonts` — the bundled substitute faces.
+- `pdfboss-core` `predefined-cmaps` — the predefined CJK CMap set.
+- `pdfboss-aio` `http` — remote documents over HTTP range requests.
+- `pdfboss-aio` `write` — streaming created documents into tokio writers.
+
+Enable a feature at add time, for example:
+
+```bash
+cargo add pdfboss-aio --features http
+```
+
+## Building from source
+
+```bash
+git clone https://github.com/4thel00z/pdfboss
+cd pdfboss
+cargo build --release           # the CLI lands at target/release/pdfboss
+cargo test --workspace          # Rust test suite
+```
+
+The Python extension builds with [maturin](https://www.maturin.rs) into the
+active virtualenv:
+
+```bash
+maturin develop                 # build the extension into your venv
+pytest                          # Python integration tests
+```
+
+Next: the [Quickstart](./quickstart.md).

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,81 @@
+# Introduction
+
+pdfboss is a PDF engine written from scratch in safe Rust against the ISO 32000
+specification. It is a clean-room implementation: no C dependencies, no
+bindings to another engine, and the image and color codecs a PDF needs —
+JPEG 2000, JBIG2, CCITT, ICC — are its own. One core sits behind every
+surface: the `pdfboss` command-line tool, an interactive terminal explorer
+(`pdfboss tui`), a set of Rust library crates, and a native Python extension.
+
+The surfaces expose the same engine at different altitudes. The CLI covers
+extraction, rendering, creation and explorer subcommands over a document's
+structure; the terminal explorer browses a file interactively, local or
+remote. Python gets `Document` and its async twin `AsyncDocument`, with
+pages, styled spans, lazy element iteration, rendering and image extraction.
+The Rust crates split the core by concern, from parsing (`pdfboss-core`)
+through layout analysis (`pdfboss-output`) and rasterization
+(`pdfboss-render`) to creation (`pdfboss-write`).
+
+## Leniency
+
+Real-world PDFs are damaged: truncated downloads, editors that miscount stream
+lengths, generators that write cross-reference tables pointing nowhere.
+pdfboss reads them anyway:
+
+- A broken or missing cross-reference table is reconstructed by scanning the
+  file for its objects.
+- A stream whose declared length is wrong is still decoded.
+- Content-stream operators that will not parse are skipped, and the rest of
+  the page still extracts and rasterizes.
+
+Leniency never hides what it cost. Every dropped or approximated piece of
+content lands in a report: `pdfboss render` warns on stderr, the terminal
+explorer raises a notice, and the libraries return the report as a value —
+`render_page_reporting` and `extract_text_reporting` in Rust,
+`Page.render_reporting()` in Python. A page that came out exactly as the file
+describes it carries an empty report, so silence means fidelity, not luck.
+
+## Scope
+
+pdfboss extracts plain text and Markdown (headings, lists and tables inferred
+from page layout), yields styled text spans carrying position, font, weight,
+decorations and color, rasterizes pages to PNG through its own JPEG 2000,
+JBIG2, CCITT and ICC codecs, extracts embedded images at their native pixel
+size, creates new PDFs (the `pdfboss-write` crate and the `pdfboss create`
+subcommand — creation has no Python API), and reads documents asynchronously
+over range-fetching I/O, from local files or HTTP, without ever reading the
+whole file.
+
+Encrypted files open through the standard security handler — RC4 and
+AES-128/256, with either the user or the owner password; a file whose user
+password is empty opens without one.
+
+## Where to go next
+
+[Installation](./installation.md) covers the wheel, the binary and the crates;
+the [Quickstart](./quickstart.md) shows each surface doing real work. The
+guide then takes one task per chapter:
+
+- [Extracting text](./guide/text.md) — plain text, reading order, page
+  selection.
+- [Markdown output](./guide/markdown.md) — headings, lists and tables
+  inferred from layout.
+- [Styled spans](./guide/spans.md) — positioned text runs with font, size,
+  weight, decorations and color.
+- [Rendering pages](./guide/rendering.md) — PNG output, scale, font tiers,
+  render reports.
+- [Extracting images](./guide/images.md) — every image a page draws, at
+  native size.
+- [Creating PDFs](./guide/creating.md) — blank, text and image pages from
+  the CLI and Rust.
+- [Async and remote documents](./guide/async.md) — range-fetching access to
+  local files and HTTP URLs.
+- [Exploring PDF internals](./guide/explorer.md) — the JSON value tree, jq
+  queries, hexdumps and the terminal explorer.
+- [Encrypted documents](./guide/encryption.md) — passwords on every surface.
+
+The reference section holds the [CLI reference](./reference/cli.md), the
+[Python API](./reference/python.md), the [Rust crates](./reference/rust.md)
+and the list of [limitations](./reference/limitations.md).
+
+pdfboss is dual-licensed under MIT or Apache-2.0, at your option.

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,0 +1,83 @@
+# Quickstart
+
+One taste of each surface. `report.pdf` stands in for any PDF of yours;
+[Installation](./installation.md) covers getting the binary, the wheel and the
+crates.
+
+## CLI
+
+```bash
+pdfboss info    report.pdf                    # version, page count, page sizes, metadata
+pdfboss text    report.pdf --page 2           # extract text (omit --page for all pages)
+pdfboss md      report.pdf                    # markdown: headings, lists, tables from layout
+pdfboss render  report.pdf --page 1 -o page.png --scale 2.0
+mkdir out
+pdfboss images  report.pdf -o out/            # embedded images as native-size PNGs
+pdfboss create text notes.txt -o notes.pdf    # a new PDF from a word-wrapped text file
+```
+
+`render` prints what it wrote (`wrote page.png (1224 x 1584 px)`) and warns on
+stderr about anything it had to drop; `images` names every file it writes,
+`out/page-1-image-1.png` style. Page numbers are 1-based on the command line.
+
+## Python
+
+```python
+from pathlib import Path
+
+import pdfboss
+
+doc = pdfboss.Document("report.pdf")
+print(doc.page_count, "pages, PDF", doc.version)
+
+text = doc.extract_text()          # all pages, form-feed separated
+markdown = doc.extract_markdown()  # headings, lists, tables from layout
+
+page = doc[0]
+Path("page.png").write_bytes(page.render(scale=2.0))
+
+for image in page.extract_images():
+    print(image.width, image.height, len(image.data))
+```
+
+`Document` also opens from memory (`Document(data=raw_bytes)`), pages index
+0-based with negative indexes from the end, and `render` returns PNG bytes
+directly. `extract_images` yields each image the page draws at its native
+pixel size, PNG-encoded. PDF creation has no Python API — it lives in the CLI
+and the `pdfboss-write` crate; see [Creating PDFs](./guide/creating.md).
+
+## Rust
+
+With `pdfboss-core`, `pdfboss-output` and `pdfboss-render` added:
+
+```rust,no_run
+use pdfboss_core::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = Document::open("report.pdf")?;
+    println!("{} pages", doc.page_count());
+
+    let page = doc.page(0)?;
+    let text = pdfboss_output::extract_text(&doc, &page)?;
+    println!("{text}");
+
+    let pixmap = pdfboss_render::render_page(&doc, &page, 2.0)?;
+    pixmap.save_png("page.png")?;
+    Ok(())
+}
+```
+
+`render_page` returns an RGBA `Pixmap` (`width`, `height`, `data`); `save_png`
+and `encode_png` turn it into a file or bytes. Page indexes are 0-based, as in
+Python; only the CLI counts from 1.
+
+## Next steps
+
+- [Extracting text](./guide/text.md) and [Markdown output](./guide/markdown.md)
+  for layout analysis details.
+- [Rendering pages](./guide/rendering.md) for scale, font tiers and PNG
+  compression.
+- [Extracting images](./guide/images.md) for what counts as an embedded image.
+- [Creating PDFs](./guide/creating.md) for blank, text and image pages.
+- [Async and remote documents](./guide/async.md) for `AsyncDocument` and HTTP
+  range fetching.

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -1,0 +1,206 @@
+# CLI reference
+
+One binary, `pdfboss`, with a subcommand per job. This chapter is the flag inventory; worked examples live in the guide chapters linked from each entry.
+
+Shared behavior:
+
+- Every subcommand that reads a PDF takes `--password <PASSWORD>` for encrypted files — user or owner password; the empty user password opens transparently. See [Encrypted documents](../guide/encryption.md).
+- The explorer subcommands — `tui`, `json`, `hex`, `q` — accept either a local path or an `http(s)://` URL as input; URLs are range-fetched, never downloaded whole. The other subcommands take a local path.
+- Exit codes: 0 on success, 1 for PDF and I/O problems, 2 for an invalid jq program (mirroring clap's own usage-error code). `render` and `images` are lenient: content that cannot be read is skipped with a warning on stderr, and the exit code stays 0.
+
+## info
+
+Show version, page count, page sizes and metadata.
+
+```text
+pdfboss info [OPTIONS] <FILE>
+```
+
+```bash
+pdfboss info report.pdf
+```
+
+## text
+
+Extract text; all pages separated by form feed unless `--page` (1-based) is given. See [Extracting text](../guide/text.md).
+
+```text
+pdfboss text [OPTIONS] <FILE>
+```
+
+```bash
+pdfboss text report.pdf --page 1
+```
+
+## md
+
+Extract markdown, with headings, lists and tables inferred from layout. `--page <PAGE>` restricts to one 1-based page — heading sizes are then judged per page, not across the document. See [Markdown output](../guide/markdown.md).
+
+```text
+pdfboss md [OPTIONS] <FILE>
+```
+
+```bash
+pdfboss md report.pdf > report.md
+```
+
+## render
+
+Render a page to PNG. See [Rendering pages](../guide/rendering.md).
+
+```text
+pdfboss render [OPTIONS] --page <PAGE> <FILE>
+```
+
+- `--page <PAGE>` — 1-based page number (required)
+- `-o, --out <OUT>` — output file (default: `page-N.png`)
+- `--scale <SCALE>` — scale factor (default: 1)
+- `--fonts <FONTS>` — which fonts to paint: `embedded-only` (only embedded TrueType outlines, fastest), `all-embedded` (every embedded program, the default), `full` (also substitute bundled faces for non-embedded fonts)
+- `--font-dir <FONT_DIR>` — directory of substitute faces for `--fonts full`; overrides the compiled-in OFL set
+- `--png-compression <PNG_COMPRESSION>` — `none`, `fast`, `default` or `best`: encode time against file size, same pixels
+
+```bash
+pdfboss render --page 1 --scale 2 -o page-1.png report.pdf
+```
+
+## images
+
+Extract every image a page draws, each as a native-size PNG. See [Extracting images](../guide/images.md).
+
+```text
+pdfboss images [OPTIONS] <FILE>
+```
+
+- `--page <PAGE>` — 1-based page number (default: all pages)
+- `-o, --out <OUT>` — output directory, which must already exist (default: current directory)
+- `--png-compression <PNG_COMPRESSION>` — as in `render`
+
+```bash
+pdfboss images report.pdf --page 1 -o out
+```
+
+## obj
+
+Pretty-print a single object by number, with an optional generation number (default 0).
+
+```text
+pdfboss obj [OPTIONS] <FILE> <NUM> [GEN]
+```
+
+```bash
+pdfboss obj report.pdf 1
+```
+
+## tui
+
+Explore a PDF interactively in the terminal: element tree, object inspector, hex view, page preview and Markdown preview. Takes a path or `http(s)` URL and requires an interactive terminal. See [Exploring PDF internals](../guide/explorer.md).
+
+```text
+pdfboss tui [OPTIONS] <TARGET>
+```
+
+```bash
+pdfboss tui report.pdf
+```
+
+## json
+
+Dump the document as a JSON value tree, for piping to external tools.
+
+```text
+pdfboss json [OPTIONS] <INPUT>
+```
+
+- `--raw` — embed raw (still encoded) stream data as base64
+- `--decode` — embed decoded stream data as base64
+- `--pages <PAGES>` — restrict logical elements to these 1-based pages (comma separated)
+- `--no-logical` — skip the logical layer (pages/fonts/images/annotations)
+- `--content-ops` — include per-page content-stream operators (high volume)
+- `--layout` — include per-page layout blocks (headings, paragraphs, lists, tables)
+
+```bash
+pdfboss json report.pdf --no-logical > tree.json
+```
+
+## hex
+
+Hexdump the file or a selected element, hexyl-style.
+
+```text
+pdfboss hex [OPTIONS] <INPUT> [SELECTOR]
+```
+
+The selector is one of `obj:N[,G]`, `header`, `xref:N`, `trailer` or `range:START-END` (offsets decimal or `0x`-hex; xref sections indexed in chain order, newest first); without one, the whole file is dumped.
+
+- `--annotate` — print labeled element boundaries as the dump crosses them
+- `--width <WIDTH>` — bytes per row (default: 16)
+
+```bash
+pdfboss hex report.pdf header
+```
+
+## q
+
+Run a jq program over the document's JSON value tree (the same tree `json` prints).
+
+```text
+pdfboss q [OPTIONS] <INPUT> <PROGRAM>
+```
+
+- `--raw`, `--decode`, `--pages <PAGES>`, `--no-logical`, `--content-ops` — as in `json`
+- `--hex` — hexdump results carrying a `_span` instead of printing JSON
+- `-r` — print string results raw, without quotes (like `jq -r`)
+
+```bash
+pdfboss q report.pdf -r '.pages[].fonts[].base_font'
+```
+
+## create
+
+Create a new PDF: blank pages, word-wrapped text, or image pages.
+
+```text
+pdfboss create <COMMAND>
+```
+
+Three subcommands, each writing to `-o, --out <OUT>`. All three share `--size a3|a4|a5|letter|legal` and `--landscape` (swap page width and height). See [Creating PDFs](../guide/creating.md).
+
+### create blank
+
+Empty pages. `--pages <PAGES>` sets the page count (default: 1); `--size` defaults to `a4`.
+
+```text
+pdfboss create blank [OPTIONS] --out <OUT>
+```
+
+```bash
+pdfboss create blank -o blank.pdf --pages 3 --size letter
+```
+
+### create text
+
+A UTF-8 text file, word-wrapped into pages.
+
+```text
+pdfboss create text [OPTIONS] --out <OUT> <INPUT>
+```
+
+- `--font <FONT>` — one of the fourteen standard fonts: `helvetica` (default), `helvetica-bold`, `helvetica-oblique`, `helvetica-bold-oblique`, `times-roman`, `times-bold`, `times-italic`, `times-bold-italic`, `courier`, `courier-bold`, `courier-oblique`, `courier-bold-oblique`, `symbol`, `zapf-dingbats`
+- `--font-size <FONT_SIZE>` — font size in points (default: 11)
+- `--margin <MARGIN>` — page margin in points, all four sides (default: 72)
+
+```bash
+pdfboss create text notes.txt -o notes.pdf --font times-roman --font-size 12
+```
+
+### create images
+
+One page per input image (PNG or JPEG, detected by content). Without `--size`, each page matches its image at 72 dpi; `--landscape` is only meaningful with `--size`.
+
+```text
+pdfboss create images [OPTIONS] --out <OUT> <INPUTS>...
+```
+
+```bash
+pdfboss create images scan-1.png scan-2.png -o scans.pdf
+```

--- a/docs/src/reference/limitations.md
+++ b/docs/src/reference/limitations.md
@@ -1,0 +1,40 @@
+# Limitations
+
+Rendering is lenient and it says so: content pdfboss cannot read is skipped so the rest of the page still rasterizes, and every dropped or approximated item lands in a report — `pdfboss render` warns on stderr, the terminal explorer raises a notice, and the libraries return it through `render_page_reporting` (Rust) and `Page.render_reporting()` (Python). See [Rendering pages](../guide/rendering.md) for the reporting APIs.
+
+The whole not-yet-supported list is two faces: `/Symbol` and `/ZapfDingbats` have no license-clean substitute, so they stay blank rather than borrowing an unrelated face's glyphs.
+
+## Fonts
+
+Glyph painting is staged in tiers — `embedded-only`, `all-embedded`, `full` — selected with `--fonts` (CLI), the `fonts` parameter (Python) or `RenderOptions::glyph_painting` (Rust); the tiers are described in [Rendering pages](../guide/rendering.md#font-tiers). What stays limited:
+
+- `full` substitutes only **non-embedded simple** fonts, and a bold *sans* substitute is not visually distinct from regular weight.
+- Standard-14 advance widths come from the Adobe Core-14 AFM tables when a substitute is used, behind the PDF's own `/Widths`.
+
+## CMaps and CID fonts
+
+Type0 `/Encoding` CMaps resolve — the predefined ISO 32000 Table 118 CJK set is compiled in (behind the `predefined-cmaps` feature, on by default in the CLI and the wheel), embedded CMap streams parse the same way, widths key on the mapped CID, vertical text (`WMode` 1) advances by `/W2`/`/DW2` with the default position vector, and extraction maps CIDs to Unicode through the character collection when `/ToUnicode` is absent.
+
+Deferred: vertical runs still extract as horizontal-schema spans, one per show operator, with x/y at the glyph origin.
+
+## JBIG2
+
+`JBIG2Decode` covers the embedded stream format end to end: generic regions (all four templates, with TPGDON, arithmetic or MMR-coded), symbol dictionaries and text regions in both the arithmetic and the Huffman variant — refinement/aggregate-coded symbols and refined instance placements included — pattern dictionaries and halftone regions, generic refinement regions (both templates, with TPGRON) refining either the page or a retained intermediate region, intermediate regions of every type, and custom code table segments. Nothing in the standard's segment type table is refused; a malformed or truncated stream fails with a message naming what was wrong instead of rendering a blank.
+
+## Colour
+
+Colour converts to sRGB. `ICCBased` spaces parse their embedded profile (v2 and v4; matrix/TRC and grayTRC models, and `A2B0` lookup pipelines): a profile equivalent to sRGB keeps the exact device-RGB path, others transform per colour with Bradford adaptation from the D50 connection space, and a profile that will not parse falls back to the `/N` channel-count reduction. `CalRGB`, `CalGray`, and `Lab` convert through CIE XYZ the same way.
+
+Only a profile's default transform is used — rendering intents are not switched — and `DeviceN` keeps a tint approximation.
+
+## JPEG 2000
+
+`JPXDecode` implements ITU-T T.800 (JPEG 2000 Part 1); what it approximates it reports as a render warning rather than passing off silently.
+
+ICC profiles embedded in the JPEG 2000 container are interpreted through the same ICC engine as `ICCBased` colour — a profile equivalent to sRGB or device gray keeps the exact device path, others transform per sample — and only a profile that will not parse falls back to the channel-count approximation. sYCC converts with the exact IEC 61966-2-1 Amd. 1 inverse.
+
+Part 2 (ISO/IEC 15444-2) extensions are tolerated in the container but not decoded. Every output sample is normalized to 8 bits per channel with round-to-nearest, so sources deeper than 8 bits (the spec allows up to 38) still land on an 8-bit output grid.
+
+## Optional content
+
+Optional content groups (PDF layers, ISO 32000 §8.11) are honored per the document's default configuration: rendering and text extraction skip layers it turns off, counting them on the reports' `hidden` counters.

--- a/docs/src/reference/python.md
+++ b/docs/src/reference/python.md
@@ -1,0 +1,45 @@
+# Python API
+
+The `pdfboss` package re-exports the compiled extension module `pdfboss._pdfboss`. Its public surface is twelve names; the typed stubs in [`_pdfboss.pyi`](https://github.com/4thel00z/pdfboss/blob/main/python/pdfboss/_pdfboss.pyi) are the authoritative reference for every signature and docstring. This chapter is the inventory; worked examples live in the guide chapters.
+
+## The twelve names
+
+| Name | What it is |
+|---|---|
+| `Document` | A loaded PDF, from a path or bytes; pages by index, `extract_text`, `extract_markdown`, `render_pages`, `elements`, `spans` |
+| `Page` | One page: geometry (width/height/rotation and the five boxes), `extract_text`, `extract_markdown`, `spans`, `render`, `render_reporting`, `extract_images` |
+| `AsyncDocument` | The async twin of `Document`, opened from a path, bytes, or an HTTP URL via range requests; data-fetching methods are coroutines |
+| `AsyncPage` | The async twin of `Page`; attributes are synchronous, extraction and rendering are coroutines |
+| `Element` | One physical or logical element of a PDF (`kind`, `span`, `ref`, `page`, lazy `value()`), yielded by `elements` |
+| `ElementIter` | Lazy sync iterator over elements; each step releases the GIL |
+| `AsyncElementIter` | Async iterator over elements; each step is a coroutine |
+| `Span` | One styled text span: text, position, bbox, font identity, bold/italic/monospace/serif, underline/strikethrough, rise, vertical, invisible, color |
+| `SpanIter` | Lazy sync iterator over a document's spans, buffering one page at a time |
+| `AsyncSpanIter` | Async iterator over a document's spans |
+| `PageImage` | One embedded image extracted from a page: native `width`/`height` and PNG-encoded `data` |
+| `PdfError` | The exception type for any PDF processing error |
+
+Guide chapters with runnable examples: [Extracting text](../guide/text.md), [Markdown output](../guide/markdown.md), [Styled spans](../guide/spans.md), [Rendering pages](../guide/rendering.md), [Extracting images](../guide/images.md), [Async and remote documents](../guide/async.md), [Encrypted documents](../guide/encryption.md).
+
+There is no PDF-creation API in Python; creating PDFs is the Rust crate [`pdfboss-write`](./rust.md) and the [`pdfboss create`](./cli.md#create) CLI.
+
+## Error handling
+
+Everything raises `PdfError`: bad or truncated data, unsupported encryption, stream decode failures and I/O errors, with the underlying detail in the message. Messages from the element and async APIs are prefixed by the layer they came from: `"parse: …"`, `"io: …"` or `"http: …"`.
+
+```python
+import pdfboss
+
+try:
+    doc = pdfboss.Document("report.pdf")
+except pdfboss.PdfError as e:
+    print(f"could not open: {e}")
+```
+
+Two conventional exceptions apply where Python conventions demand them: constructing a `Document` with neither or both of `path` and `data` raises `ValueError` (as does a non-positive `scale` or an unusable `fonts="full"` setup in `render`), and an out-of-range page index raises `IndexError`. Element iterators have salvage semantics: a per-item failure raises `PdfError` for that item, and iteration may be continued. Span iterators raise `PdfError` when a page cannot be materialized.
+
+## Threading
+
+A `Document` — and any `Page` it hands out — may be used from any thread. Access to the underlying parsed document is serialized internally, and `extract_text`/`render` release the GIL while they run, so other Python threads keep making progress during long extractions or renders. Element and span iteration release the GIL per step the same way. `Document.render_pages` fans page rendering out across the machine's cores.
+
+The async API needs no thread juggling: `AsyncDocument`'s coroutines are driven by one global multi-thread tokio runtime, and `AsyncDocument.render_pages` fans out as tokio tasks so the asyncio loop stays free.

--- a/docs/src/reference/rust.md
+++ b/docs/src/reference/rust.md
@@ -1,0 +1,30 @@
+# Rust crates
+
+pdfboss is a workspace of focused crates, all sharing one version. Add the ones you need with `cargo add`; each crate's API reference lives on docs.rs.
+
+| Crate | Responsibility | Docs |
+|---|---|---|
+| `pdfboss-core` | PDF syntax, objects, filters, cross-references and document model (ISO 32000) | [docs.rs](https://docs.rs/pdfboss-core) |
+| `pdfboss-text` | Font loading, encodings, ToUnicode CMaps and text extraction | [docs.rs](https://docs.rs/pdfboss-text) |
+| `pdfboss-output` | Layout analysis and output rendering: plain text and markdown | [docs.rs](https://docs.rs/pdfboss-output) |
+| `pdfboss-encoding` | Shared font encoding tables and glyph-name mappings (ISO 32000 Appendix D) | [docs.rs](https://docs.rs/pdfboss-encoding) |
+| `pdfboss-jpx` | Cleanroom JPEG 2000 (`JPXDecode`) decoder (ITU-T T.800) | [docs.rs](https://docs.rs/pdfboss-jpx) |
+| `pdfboss-icc` | Cleanroom ICC profile parser and colour transform (ICC.1:2010) | [docs.rs](https://docs.rs/pdfboss-icc) |
+| `pdfboss-render` | Page rasterization to RGBA pixmaps and PNG, plus embedded-image extraction | [docs.rs](https://docs.rs/pdfboss-render) |
+| `pdfboss-write` | PDF creation: COS object writer, content canvas and document assembly | [docs.rs](https://docs.rs/pdfboss-write) |
+| `pdfboss-aio` | Async, range-fetching PDF access: huge files, many documents, remote HTTP sources | [docs.rs](https://docs.rs/pdfboss-aio) |
+| `pdfboss-cli` | The `pdfboss` command-line tool | [docs.rs](https://docs.rs/pdfboss-cli) |
+| `pdfboss-tui` | Terminal explorer for PDF internals: element tree, object inspector, hex view, page preview and Markdown preview | [docs.rs](https://docs.rs/pdfboss-tui) |
+| `pdfboss-py` | PyO3 extension module `pdfboss._pdfboss`, built with maturin | not on crates.io; ships as the [pdfboss wheel](https://pypi.org/project/pdfboss/) |
+
+A further workspace member, `pdfboss-testkit`, is an internal PDF fixture builder for the test suite; it is not published.
+
+## Where to start
+
+- Reading a document: `pdfboss_core::Document` — `open`, `load`, and their `_with_password` twins, then `page`, `page_count`, `metadata`, `version`.
+- Text and markdown: `pdfboss_output::{extract_text, extract_markdown}`; positioned styled spans via `pdfboss_text::extract_spans`.
+- Rasterizing: `pdfboss_render::{render_page, render_page_with_options, render_page_reporting}` and `Pixmap::save_png`; embedded images via `extract_page_images`.
+- Creating: `pdfboss_write::{Pdf, Page, Canvas}` — see [Creating PDFs](../guide/creating.md).
+- Async and HTTP sources: `pdfboss_aio::AsyncDocument` — `open`, `open_url`, `from_bytes` — see [Async and remote documents](../guide/async.md).
+
+The guide chapters carry compiled examples for each of these; the [Quickstart](../quickstart.md) has the shortest end-to-end one.


### PR DESCRIPTION
## What

- **mdBook under `docs/`** — 17 chapters: getting started (introduction, installation, quickstart), one guide chapter per surface (text, markdown, styled spans, rendering, **image extraction**, **PDF creation**, async and remote documents, the explorer, encryption), and thin CLI/Python/Rust/limitations reference chapters that link out instead of duplicating.
- **`.github/workflows/book.yaml`** — builds the book on PRs touching `docs/`, deploys to GitHub Pages on pushes to main. Pages must be enabled once in Settings → Pages → Source: GitHub Actions.
- **README refresh** — docs badge + nav row, a highlights section, two feature sections with real examples: embedded-image extraction (Python + Rust) and PDF creation (Rust + CLI), crate map updated to the twelve public crates. The Benchmarks and Limitations sections are byte-identical to main.

## Verification

- Every CLI example ran against real corpus PDFs with the debug binary (40+ invocations, exit codes checked, output shapes quoted from real runs).
- Every Python example ran on the venv wheel (0.21.0); the async `open_url` path was verified against a local Range-supporting HTTP server.
- All 23 Rust examples compiled in an out-of-tree rig against the workspace crates; 22 also ran, and every creation example's output PDF was re-opened with pdfboss itself (`info`/`text` round trip).
- `mdbook build docs` exits 0; internal links and anchors scanned clean; the frozen README zones were diffed against main and match.