### PR TITLE
perf(text): move layout assembly's lines instead of cloning them, group spans into lines once

### DIFF
--- a/crates/pdfboss-output/src/lib.rs
+++ b/crates/pdfboss-output/src/lib.rs
@@ -358,6 +358,22 @@ mod tests {
         assert!(!md.contains('\u{2022}'), "marker replaced, not kept: {md}");
     }
 
+    /// A marker line whose candidate falls short of the list minimum stays
+    /// prose, and the scan resumes at the very next line — a later list on
+    /// the same run must still form.
+    #[test]
+    fn a_lone_marker_line_stays_prose() {
+        let content = "BT /F1 12 Tf 72 720 Td (- stray dash line) Tj \
+                       0 -14 Td (Body sentence at the same indent.) Tj \
+                       0 -14 Td (- alpha) Tj 0 -14 Td (- beta) Tj ET";
+        let md = markdown_of(content);
+        assert!(md.contains("- alpha\n- beta"), "md: {md}");
+        assert!(
+            md.contains("- stray dash line\nBody sentence at the same indent."),
+            "the stray marker line stays in the paragraph: {md}"
+        );
+    }
+
     #[test]
     fn numbered_items_keep_their_numbers() {
         let content = "BT /F1 12 Tf 72 720 Td (1. alpha) Tj 0 -14 Td (2. beta) Tj \

--- a/crates/pdfboss-output/src/structure.rs
+++ b/crates/pdfboss-output/src/structure.rs
@@ -407,18 +407,20 @@ fn push_segment_blocks(
     push_stretch(&groups[next..], stats, out);
 }
 
-/// The lane path: one [`table_band`] attempt over the spans, else prose.
+/// The lane path: one [`table_band`] attempt over the spans' line groups,
+/// else prose. The groups are built once and feed both paths.
 fn push_lane_blocks(spans: &[&TextSpan], stats: &SizeStats, out: &mut Vec<Block>) {
-    let Some(band) = table_band(spans) else {
-        push_blocks(&assemble_lines(spans), stats, out);
+    let groups = line_groups(spans);
+    let Some(band) = table_band(&groups) else {
+        push_blocks(groups.iter().map(assembled).collect(), stats, out);
         return;
     };
-    push_blocks(&band.above, stats, out);
+    push_blocks(band.above, stats, out);
     out.push(Block::Table {
         bbox: table_bbox(&band.rows),
         rows: band.rows,
     });
-    push_blocks(&band.below, stats, out);
+    push_blocks(band.below, stats, out);
 }
 
 /// A remainder stretch between grid claims, back as spans, through the same
@@ -515,45 +517,64 @@ struct Assembled {
     min_size: f32,
 }
 
-/// Emits one segment's lines as blocks, walking them once: a heading line
-/// closes the paragraph run before it and takes any tightly-spaced
-/// continuation lines of the same size with it.
-fn push_blocks(lines: &[Assembled], stats: &SizeStats, out: &mut Vec<Block>) {
-    let mut run: Vec<Line> = Vec::new();
+/// Emits one segment's lines as blocks: a heading line closes the paragraph
+/// run before it and takes any tightly-spaced continuation lines of the same
+/// size with it. Classification walks the lines borrowed — stretches of
+/// (line count, heading level or `None` for a run) — and only then are the
+/// lines moved into their blocks, never cloned.
+fn push_blocks(lines: Vec<Assembled>, stats: &SizeStats, out: &mut Vec<Block>) {
+    let mut stretches: Vec<(usize, Option<u8>)> = Vec::new();
     let mut index = 0;
     while index < lines.len() {
-        let Some(level) = heading_level(&lines[index], stats) else {
-            run.push(lines[index].line.clone());
-            index += 1;
+        let heading = heading_level(&lines[index], stats).map(|level| {
+            let mut end = index + 1;
+            while end < lines.len() && continues_heading(&lines[end - 1], &lines[end], stats, level)
+            {
+                end += 1;
+            }
+            (end, level)
+        });
+        let run_length = match heading {
+            None => 1,
+            Some((end, level)) => {
+                let candidate = lines[index..end].iter().map(|a| &a.line);
+                if heading_chars(candidate) <= HEADING_MAX_CHARS {
+                    stretches.push((end - index, Some(level)));
+                    index = end;
+                    continue;
+                }
+                // Too long for a heading: the candidate folds into the run.
+                end - index
+            }
+        };
+        match stretches.last_mut() {
+            Some((count, None)) => *count += run_length,
+            _ => stretches.push((run_length, None)),
+        }
+        index += run_length;
+    }
+    let mut moved = lines.into_iter();
+    let mut run: Vec<Line> = Vec::new();
+    for (count, level) in stretches {
+        let Some(level) = level else {
+            run.extend(moved.by_ref().take(count).map(|a| a.line));
+            push_run(&mut run, out);
             continue;
         };
-        let mut end = index + 1;
-        while end < lines.len() && continues_heading(&lines[end - 1], &lines[end], stats, level) {
-            end += 1;
-        }
-        let heading: Vec<Line> = lines[index..end].iter().map(|a| a.line.clone()).collect();
-        if heading_chars(&heading) > HEADING_MAX_CHARS {
-            run.extend(heading);
-            index = end;
-            continue;
-        }
-        push_run(&mut run, out);
+        let heading: Vec<Line> = moved.by_ref().take(count).map(|a| a.line).collect();
         let bbox = bbox(&heading);
         out.push(Block::Heading {
             level,
             lines: heading,
             bbox,
         });
-        index = end;
     }
-    push_run(&mut run, out);
 }
 
 /// A candidate heading's text length, counted as the Markdown adapter joins
 /// its lines: one space between them, ends trimmed.
-fn heading_chars(lines: &[Line]) -> usize {
+fn heading_chars<'l>(lines: impl Iterator<Item = &'l Line>) -> usize {
     lines
-        .iter()
         .map(line_text)
         .collect::<Vec<String>>()
         .join(" ")
@@ -612,52 +633,79 @@ fn is_bold_title(line: &Line) -> bool {
 /// its own leading.
 fn push_run(run: &mut Vec<Line>, out: &mut Vec<Block>) {
     let lines = std::mem::take(run);
-    let mut prose: Vec<Line> = Vec::new();
+    if lines.is_empty() {
+        return;
+    }
+    let markers: Vec<Option<(Marker, usize)>> = lines
+        .iter()
+        .map(|line| list_marker(&line_text(line)))
+        .collect();
+    // Each list found, with the prose line count standing before it; the
+    // lines only move into their blocks once the whole run is walked.
+    let mut lists: Vec<(usize, Vec<ListRunItem>)> = Vec::new();
+    let mut prose_count = 0usize;
     let mut index = 0;
     while index < lines.len() {
-        let Some(items) = list_run(&lines[index..]) else {
-            prose.push(lines[index].clone());
+        let Some(items) = list_run(&lines[index..], &markers[index..]) else {
+            prose_count += 1;
             index += 1;
             continue;
         };
+        index += items.iter().map(|(_, _, count)| count).sum::<usize>();
+        lists.push((prose_count, items));
+        prose_count = 0;
+    }
+    let mut moved = lines.into_iter();
+    let mut prose: Vec<Line> = Vec::new();
+    for (count, items) in lists {
+        prose.extend(moved.by_ref().take(count));
         push_paragraphs(&mut prose, out);
-        index += items.iter().map(|item| item.lines.len()).sum::<usize>();
+        let items: Vec<ListItem> = items
+            .into_iter()
+            .map(|(marker, marker_len, count)| ListItem {
+                marker,
+                marker_len,
+                lines: moved.by_ref().take(count).collect(),
+            })
+            .collect();
         out.push(Block::List {
-            bbox: list_bbox(&items),
+            bbox: bbox(items.iter().flat_map(|item| &item.lines)),
             items,
         });
     }
+    prose.extend(moved);
     push_paragraphs(&mut prose, out);
 }
 
-/// The list opening at `lines[0]`, or `None` when that line does not open
-/// one or the candidate falls short of [`LIST_MIN_LINES`] — in which case
-/// the line is left for [`push_run`] to fold back into prose.
-fn list_run(lines: &[Line]) -> Option<Vec<ListItem>> {
+/// One item of a list found by [`list_run`]: its marker, the marker's
+/// length in characters, and how many of the run's lines the item takes.
+type ListRunItem = (Marker, usize, usize);
+
+/// The list opening at `lines[0]` as one [`ListRunItem`] per item, or `None`
+/// when that line does not open one or the candidate falls short of
+/// [`LIST_MIN_LINES`] — in which case the line is left for [`push_run`] to
+/// fold back into prose. `markers` carries every line's [`list_marker`],
+/// computed once for the whole run.
+fn list_run(lines: &[Line], markers: &[Option<(Marker, usize)>]) -> Option<Vec<ListRunItem>> {
     let mut items = Vec::new();
     let mut consumed = 0usize;
     let mut index = 0;
     while index < lines.len() {
-        let Some((marker, marker_len)) = list_marker(&line_text(&lines[index])) else {
+        let Some((marker, marker_len)) = markers[index].clone() else {
             break;
         };
         let item_x = lines[index].x;
         let item_size = lines[index].size;
-        let mut item_lines = vec![lines[index].clone()];
+        let opened = index;
         index += 1;
         while index < lines.len()
-            && list_marker(&line_text(&lines[index])).is_none()
+            && markers[index].is_none()
             && lines[index].x > item_x + LIST_CONTINUATION_INDENT * item_size
         {
-            item_lines.push(lines[index].clone());
             index += 1;
         }
-        consumed += item_lines.len();
-        items.push(ListItem {
-            marker,
-            marker_len,
-            lines: item_lines,
-        });
+        consumed += index - opened;
+        items.push((marker, marker_len, index - opened));
     }
     (consumed >= LIST_MIN_LINES).then_some(items)
 }
@@ -707,40 +755,34 @@ fn list_marker(text: &str) -> Option<(Marker, usize)> {
     ))
 }
 
-/// The list's device-space box: every item's lines combined.
-fn list_bbox(items: &[ListItem]) -> BBox {
-    let lines: Vec<Line> = items.iter().flat_map(|item| item.lines.clone()).collect();
-    bbox(&lines)
-}
-
 /// Drains a paragraph run into blocks, cutting it where a baseline step
-/// exceeds [`PARAGRAPH_GAP`] times the run's median step.
+/// exceeds [`PARAGRAPH_GAP`] times the run's median step. The cuts are found
+/// first, borrowed; the lines then move into their paragraphs uncloned.
 fn push_paragraphs(run: &mut Vec<Line>, out: &mut Vec<Block>) {
     let lines = std::mem::take(run);
     if lines.is_empty() {
         return;
     }
     let limit = PARAGRAPH_GAP * median_step(&lines);
+    let mut counts: Vec<usize> = Vec::new();
     let mut start = 0;
     for index in 1..lines.len() {
         if limit <= 0.0 || lines[index - 1].y - lines[index].y <= limit {
             continue;
         }
-        push_paragraph(&lines[start..index], out);
+        counts.push(index - start);
         start = index;
     }
-    push_paragraph(&lines[start..], out);
-}
-
-fn push_paragraph(lines: &[Line], out: &mut Vec<Block>) {
-    if lines.is_empty() {
-        return;
+    counts.push(lines.len() - start);
+    let mut moved = lines.into_iter();
+    for count in counts {
+        let paragraph: Vec<Line> = moved.by_ref().take(count).collect();
+        out.push(Block::Paragraph {
+            bbox: bbox(&paragraph),
+            lines: paragraph,
+            role: Role::Body,
+        });
     }
-    out.push(Block::Paragraph {
-        lines: lines.to_vec(),
-        bbox: bbox(lines),
-        role: Role::Body,
-    });
 }
 
 /// Median baseline step of consecutive lines, or zero when there is no step
@@ -769,34 +811,45 @@ struct Group<'s> {
 
 /// One reading-order segment's spans grouped into lines — baselines within
 /// `0.5 · size` — top of page first, spans left to right inside each.
+/// Two passes: the first assigns every span its group — each span tests
+/// against the group's size as it stood when the span arrived — and counts,
+/// the second fills exact-sized span lists, so no list grows push by push.
 fn line_groups<'s>(spans: &[&'s TextSpan]) -> Vec<Group<'s>> {
     let mut groups: Vec<Group> = Vec::new();
+    let mut counts: Vec<usize> = Vec::new();
+    let mut homes: Vec<usize> = Vec::with_capacity(spans.len());
     for &span in spans {
         let found = groups
-            .iter_mut()
-            .find(|group| (group.y - span.y).abs() <= 0.5 * group.size.max(span.size));
+            .iter()
+            .position(|group| (group.y - span.y).abs() <= 0.5 * group.size.max(span.size));
         match found {
-            Some(group) => {
-                group.size = group.size.max(span.size);
-                group.spans.push(span);
+            Some(index) => {
+                groups[index].size = groups[index].size.max(span.size);
+                counts[index] += 1;
+                homes.push(index);
             }
-            None => groups.push(Group {
-                y: span.y,
-                size: span.size,
-                spans: vec![span],
-            }),
+            None => {
+                homes.push(groups.len());
+                groups.push(Group {
+                    y: span.y,
+                    size: span.size,
+                    spans: Vec::new(),
+                });
+                counts.push(1);
+            }
         }
+    }
+    for (group, count) in groups.iter_mut().zip(&counts) {
+        group.spans.reserve_exact(*count);
+    }
+    for (&span, &home) in spans.iter().zip(&homes) {
+        groups[home].spans.push(span);
     }
     groups.sort_by(|a, b| b.y.total_cmp(&a.y)); // top of page first
     for group in &mut groups {
         group.spans.sort_by(|a, b| a.x.total_cmp(&b.x));
     }
     groups
-}
-
-/// One reading-order segment's spans as lines, top of page first.
-fn assemble_lines(spans: &[&TextSpan]) -> Vec<Assembled> {
-    line_groups(spans).iter().map(assembled).collect()
 }
 
 /// A grid and the page-edge lines around it: the lines above the first
@@ -1305,14 +1358,13 @@ fn merged_line(fragments: &[&Line]) -> Line {
 /// [`TABLE_MIN_LANES`], and that is its end. A wrapped cell standing alone in
 /// one column survives inside the stretch for free: it puts ink where that
 /// column already held some.
-fn table_band(segment: &[&TextSpan]) -> Option<TableBand> {
-    let groups = line_groups(segment);
+fn table_band(groups: &[Group]) -> Option<TableBand> {
     for start in 0..groups.len() {
-        let (end, lanes) = lane_run(&groups, start);
+        let (end, lanes) = lane_run(groups, start);
         if end - start < TABLE_MIN_ROWS {
             continue;
         }
-        if let Some(band) = grid(&groups, start, end, &lanes) {
+        if let Some(band) = grid(groups, start, end, &lanes) {
             return Some(band);
         }
     }
@@ -1526,8 +1578,10 @@ fn even_rows(baselines: &[f32]) -> bool {
 /// is merged there, and everything under its covered columns reads as its
 /// contents.
 fn table_row(group: &Group, columns: &[std::ops::Range<f32>]) -> Option<Vec<Cell>> {
-    let mut claimed: Vec<(usize, usize, Vec<&TextSpan>)> = Vec::new();
-    for &span in &group.spans {
+    // A span only ever extends the last claim, so each claim's spans are a
+    // contiguous stretch of `group.spans` — held as a range, never copied.
+    let mut claimed: Vec<(usize, usize, std::ops::Range<usize>)> = Vec::new();
+    for (position, &span) in group.spans.iter().enumerate() {
         let lo = span.x.min(span.end_x);
         let hi = span.x.max(span.end_x);
         let start = columns.iter().rposition(|column| column.start <= lo)?;
@@ -1538,9 +1592,9 @@ fn table_row(group: &Group, columns: &[std::ops::Range<f32>]) -> Option<Vec<Cell
         match claimed.last_mut() {
             Some(last) if start <= last.1 => {
                 last.1 = last.1.max(end);
-                last.2.push(span);
+                last.2.end = position + 1;
             }
-            _ => claimed.push((start, end, vec![span])),
+            _ => claimed.push((start, end, position..position + 1)),
         }
     }
     // `next` counts columns, `row` counts cells: a colspan cell is one cell
@@ -1552,7 +1606,7 @@ fn table_row(group: &Group, columns: &[std::ops::Range<f32>]) -> Option<Vec<Cell
             row.push(empty_cell());
         }
         row.push(Cell {
-            line: Some(assemble_line(group.y, group.size, spans).line),
+            line: Some(assemble_line(group.y, group.size, &group.spans[spans.clone()]).line),
             colspan: (end - start + 1) as u8,
             rowspan: 1,
         });
@@ -1585,12 +1639,7 @@ fn spaced_cells(row: &[Cell], size: f32) -> bool {
 
 /// The table's device-space box: every populated cell's line.
 fn table_bbox(rows: &[Vec<Cell>]) -> BBox {
-    let lines: Vec<Line> = rows
-        .iter()
-        .flatten()
-        .filter_map(|cell| cell.line.clone())
-        .collect();
-    bbox(&lines)
+    bbox(rows.iter().flatten().filter_map(|cell| cell.line.as_ref()))
 }
 
 /// One line from its spans in left-to-right order: a gap wider than
@@ -1642,7 +1691,7 @@ fn push_span(inlines: &mut Vec<Inline>, span: &TextSpan, spaced: bool) {
 
 /// The lines' device-space box. Spans carry no glyph extents, so the top is
 /// the highest baseline plus the largest size — an ascender approximation.
-fn bbox(lines: &[Line]) -> BBox {
+fn bbox<'l>(lines: impl IntoIterator<Item = &'l Line>) -> BBox {
     let mut x0 = f32::INFINITY;
     let mut y0 = f32::INFINITY;
     let mut x1 = f32::NEG_INFINITY;


### PR DESCRIPTION
Re-profiling extraction after #102 moved layout assembly to the top of the
lever table: `push_lane_blocks` and its callees were 22.2% of the 049
extraction pass, and the profile inside it was allocator churn, not
algorithm — every prose segment grouped its spans into lines twice (once
for the table attempt, once for prose), the span lists behind those groups
grew one push at a time, every prose line's `Line` was deep-cloned three
times on its way into a `Paragraph` block (into the run, into prose, into
the block), list detection re-rendered and re-parsed each line's text once
per scan position, and the table path copied span lists and cell lines
around just to measure boxes.

The layout pass now moves data instead of copying it, with classification
unchanged:

- `push_lane_blocks` builds the line groups once and feeds both the table
  attempt and the prose path.
- `line_groups` runs two passes — assign and count, then fill exact-sized
  span lists — replicating the original evolving-size group assignment
  span for span.
- `push_blocks`, `push_run`, and `push_paragraphs` classify over borrowed
  lines first (stretch boundaries, list item extents, paragraph cuts), then
  move each `Line` into its block. List markers are computed once per run.
- `table_row` holds each claim as a range into the group's span list —
  claims only ever extend at the tail, so they are contiguous by
  construction.
- `bbox` takes any iterator of lines, so list and table boxes are measured
  without cloning every line.

Byte-identical by construction — no threshold, gate, or float expression
changed. Because the `Text` adapter deliberately flattens block
classification, text equality alone cannot prove headings, lists, and
tables classified the same, so this wave's oracle also hashes markdown:
text AND markdown output identical across the 259-file 049 corpus and the
3,910-file pdf_oxide corpus (per-document sha256, both sides).

Verification

- Full workspace suite green (plus a new test pinning the failed-list
  rescan edge: a lone marker line stays prose and a later list still
  forms); clippy in both `substitute-fonts` states, fmt, `cargo doc`
  clean.

Measurement (pre-registered target: 049-corpus text extraction, 16
interleaved paired rounds main@50ce6dd vs this branch, keep iff >=14/16
wins AND median > 3x the A/A-null median; pdf_oxide corpus as 8-round
control; machine gated >=85% idle)

- 049 target: formally keep=NO — 15/16 wins, median +4.58% (1.985s ->
  1.892s, x1.049), against a threshold of 5.79% (3x this session's
  A/A-null median of 1.93%; the null carried one 14.2% outlier round).
  The wins gate passed; the median missed a bar set by an unusually noisy
  null.
- pdf_oxide control: 6/8 wins, median +1.7% — layout is a small share of
  that corpus's pass, as expected.
- per-file sweep (best-of-3 per file, which strips interference the paired
  rounds absorb): 250/259 files faster, per-file median +7.0%, corpus sum
  1.963s -> 1.844s (x1.064); worst file -3.7% vs an A/A per-file noise p90
  of 5.1% — zero regressions beyond noise; best file +60.3%.

Under the campaign's pre-registration discipline the registered verdict
stands as keep=NO, so this PR does not claim the threshold — the per-file
evidence (250/259 wins, no regression beyond noise, byte-identical output)
is presented as-is and merging is the maintainer's call.

Disclosure: the first measurement session was voided on environment
diagnostics, before its verdict could count in either direction — the
machine was running on a near-empty battery (1%), which throttles it while
looking healthy to the >=85%-idle gate: the wave-3 binary that measured
1.987s in its clean session ran 3.49s, one A/A-null round hit 40.8%, and
top showed the single-threaded pass starved to 50% CPU. Its numbers, for
the record: target 13/16 wins, median +2.74% vs a 3.68% threshold. The
re-run is the identical registered protocol, additionally gated on
measured throughput (an A-side pass back within ~10% of its known-clean
time, twice consecutively, on AC power).
