### PR TITLE
perf(text): iterate a show string's codes instead of collecting them, size the span text up front

### DIFF
--- a/crates/pdfboss-text/src/extract.rs
+++ b/crates/pdfboss-text/src/extract.rs
@@ -1072,8 +1072,10 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         // Device-space font size: the length of the text-space vertical
         // unit vector scaled by Tfs under Tm·CTM.
         let size = gs.size * (start.c * start.c + start.d * start.d).sqrt();
-        let mut text = String::new();
-        for cc in font.codes(bytes) {
+        // One byte per code is the floor on the decoded length, so this
+        // reservation removes the per-glyph regrowth of typical text.
+        let mut text = String::with_capacity(bytes.len());
+        for cc in font.codes_in(bytes) {
             font.decode_into(cc, &mut text);
             let word = if font.is_space(cc) {
                 gs.word_spacing

--- a/crates/pdfboss-text/src/font.rs
+++ b/crates/pdfboss-text/src/font.rs
@@ -20,6 +20,43 @@ pub struct CharCode {
     pub len: u8,
 }
 
+/// One show string's codes, yielded in order; built by [`Font::codes_in`].
+pub(crate) struct Codes<'f> {
+    bytes: &'f [u8],
+    pos: usize,
+    split: Split<'f>,
+}
+
+/// How the active font splits a show string into codes.
+#[derive(Clone, Copy)]
+enum Split<'f> {
+    /// One byte per code (simple fonts).
+    Single,
+    /// The `/Encoding` CMap's codespaces (Type0 fonts with one).
+    Codespaces(&'f CidCmap),
+    /// Two bytes per code, a trailing odd byte its own code.
+    Pairs,
+}
+
+impl Iterator for Codes<'_> {
+    type Item = CharCode;
+
+    fn next(&mut self) -> Option<CharCode> {
+        let rest = &self.bytes[self.pos..];
+        let first = *rest.first()?;
+        let (code, len) = match self.split {
+            Split::Single => (u32::from(first), 1),
+            Split::Codespaces(cmap) => cmap.code_at(self.bytes, self.pos),
+            Split::Pairs => match rest.get(1) {
+                Some(&second) => (u32::from(u16::from_be_bytes([first, second])), 2),
+                None => (u32::from(first), 1),
+            },
+        };
+        self.pos += usize::from(len);
+        Some(CharCode { code, len })
+    }
+}
+
 /// The descriptor `/StemV` (glyph-space units) at which a face reads as
 /// bold. Regular text faces report dominant vertical stems up to ~110 and
 /// bold faces from ~140, so the cut sits in the gap between the clusters.
@@ -188,40 +225,31 @@ impl Font {
         (!cmap.is_empty()).then_some(cmap)
     }
 
+    /// Splits a show-string into character codes as a list (test helper;
+    /// lib code iterates [`Font::codes_in`] to avoid the allocation).
+    #[cfg(test)]
+    pub fn codes(&self, bytes: &[u8]) -> Vec<CharCode> {
+        self.codes_in(bytes).collect()
+    }
+
     /// Splits a show-string into character codes: one byte each for simple
     /// fonts, the `/Encoding` CMap's codespaces for Type0 fonts with one,
     /// and two bytes otherwise (a trailing odd byte becomes its own code).
-    pub fn codes(&self, bytes: &[u8]) -> Vec<CharCode> {
-        if self.simple {
-            return bytes
-                .iter()
-                .map(|&b| CharCode {
-                    code: u32::from(b),
-                    len: 1,
-                })
-                .collect();
+    /// An iterator because the show loop reads each code once — the hottest
+    /// operator on a text page never pays a per-string list allocation.
+    pub(crate) fn codes_in<'f>(&'f self, bytes: &'f [u8]) -> Codes<'f> {
+        let split = if self.simple {
+            Split::Single
+        } else if let Some(cmap) = self.cmap.as_deref() {
+            Split::Codespaces(cmap)
+        } else {
+            Split::Pairs
+        };
+        Codes {
+            bytes,
+            pos: 0,
+            split,
         }
-        if let Some(cmap) = &self.cmap {
-            let mut out = Vec::with_capacity(bytes.len() / 2 + 1);
-            let mut pos = 0;
-            while pos < bytes.len() {
-                let (code, len) = cmap.code_at(bytes, pos);
-                out.push(CharCode { code, len });
-                pos += usize::from(len);
-            }
-            return out;
-        }
-        bytes
-            .chunks(2)
-            .map(|c| CharCode {
-                code: if c.len() == 2 {
-                    u32::from(u16::from_be_bytes([c[0], c[1]]))
-                } else {
-                    u32::from(c[0])
-                },
-                len: c.len() as u8,
-            })
-            .collect()
     }
 
     /// The CID a code selects in the descendant font: through the


### PR DESCRIPTION
Re-profiling after #106 left span building (`emit`/`show`) as the largest
extraction subtree with a structural waste: about half its time was
allocator traffic. Every shown string collected its character codes into
a `Vec<CharCode>` the show loop read once and dropped — `Tj` is the
hottest operator on a text page — and each span's text grew from an empty
`String` one glyph at a time, paying a realloc chain per span.

The codes are now an iterator over the same three splits (simple fonts'
single bytes, a Type0 `/Encoding` CMap's codespaces, byte pairs with a
trailing odd byte its own code); the list-returning `codes` stays as a
test helper that collects it, so the two forms cannot split differently.
The span's text starts at the show string's byte length — one byte per
code is the floor on the decoded size, so typical text never regrows.

Byte-identical by construction: same codes in the same order, same decode
calls, capacity is unobservable. Verified: text AND markdown output
identical across the 259-file 049 corpus and the 3,910-file pdf_oxide
corpus (per-document sha256); full workspace suite (2,176 tests), clippy
in both `substitute-fonts` states, fmt, `cargo doc` clean.

Measurement (pre-registered target: 049-corpus text extraction, 16
interleaved paired rounds main vs this branch, keep iff >=14/16 wins AND
median > 3x the A/A-null median; pdf_oxide corpus as 8-round control;
gated on AC power and measured throughput at the known-clean reference)

- 049 target: keep=YES — 16/16 wins, median +4.04% (2.006s -> 1.924s,
  x1.042), threshold 1.65% (3x null median 0.55%, max null round 1.44%)
  cleared 2.4x
- pdf_oxide control: 8/8 wins, median +2.5% — span building runs there
  too, so a small positive is expected
- per-file sweep (best-of-3): 207/259 files faster, median +4.6%; the 8
  files past the sweep's noise p90 re-timed interleaved as a group and
  came out FASTER under this branch in all three rounds — they are
  sub-millisecond files, phantom readings of a warm-machine sweep
  (its own A/A per-file noise median was 3.4%)

Campaign running total on the 049 extraction pass, single-threaded, vs
the frozen v0.20.0 baseline: about x1.48 (#102 x1.354, #106 x1.049, this
x1.042).
