### PR TITLE
feat(write): composition layer — element vocabulary, document slots, pdfboss.write, create manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,8 +1260,10 @@ dependencies = [
  "pdfboss-tui",
  "pdfboss-write",
  "png",
+ "serde",
  "serde_json",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -1948,6 +1950,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,6 +2227,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2669,6 +2721,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,7 @@ dependencies = [
  "pdfboss-output",
  "pdfboss-render",
  "pdfboss-text",
+ "pdfboss-write",
  "pyo3",
  "pyo3-async-runtimes",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ pdfboss create blank  -o out.pdf --pages 3    # new PDF: empty pages
 pdfboss create text   notes.txt -o out.pdf    # new PDF: word-wrapped text
 pdfboss create images a.png b.jpg -o out.pdf  # new PDF: one page per image
 pdfboss create md     notes.md -o out.pdf     # new PDF: markdown composed with a CSS theme
+pdfboss create manifest q3.toml -o out.pdf    # new PDF: TOML manifest — metadata, pages, text, paragraphs, images, links
 ```
 
 `create md` composes CommonMark+GFM into a themed PDF. `--theme` takes a small CSS subset over element-type selectors, overlaid on the built-in default theme:
@@ -59,6 +60,21 @@ png  = doc[0].render(scale=2.0)            # PNG bytes
 imgs = doc[0].extract_images()             # embedded images: .data (PNG), .width, .height
 pdf  = pdfboss.md.to_pdf(open("notes.md").read())  # markdown -> themed PDF bytes
 ```
+
+`pdfboss.write` composes a `Pdf` from Python: pages and elements join with `|`, and `save`/`to_bytes` builds the file bytes once:
+
+```python
+from pdfboss.write import Link, Metadata, Page, Paragraph, Pdf, Standard14, Text
+cover = (
+    Page(size="a4")
+    | Text("Q3 Report", at=(72, 770), font=Standard14.HELVETICA_BOLD, size=28)
+    | Paragraph("Prepared for the board.", rect=(72, 700, 500, 740))
+    | Link(rect=(72, 60, 200, 80), url="https://example.com/q3")
+)
+data = (Pdf() | Metadata(title="Q3 Report") | cover).to_bytes()
+```
+
+An `Outline` of nested `Bookmark`s becomes the document's bookmark panel (`Pdf.outline`); `Attachment` objects embed arbitrary files inside the document (`Pdf.attachments`); `PageLabel` ranges control how page numbers render in viewer UI (`Pdf.page_labels`); and a `Viewer` sets the document's opening layout, mode, and page (`Pdf.viewer`) — each slots into `Pdf` with `|`, exactly like `Metadata`.
 
 <details>
 <summary><strong>More: explorer subcommands, async Python, Rust</strong></summary>

--- a/crates/pdfboss-cli/Cargo.toml
+++ b/crates/pdfboss-cli/Cargo.toml
@@ -18,7 +18,9 @@ pdfboss-tui = { workspace = true }
 pdfboss-write = { workspace = true }
 pdfboss-markdown = { workspace = true }
 clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+toml = "0.8"
 base64 = "0.22"
 tokio = { version = "1", features = ["rt", "net", "time"] }
 futures-core = "0.3"

--- a/crates/pdfboss-cli/src/create.rs
+++ b/crates/pdfboss-cli/src/create.rs
@@ -81,6 +81,15 @@ pub enum CreateCommand {
         #[arg(long)]
         landscape: bool,
     },
+    /// A TOML manifest describing metadata and pages — text, paragraphs,
+    /// images and links mapped onto the compose vocabulary.
+    Manifest {
+        /// Path to the TOML manifest.
+        input: PathBuf,
+        /// Output PDF file.
+        #[arg(short, long)]
+        out: PathBuf,
+    },
 }
 
 /// `--font` choices for `create text`, mirroring
@@ -243,6 +252,15 @@ pub fn cmd_create(command: CreateCommand) -> Result<(), String> {
             if !report.is_empty() {
                 eprintln!("{}", report.summary());
             }
+            let count = pdf.pages.len();
+            pdf.save(&out)
+                .map_err(|e| format!("{}: {e}", out.display()))?;
+            let plural = if count == 1 { "" } else { "s" };
+            println!("wrote {} ({count} page{plural})", out.display());
+            return Ok(());
+        }
+        CreateCommand::Manifest { input, out } => {
+            let pdf = crate::manifest::build(&input)?;
             let count = pdf.pages.len();
             pdf.save(&out)
                 .map_err(|e| format!("{}: {e}", out.display()))?;

--- a/crates/pdfboss-cli/src/main.rs
+++ b/crates/pdfboss-cli/src/main.rs
@@ -5,6 +5,7 @@ mod create;
 mod hexdump;
 mod input;
 mod json;
+mod manifest;
 mod q;
 
 use pdfboss_core::pretty;
@@ -1144,6 +1145,26 @@ mod tests {
             panic!("expected create md");
         };
         assert!(theme.is_none());
+    }
+
+    #[test]
+    fn create_manifest_parses_input_and_out() {
+        let cli = Cli::try_parse_from(["pdfboss", "create", "manifest", "q3.toml", "-o", "q3.pdf"])
+            .unwrap();
+        let Command::Create {
+            command: create::CreateCommand::Manifest { input, out },
+        } = cli.command
+        else {
+            panic!("expected create manifest");
+        };
+        assert_eq!(input, PathBuf::from("q3.toml"));
+        assert_eq!(out, PathBuf::from("q3.pdf"));
+    }
+
+    #[test]
+    fn create_manifest_requires_out() {
+        let outcome = Cli::try_parse_from(["pdfboss", "create", "manifest", "q3.toml"]);
+        assert!(outcome.is_err());
     }
 
     #[test]

--- a/crates/pdfboss-cli/src/manifest.rs
+++ b/crates/pdfboss-cli/src/manifest.rs
@@ -1,0 +1,484 @@
+//! `pdfboss create manifest`: a TOML document description — metadata, pages
+//! and page content (text, paragraphs, images, links) — mapped onto the
+//! compose vocabulary in `pdfboss_write`.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use pdfboss_core::Point;
+use pdfboss_write::{
+    Content, Image, ImageData, Link, LinkTarget, Metadata, Page, PageSize, Paragraph,
+    ParagraphAlign, Pdf, Standard14, Text,
+};
+
+/// The manifest's top-level shape: optional document metadata plus its
+/// pages, in reading order.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Manifest {
+    meta: Option<ManifestMeta>,
+    #[serde(rename = "page", default)]
+    pages: Vec<ManifestPage>,
+}
+
+/// `[meta]`: maps directly onto `pdfboss_write::Metadata`'s text fields.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestMeta {
+    title: Option<String>,
+    author: Option<String>,
+    subject: Option<String>,
+    keywords: Option<String>,
+    creator: Option<String>,
+    producer: Option<String>,
+}
+
+/// `[[page]]`: a page's size, orientation, and its content, in schema
+/// order (text, then paragraph, then image, then link — TOML's separate
+/// arrays-of-tables carry no cross-type ordering, so the schema's own
+/// order is the one the manifest maps to).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestPage {
+    size: Option<String>,
+    #[serde(default)]
+    landscape: bool,
+    #[serde(rename = "text", default)]
+    texts: Vec<ManifestText>,
+    #[serde(rename = "paragraph", default)]
+    paragraphs: Vec<ManifestParagraph>,
+    #[serde(rename = "image", default)]
+    images: Vec<ManifestImage>,
+    #[serde(rename = "link", default)]
+    links: Vec<ManifestLink>,
+}
+
+/// `[[page.text]]`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestText {
+    value: String,
+    at: [f32; 2],
+    font: Option<String>,
+    size: Option<f32>,
+}
+
+/// `[[page.paragraph]]`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestParagraph {
+    value: String,
+    rect: [f32; 4],
+    font: Option<String>,
+    size: Option<f32>,
+    leading: Option<f32>,
+    align: Option<String>,
+}
+
+/// `[[page.image]]`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestImage {
+    path: String,
+    at: [f32; 2],
+    width: Option<f32>,
+    height: Option<f32>,
+}
+
+/// `[[page.link]]`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestLink {
+    rect: [f32; 4],
+    url: Option<String>,
+    page: Option<usize>,
+}
+
+/// Builds a `Pdf` from the TOML manifest at `manifest_path`. Every error
+/// this returns is prefixed with `manifest_path`, in the CLI's own
+/// `"{path}: {cause}"` shape.
+pub fn build(manifest_path: &Path) -> Result<Pdf, String> {
+    build_inner(manifest_path).map_err(|e| format!("{}: {e}", manifest_path.display()))
+}
+
+/// [`build`]'s body: every error here is a bare cause, prefixed with the
+/// manifest path exactly once, at the single call site above.
+fn build_inner(manifest_path: &Path) -> Result<Pdf, String> {
+    let text = std::fs::read_to_string(manifest_path).map_err(|e| e.to_string())?;
+    let manifest: Manifest = toml::from_str(&text).map_err(|e| e.to_string())?;
+    let base_dir = manifest_path.parent().unwrap_or(Path::new("."));
+    let metadata = manifest.meta.map(to_metadata);
+    let mut pages = Vec::with_capacity(manifest.pages.len());
+    for page in manifest.pages {
+        pages.push(to_page(page, base_dir)?);
+    }
+    Ok(Pdf {
+        metadata,
+        pages,
+        ..Pdf::default()
+    })
+}
+
+/// `[meta]` -> `Metadata`: a direct field-for-field copy, every field
+/// optional.
+fn to_metadata(meta: ManifestMeta) -> Metadata {
+    Metadata {
+        title: meta.title,
+        author: meta.author,
+        subject: meta.subject,
+        keywords: meta.keywords,
+        creator: meta.creator,
+        producer: meta.producer,
+        ..Metadata::default()
+    }
+}
+
+/// `[[page]]` -> `Page`: size (named or default A4, swapped under
+/// `landscape`) plus content in schema order.
+fn to_page(page: ManifestPage, base_dir: &Path) -> Result<Page, String> {
+    let size = resolve_size(page.size.as_deref(), page.landscape)?;
+    let mut content = Vec::new();
+    for text in page.texts {
+        content.push(Content::from(to_text(text)?));
+    }
+    for paragraph in page.paragraphs {
+        content.push(Content::from(to_paragraph(paragraph)?));
+    }
+    for image in page.images {
+        content.push(Content::from(to_image(image, base_dir)?));
+    }
+    for link in page.links {
+        content.push(Content::from(to_link(link)?));
+    }
+    Ok(Page {
+        size,
+        content,
+        ..Page::default()
+    })
+}
+
+/// A page's `size`/`landscape` pair resolved to a `PageSize`: an absent
+/// name defaults to A4, an unnamed size errors naming the size and the
+/// valid list.
+fn resolve_size(name: Option<&str>, landscape: bool) -> Result<PageSize, String> {
+    let size = match name {
+        None => PageSize::default(),
+        Some(name) => PageSize::by_name(name).ok_or_else(|| {
+            format!("unknown page size {name:?}: valid sizes are a3, a4, a5, letter, legal")
+        })?,
+    };
+    if !landscape {
+        return Ok(size);
+    }
+    Ok(size.landscape())
+}
+
+/// A font name resolved to a `Standard14`: absent defaults to Helvetica, an
+/// unknown name errors naming the font and the valid list of PostScript
+/// base names.
+fn to_font(name: Option<&str>) -> Result<Standard14, String> {
+    let Some(name) = name else {
+        return Ok(Standard14::Helvetica);
+    };
+    Standard14::from_base_font(name).ok_or_else(|| {
+        let valid: Vec<&str> = Standard14::ALL
+            .iter()
+            .map(|font| font.base_font())
+            .collect();
+        format!(
+            "unknown font {name:?}: valid fonts are {}",
+            valid.join(", ")
+        )
+    })
+}
+
+/// `[[page.text]]` -> `Text`.
+fn to_text(item: ManifestText) -> Result<Text, String> {
+    let font = to_font(item.font.as_deref())?;
+    let mut text = Text {
+        value: item.value,
+        at: Point::new(item.at[0], item.at[1]),
+        font,
+        ..Text::default()
+    };
+    if let Some(size) = item.size {
+        text.size = size;
+    }
+    Ok(text)
+}
+
+/// `align` resolved to a `ParagraphAlign`: absent defaults to left, an
+/// unknown value errors naming the value and the valid list.
+fn to_align(name: Option<&str>) -> Result<ParagraphAlign, String> {
+    match name {
+        None | Some("left") => Ok(ParagraphAlign::Left),
+        Some("center") => Ok(ParagraphAlign::Center),
+        Some("right") => Ok(ParagraphAlign::Right),
+        Some("justify") => Ok(ParagraphAlign::Justify),
+        Some(other) => Err(format!(
+            "unknown paragraph align {other:?}: valid values are left, center, right, justify"
+        )),
+    }
+}
+
+/// `[[page.paragraph]]` -> `Paragraph`.
+fn to_paragraph(item: ManifestParagraph) -> Result<Paragraph, String> {
+    let font = to_font(item.font.as_deref())?;
+    let align = to_align(item.align.as_deref())?;
+    let mut paragraph = Paragraph {
+        text: item.value,
+        rect: item.rect,
+        font,
+        align,
+        ..Paragraph::default()
+    };
+    if let Some(size) = item.size {
+        paragraph.size = size;
+    }
+    if let Some(leading) = item.leading {
+        paragraph.leading = Some(leading);
+    }
+    Ok(paragraph)
+}
+
+/// `[[page.image]]` -> `Image`: `path` resolved relative to the manifest's
+/// directory and decoded by content (PNG or JPEG), never by extension.
+fn to_image(item: ManifestImage, base_dir: &Path) -> Result<Image, String> {
+    let path = base_dir.join(&item.path);
+    let bytes = std::fs::read(&path).map_err(|e| format!("{}: {e}", path.display()))?;
+    let data = ImageData::decode(&bytes).map_err(|e| format!("{}: {e}", path.display()))?;
+    Ok(Image {
+        data,
+        at: Point::new(item.at[0], item.at[1]),
+        width: item.width,
+        height: item.height,
+    })
+}
+
+/// `[[page.link]]` -> `Link`: exactly one of `url`/`page` must be given.
+fn to_link(item: ManifestLink) -> Result<Link, String> {
+    let target = match (item.url, item.page) {
+        (Some(url), None) => LinkTarget::Uri(url),
+        (None, Some(page)) => LinkTarget::Page(page),
+        _ => return Err("link must have exactly one of url or page".to_string()),
+    };
+    Ok(Link {
+        rect: item.rect,
+        target,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const Q3_MANIFEST: &str = r#"
+[meta]
+title  = "Q3 Report"
+author = "Mo"
+
+[[page]]
+size = "a4"
+
+  [[page.text]]
+  value = "Q3 Report"
+  at    = [72, 770]
+  font  = "Helvetica-Bold"
+  size  = 28
+
+  [[page.paragraph]]
+  value   = "Body copy for the quarter."
+  rect    = [72, 380, 523, 720]
+  size    = 11
+  leading = 15
+  align   = "left"
+
+  [[page.image]]
+  path  = "chart.png"
+  at    = [72, 96]
+  width = 200
+
+  [[page.link]]
+  rect = [72, 88, 523, 380]
+  url  = "https://example.com/q3"
+
+[[page]]
+"#;
+
+    fn tiny_png_bytes() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut encoder = png::Encoder::new(&mut bytes, 3, 2);
+        encoder.set_color(png::ColorType::Rgb);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().unwrap();
+        writer.write_image_data(&[10u8; 18]).unwrap();
+        writer.finish().unwrap();
+        bytes
+    }
+
+    fn scratch_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "pdfboss-manifest-test-{label}-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn full_manifest_maps_element_counts_and_values() {
+        let dir = scratch_dir("full");
+        std::fs::write(dir.join("chart.png"), tiny_png_bytes()).unwrap();
+        let manifest_path = dir.join("q3.toml");
+        std::fs::write(&manifest_path, Q3_MANIFEST).unwrap();
+
+        let pdf = build(&manifest_path).unwrap();
+        assert_eq!(pdf.pages.len(), 2);
+        let metadata = pdf.metadata.as_ref().unwrap();
+        assert_eq!(metadata.title.as_deref(), Some("Q3 Report"));
+        assert_eq!(metadata.author.as_deref(), Some("Mo"));
+
+        let first = &pdf.pages[0];
+        assert_eq!(first.size, PageSize::A4);
+        assert_eq!(first.content.len(), 4);
+
+        match &first.content[0] {
+            Content::Text(text) => {
+                assert_eq!(text.value, "Q3 Report");
+                assert_eq!(text.at, Point::new(72.0, 770.0));
+                assert_eq!(text.font, Standard14::HelveticaBold);
+                assert_eq!(text.size, 28.0);
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+        match &first.content[1] {
+            Content::Paragraph(paragraph) => {
+                assert_eq!(paragraph.text, "Body copy for the quarter.");
+                assert_eq!(paragraph.rect, [72.0, 380.0, 523.0, 720.0]);
+                assert_eq!(paragraph.size, 11.0);
+                assert_eq!(paragraph.leading, Some(15.0));
+                assert_eq!(paragraph.align, ParagraphAlign::Left);
+            }
+            other => panic!("expected Paragraph, got {other:?}"),
+        }
+        match &first.content[2] {
+            Content::Image(image) => {
+                assert_eq!(image.at, Point::new(72.0, 96.0));
+                assert_eq!(image.width, Some(200.0));
+                assert_eq!(image.height, None);
+                assert_eq!((image.data.width(), image.data.height()), (3, 2));
+            }
+            other => panic!("expected Image, got {other:?}"),
+        }
+        match &first.content[3] {
+            Content::Link(link) => {
+                assert_eq!(link.rect, [72.0, 88.0, 523.0, 380.0]);
+                assert_eq!(
+                    link.target,
+                    LinkTarget::Uri("https://example.com/q3".to_string())
+                );
+            }
+            other => panic!("expected Link, got {other:?}"),
+        }
+
+        let second = &pdf.pages[1];
+        assert_eq!(second.size, PageSize::A4);
+        assert!(second.content.is_empty());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn errors_are_prefixed_with_the_manifest_path() {
+        let dir = scratch_dir("missing");
+        let manifest_path = dir.join("nope.toml");
+        let err = build(&manifest_path).unwrap_err();
+        assert!(
+            err.starts_with(&manifest_path.display().to_string()),
+            "{err}"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn unknown_key_is_rejected() {
+        let dir = scratch_dir("unknown-key");
+        let manifest_path = dir.join("bad.toml");
+        std::fs::write(&manifest_path, "[meta]\ntitle = \"x\"\nbogus = 1\n").unwrap();
+        let err = build(&manifest_path).unwrap_err();
+        assert!(
+            err.starts_with(&manifest_path.display().to_string()),
+            "{err}"
+        );
+        assert!(err.contains("bogus"), "{err}");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn unknown_font_names_the_font_and_valid_list() {
+        let dir = scratch_dir("unknown-font");
+        let manifest_path = dir.join("bad-font.toml");
+        std::fs::write(
+            &manifest_path,
+            "[[page]]\n  [[page.text]]\n  value = \"hi\"\n  at = [0, 0]\n  font = \"Arial\"\n",
+        )
+        .unwrap();
+        let err = build(&manifest_path).unwrap_err();
+        assert!(err.contains("Arial"), "{err}");
+        assert!(err.contains("Helvetica"), "{err}");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn link_with_both_url_and_page_is_an_error() {
+        let dir = scratch_dir("link-both");
+        let manifest_path = dir.join("bad-link.toml");
+        std::fs::write(
+            &manifest_path,
+            "[[page]]\n  [[page.link]]\n  rect = [0, 0, 1, 1]\n  url = \"https://x\"\n  page = 0\n",
+        )
+        .unwrap();
+        let err = build(&manifest_path).unwrap_err();
+        assert!(err.contains("exactly one"), "{err}");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn link_with_neither_url_nor_page_is_an_error() {
+        let dir = scratch_dir("link-neither");
+        let manifest_path = dir.join("bad-link2.toml");
+        std::fs::write(
+            &manifest_path,
+            "[[page]]\n  [[page.link]]\n  rect = [0, 0, 1, 1]\n",
+        )
+        .unwrap();
+        let err = build(&manifest_path).unwrap_err();
+        assert!(err.contains("exactly one"), "{err}");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn per_page_landscape_swaps_dimensions() {
+        let dir = scratch_dir("landscape");
+        let manifest_path = dir.join("landscape.toml");
+        std::fs::write(
+            &manifest_path,
+            "[[page]]\nsize = \"letter\"\nlandscape = true\n",
+        )
+        .unwrap();
+        let pdf = build(&manifest_path).unwrap();
+        assert_eq!(pdf.pages[0].size.dimensions(), (792.0, 612.0));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn missing_size_defaults_to_a4() {
+        let dir = scratch_dir("default-size");
+        let manifest_path = dir.join("no-size.toml");
+        std::fs::write(&manifest_path, "[[page]]\n").unwrap();
+        let pdf = build(&manifest_path).unwrap();
+        assert_eq!(pdf.pages[0].size, PageSize::A4);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/crates/pdfboss-cli/tests/create_cmd.rs
+++ b/crates/pdfboss-cli/tests/create_cmd.rs
@@ -227,6 +227,88 @@ fn images_with_size_scale_into_the_page() {
     assert!((h - 841.89).abs() < 0.01, "unexpected height {h}");
 }
 
+const Q3_MANIFEST: &str = r#"
+[meta]
+title  = "Q3 Report"
+author = "Mo"
+
+[[page]]
+size = "a4"
+
+  [[page.text]]
+  value = "Q3 Report"
+  at    = [72, 770]
+  font  = "Helvetica-Bold"
+  size  = 28
+
+  [[page.paragraph]]
+  value   = "Body copy for the quarter."
+  rect    = [72, 380, 523, 720]
+  size    = 11
+  leading = 15
+  align   = "left"
+
+  [[page.image]]
+  path  = "chart.png"
+  at    = [72, 96]
+  width = 200
+
+  [[page.link]]
+  rect = [72, 88, 523, 380]
+  url  = "https://example.com/q3"
+
+[[page]]
+"#;
+
+/// The design's own exit test for the TOML manifest: a q3-style manifest
+/// with a tiny PNG fixture on disk and a second bare `[[page]]`, loaded back
+/// through `pdfboss-core` — two pages, the text reaches the content stream,
+/// the metadata reaches `/Info`, and the link's `/URI` resolves structurally
+/// (mirroring the markdown crate's own roundtrip idiom: `/Annots` -> `Annot`
+/// dict -> `/A` -> `/URI`, since the annotation dict is packed into a
+/// compressed object stream and never appears literally in the file).
+#[test]
+fn manifest_maps_toml_through_the_compose_layer() {
+    let dir = tmp("manifest");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("chart.png"), png_bytes(3, 2)).unwrap();
+    let manifest_path = dir.join("q3.toml");
+    std::fs::write(&manifest_path, Q3_MANIFEST).unwrap();
+    let out = dir.join("q3.pdf");
+
+    let output = pdfboss(&[
+        "create",
+        "manifest",
+        manifest_path.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(
+        output.status.success(),
+        "create manifest failed: {output:?}"
+    );
+
+    let doc = load(&out);
+    assert_eq!(doc.page_count(), 2);
+    assert_eq!(doc.metadata().title.as_deref(), Some("Q3 Report"));
+    assert_eq!(doc.metadata().author.as_deref(), Some("Mo"));
+
+    let page = doc.page(0).unwrap();
+    let text = pdfboss_output::extract_text(&doc, &page).unwrap();
+    assert!(text.contains("Q3 Report"), "text was: {text}");
+
+    let annots = page.dict().get_array("Annots").unwrap_or(&[]);
+    let uris: Vec<Vec<u8>> = annots
+        .iter()
+        .filter_map(|annot| doc.resolve(annot).ok())
+        .filter_map(|annot| annot.as_dict().cloned())
+        .filter_map(|annot| annot.get_dict("A").cloned())
+        .filter_map(|action| action.get("URI").cloned())
+        .filter_map(|uri| uri.as_str_bytes().map(<[u8]>::to_vec))
+        .collect();
+    assert_eq!(uris, vec![b"https://example.com/q3".to_vec()]);
+}
+
 #[test]
 fn images_reject_files_without_image_magic() {
     let input = tmp("not-an-image.txt");

--- a/crates/pdfboss-markdown/src/emit.rs
+++ b/crates/pdfboss-markdown/src/emit.rs
@@ -1,7 +1,7 @@
 //! Canvas emission: turns paginated draw items into [`pdfboss_write::Page`]
 //! values ready for [`pdfboss_write::Pdf`] assembly.
 
-use pdfboss_write::{LinkAnnotation, Page, PageSize};
+use pdfboss_write::{LinkAnnotation, LinkTarget, Page, PageSize};
 
 use crate::layout::{Item, LaidPage};
 use crate::Error;
@@ -64,7 +64,7 @@ pub(crate) fn emit(laid: Vec<LaidPage>, page_size: PageSize) -> Result<Vec<Page>
                     Item::Link { x, y, w, h, uri } => {
                         page.links.push(LinkAnnotation {
                             rect: [x, y, x + w, y + h],
-                            uri,
+                            target: LinkTarget::Uri(uri),
                         });
                     }
                 }

--- a/crates/pdfboss-py/Cargo.toml
+++ b/crates/pdfboss-py/Cargo.toml
@@ -18,6 +18,7 @@ pdfboss-markdown = { path = "../pdfboss-markdown" }
 pdfboss-output = { path = "../pdfboss-output" }
 pdfboss-render = { path = "../pdfboss-render" }
 pdfboss-text = { path = "../pdfboss-text" }
+pdfboss-write = { workspace = true }
 # `http` is enabled here so every wheel/sdist build ships open_url support.
 pdfboss-aio = { path = "../pdfboss-aio", features = ["http"] }
 pyo3 = { version = "0.25", features = ["abi3-py312"] }

--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -28,6 +28,8 @@ use pdfboss_output::Output;
 use pdfboss_render::RenderCache;
 use pdfboss_text::{FontCache, TextSpan};
 
+mod write;
+
 create_exception!(
     pdfboss,
     PdfError,
@@ -1880,6 +1882,7 @@ fn _pdfboss(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<AsyncSpanIter>()?;
     m.add_class::<PageImage>()?;
     m.add_function(wrap_pyfunction!(md_to_pdf, m)?)?;
+    write::register(m.py(), m)?;
     Ok(())
 }
 

--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -1808,16 +1808,11 @@ impl AsyncSpanIter {
 /// Maps the Python `size=` string to a [`pdfboss_markdown::PageSize`],
 /// case-insensitively.
 fn page_size_by_name(size: &str) -> PyResult<pdfboss_markdown::PageSize> {
-    match size.to_ascii_lowercase().as_str() {
-        "a3" => Ok(pdfboss_markdown::PageSize::A3),
-        "a4" => Ok(pdfboss_markdown::PageSize::A4),
-        "a5" => Ok(pdfboss_markdown::PageSize::A5),
-        "letter" => Ok(pdfboss_markdown::PageSize::Letter),
-        "legal" => Ok(pdfboss_markdown::PageSize::Legal),
-        other => Err(PdfError::new_err(format!(
-            "unknown page size {other:?}: a3, a4, a5, letter or legal"
-        ))),
-    }
+    pdfboss_write::PageSize::by_name(size).ok_or_else(|| {
+        PdfError::new_err(format!(
+            "unknown page size {size:?}: a3, a4, a5, letter or legal"
+        ))
+    })
 }
 
 /// Composes CommonMark+GFM `markdown` into a themed PDF and returns the

--- a/crates/pdfboss-py/src/write.rs
+++ b/crates/pdfboss-py/src/write.rs
@@ -9,8 +9,19 @@
 //! `WriteMetadata` in Rust — the plain names collide with the
 //! `pdfboss_write` types they lower into — and exposed to Python as
 //! `Pdf`, `Page` and `Metadata` via `#[pyclass(name = "...")]`.
+//!
+//! `Page` also accepts anything exposing a callable `draw` attribute (the
+//! draw protocol): `PyDraw` wraps that handle as a `pdfboss_write::Draw`
+//! implementor. Its `draw` moves the page's in-progress canvas into a
+//! `Canvas` shim, calls the Python object's `draw(canvas)` under a
+//! reacquired GIL, then takes the canvas back — the shim errors once
+//! taken. A Python exception raised there cannot travel through
+//! `pdfboss_write::Error`, so it is stashed in the thread-local
+//! `DRAW_ERROR` and re-raised untouched by `WritePdf::save`/`to_bytes`.
 
+use std::cell::RefCell;
 use std::path::PathBuf;
+use std::sync::{Mutex, PoisonError};
 
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -18,12 +29,34 @@ use pyo3::types::{PyBytes, PyModule};
 
 use pdfboss_core::Point;
 use pdfboss_write::{
-    Color, Content as CoreContent, Image as CoreImage, ImageData, Link as CoreLink,
-    LinkTarget as CoreLinkTarget, Metadata as CoreMetadata, Page as CorePage, Pdf as CorePdf,
-    Standard14 as CoreStandard14, Text as CoreText,
+    Attachment as CoreAttachment, Bookmark as CoreBookmark, Canvas as CoreCanvas, Color,
+    Content as CoreContent, Draw, Image as CoreImage, ImageData, LabelStyle, Link as CoreLink,
+    LinkTarget as CoreLinkTarget, Metadata as CoreMetadata, Outline as CoreOutline,
+    Page as CorePage, PageLabel as CorePageLabel, PageLayout, PageMode, Paragraph as CoreParagraph,
+    ParagraphAlign, Pdf as CorePdf, Standard14 as CoreStandard14, Text as CoreText,
+    Viewer as CoreViewer,
 };
 
 use crate::{page_size_by_name, pdf_err, PdfError};
+
+std::thread_local! {
+    /// Holds a Python exception raised inside a draw-object's `draw()`
+    /// call until `draw_error_or` can re-raise it untouched. Set only by
+    /// `PyDraw::draw`, read only by `draw_error_or`, on the same thread
+    /// within the same `save`/`to_bytes` call — `allow_threads` releases
+    /// the GIL without changing threads, so the two always agree.
+    static DRAW_ERROR: RefCell<Option<PyErr>> = const { RefCell::new(None) };
+}
+
+/// Maps a lowering error from `pdfboss_write`, preferring a Python
+/// exception stashed by a failed draw-object call — raised exactly as
+/// the Python code raised it — over the generic `PdfError` mapping.
+fn draw_error_or(e: pdfboss_write::Error) -> PyErr {
+    if let Some(err) = DRAW_ERROR.with(|cell| cell.borrow_mut().take()) {
+        return err;
+    }
+    pdf_err(e)
+}
 
 /// Shallow-clones a vector of `Py<T>` handles: cheap reference-count
 /// bumps, never a deep copy of the underlying Python object. Shared by
@@ -251,6 +284,71 @@ impl Link {
     }
 }
 
+/// Parses a paragraph alignment string, case-sensitive, into the Rust
+/// enum — `left`, `center`, `right` or `justify`. Anything else is a
+/// `TypeError` naming the valid values, raised at construction so a typo
+/// fails fast instead of surfacing deep inside lowering.
+fn parse_paragraph_align(value: &str) -> PyResult<ParagraphAlign> {
+    match value {
+        "left" => Ok(ParagraphAlign::Left),
+        "center" => Ok(ParagraphAlign::Center),
+        "right" => Ok(ParagraphAlign::Right),
+        "justify" => Ok(ParagraphAlign::Justify),
+        other => Err(PyTypeError::new_err(format!(
+            "unknown paragraph align {other:?}: left, center, right or justify"
+        ))),
+    }
+}
+
+/// A block of text wrapped, aligned, and (for `align="justify"`)
+/// stretched to fill a rectangle.
+#[pyclass(frozen, module = "pdfboss.write")]
+struct Paragraph {
+    text: String,
+    rect: (f32, f32, f32, f32),
+    font: Standard14,
+    size: f32,
+    leading: Option<f32>,
+    align: ParagraphAlign,
+}
+
+#[pymethods]
+impl Paragraph {
+    #[new]
+    #[pyo3(signature = (text, rect, font=Standard14::Helvetica, size=11.0, leading=None, align="left"))]
+    fn new(
+        text: String,
+        rect: (f32, f32, f32, f32),
+        font: Standard14,
+        size: f32,
+        leading: Option<f32>,
+        align: &str,
+    ) -> PyResult<Paragraph> {
+        let align = parse_paragraph_align(align)?;
+        Ok(Paragraph {
+            text,
+            rect,
+            font,
+            size,
+            leading,
+            align,
+        })
+    }
+}
+
+impl Paragraph {
+    fn lower(&self) -> CoreContent {
+        CoreContent::Paragraph(CoreParagraph {
+            text: self.text.clone(),
+            rect: [self.rect.0, self.rect.1, self.rect.2, self.rect.3],
+            font: self.font.into(),
+            size: self.size,
+            leading: self.leading,
+            align: self.align,
+        })
+    }
+}
+
 /// Document information written to the `/Info` dictionary. Dates are
 /// deferred: the write surface stays clock-free, so nothing here reads
 /// the current time.
@@ -302,6 +400,406 @@ impl WriteMetadata {
     }
 }
 
+/// One outline entry: a title, the page it jumps to, and nested children,
+/// composed by nesting `Bookmark` instances rather than `|`.
+#[pyclass(frozen, module = "pdfboss.write")]
+struct Bookmark {
+    title: String,
+    page: usize,
+    children: Vec<Py<Bookmark>>,
+}
+
+#[pymethods]
+impl Bookmark {
+    #[new]
+    #[pyo3(signature = (title, page, *, children=Vec::new()))]
+    fn new(title: String, page: usize, children: Vec<Py<Bookmark>>) -> Bookmark {
+        Bookmark {
+            title,
+            page,
+            children,
+        }
+    }
+}
+
+impl Bookmark {
+    fn lower(&self, py: Python<'_>) -> CoreBookmark {
+        CoreBookmark {
+            title: self.title.clone(),
+            page: self.page,
+            children: self
+                .children
+                .iter()
+                .map(|child| child.borrow(py).lower(py))
+                .collect(),
+        }
+    }
+}
+
+/// A document's bookmark panel: an ordered forest of `Bookmark` nodes. A
+/// singleton `Pdf` slot.
+#[pyclass(frozen, module = "pdfboss.write")]
+struct Outline {
+    bookmarks: Vec<Py<Bookmark>>,
+}
+
+#[pymethods]
+impl Outline {
+    #[new]
+    #[pyo3(signature = (*bookmarks))]
+    fn new(bookmarks: Vec<Py<Bookmark>>) -> Outline {
+        Outline { bookmarks }
+    }
+}
+
+impl Outline {
+    fn lower(&self, py: Python<'_>) -> CoreOutline {
+        CoreOutline {
+            bookmarks: self
+                .bookmarks
+                .iter()
+                .map(|bookmark| bookmark.borrow(py).lower(py))
+                .collect(),
+        }
+    }
+}
+
+/// A document-level attachment, embedded via the catalog's embedded-files
+/// name tree. Attachments carry no dates: the write surface stays
+/// clock-free, so there is no `modified` parameter here.
+#[pyclass(frozen, module = "pdfboss.write")]
+struct Attachment {
+    name: String,
+    data: Vec<u8>,
+    mime: Option<String>,
+    description: Option<String>,
+}
+
+#[pymethods]
+impl Attachment {
+    #[new]
+    #[pyo3(signature = (name, data, mime=None, description=None))]
+    fn new(
+        name: String,
+        data: Vec<u8>,
+        mime: Option<String>,
+        description: Option<String>,
+    ) -> Attachment {
+        Attachment {
+            name,
+            data,
+            mime,
+            description,
+        }
+    }
+}
+
+impl Attachment {
+    fn lower(&self) -> CoreAttachment {
+        CoreAttachment {
+            name: self.name.clone(),
+            data: self.data.clone(),
+            mime: self.mime.clone(),
+            modified: None,
+            description: self.description.clone(),
+        }
+    }
+}
+
+/// Parses a page-label numbering style, case-sensitive: `decimal`,
+/// `roman-upper`, `roman-lower`, `letters-upper` or `letters-lower`.
+/// Anything else is a `TypeError` naming the valid values.
+fn parse_label_style(value: &str) -> PyResult<LabelStyle> {
+    match value {
+        "decimal" => Ok(LabelStyle::Decimal),
+        "roman-upper" => Ok(LabelStyle::RomanUpper),
+        "roman-lower" => Ok(LabelStyle::RomanLower),
+        "letters-upper" => Ok(LabelStyle::LettersUpper),
+        "letters-lower" => Ok(LabelStyle::LettersLower),
+        other => Err(PyTypeError::new_err(format!(
+            "unknown page label style {other:?}: decimal, roman-upper, roman-lower, letters-upper or letters-lower"
+        ))),
+    }
+}
+
+/// One page-numbering range, taking effect from `first_page` until the
+/// next range or the document's end. A singleton-free sequence: a `Pdf`
+/// may carry any number of these.
+#[pyclass(frozen, module = "pdfboss.write")]
+struct PageLabel {
+    first_page: usize,
+    style: Option<LabelStyle>,
+    prefix: Option<String>,
+    start_at: u32,
+}
+
+#[pymethods]
+impl PageLabel {
+    #[new]
+    #[pyo3(signature = (first_page, style=None, prefix=None, start_at=1))]
+    fn new(
+        first_page: usize,
+        style: Option<&str>,
+        prefix: Option<String>,
+        start_at: u32,
+    ) -> PyResult<PageLabel> {
+        let style = style.map(parse_label_style).transpose()?;
+        Ok(PageLabel {
+            first_page,
+            style,
+            prefix,
+            start_at,
+        })
+    }
+}
+
+impl PageLabel {
+    fn lower(&self) -> CorePageLabel {
+        CorePageLabel {
+            first_page: self.first_page,
+            style: self.style,
+            prefix: self.prefix.clone(),
+            start_at: self.start_at,
+        }
+    }
+}
+
+/// Parses an initial page-layout mode, case-sensitive, kebab-cased from
+/// the Rust `PageLayout` variant names. Anything else is a `TypeError`
+/// naming the valid values.
+fn parse_page_layout(value: &str) -> PyResult<PageLayout> {
+    match value {
+        "single-page" => Ok(PageLayout::SinglePage),
+        "one-column" => Ok(PageLayout::OneColumn),
+        "two-column-left" => Ok(PageLayout::TwoColumnLeft),
+        "two-column-right" => Ok(PageLayout::TwoColumnRight),
+        "two-page-left" => Ok(PageLayout::TwoPageLeft),
+        "two-page-right" => Ok(PageLayout::TwoPageRight),
+        other => Err(PyTypeError::new_err(format!(
+            "unknown page layout {other:?}: single-page, one-column, two-column-left, two-column-right, two-page-left or two-page-right"
+        ))),
+    }
+}
+
+/// Parses an initial navigation-panel mode, case-sensitive, kebab-cased
+/// from the Rust `PageMode` variant names. Anything else is a `TypeError`
+/// naming the valid values.
+fn parse_page_mode(value: &str) -> PyResult<PageMode> {
+    match value {
+        "use-none" => Ok(PageMode::UseNone),
+        "use-outlines" => Ok(PageMode::UseOutlines),
+        "use-thumbs" => Ok(PageMode::UseThumbs),
+        "full-screen" => Ok(PageMode::FullScreen),
+        other => Err(PyTypeError::new_err(format!(
+            "unknown page mode {other:?}: use-none, use-outlines, use-thumbs or full-screen"
+        ))),
+    }
+}
+
+/// Viewer preferences written to the catalog: initial layout, navigation
+/// mode, and the page opened at document start. A singleton `Pdf` slot.
+#[pyclass(frozen, module = "pdfboss.write")]
+struct Viewer {
+    layout: Option<PageLayout>,
+    mode: Option<PageMode>,
+    open_to: Option<usize>,
+}
+
+#[pymethods]
+impl Viewer {
+    #[new]
+    #[pyo3(signature = (layout=None, mode=None, open_to=None))]
+    fn new(layout: Option<&str>, mode: Option<&str>, open_to: Option<usize>) -> PyResult<Viewer> {
+        let layout = layout.map(parse_page_layout).transpose()?;
+        let mode = mode.map(parse_page_mode).transpose()?;
+        Ok(Viewer {
+            layout,
+            mode,
+            open_to,
+        })
+    }
+}
+
+impl Viewer {
+    fn lower(&self) -> CoreViewer {
+        CoreViewer {
+            layout: self.layout,
+            mode: self.mode,
+            open_to: self.open_to,
+        }
+    }
+}
+
+/// The message a `Canvas` shim method raises once its interior canvas has
+/// already been taken back — after the `draw()` call that received it has
+/// returned.
+const CANVAS_TAKEN: &str = "canvas is no longer usable outside draw()";
+
+/// The imperative painting surface handed to a draw object's `draw`
+/// method: the page's in-progress `pdfboss_write::Canvas` is moved into
+/// this shim for the call's duration and moved back out afterward, so
+/// painting through it lands in the same canvas as every other element
+/// on the page, in content order. Every method locks the interior and
+/// errors with `PdfError` if the canvas has already been taken back —
+/// the value must not outlive its `draw` call.
+#[pyclass(frozen, module = "pdfboss.write")]
+struct Canvas {
+    inner: Mutex<Option<CoreCanvas>>,
+}
+
+impl Canvas {
+    fn new(canvas: CoreCanvas) -> Canvas {
+        Canvas {
+            inner: Mutex::new(Some(canvas)),
+        }
+    }
+
+    /// Locks the interior canvas and runs `f` on it, or raises `PdfError`
+    /// when the canvas has already been taken back.
+    fn with_canvas<R>(&self, f: impl FnOnce(&mut CoreCanvas) -> R) -> PyResult<R> {
+        let mut guard = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let canvas = guard
+            .as_mut()
+            .ok_or_else(|| PdfError::new_err(CANVAS_TAKEN))?;
+        Ok(f(canvas))
+    }
+}
+
+#[pymethods]
+impl Canvas {
+    /// Shows one line of text with its baseline origin at `at`.
+    #[pyo3(signature = (value, at, font=Standard14::Helvetica, size=12.0))]
+    fn text(&self, value: &str, at: (f32, f32), font: Standard14, size: f32) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.text(value, at.0, at.1, font.into(), size))?
+            .map_err(pdf_err)
+    }
+
+    /// Strokes a straight line from `(x1, y1)` to `(x2, y2)` at `width`.
+    #[pyo3(signature = (x1, y1, x2, y2, width=1.0))]
+    fn line(&self, x1: f32, y1: f32, x2: f32, y2: f32, width: f32) -> PyResult<()> {
+        self.with_canvas(|canvas| {
+            canvas.set_line_width(width);
+            canvas.move_to(x1, y1);
+            canvas.line_to(x2, y2);
+            canvas.stroke();
+        })
+    }
+
+    /// Appends a rectangle subpath.
+    fn rect(&self, x: f32, y: f32, w: f32, h: f32) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.rect(x, y, w, h))
+    }
+
+    /// Begins a new subpath at `(x, y)`.
+    fn move_to(&self, x: f32, y: f32) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.move_to(x, y))
+    }
+
+    /// Straight segment to `(x, y)`.
+    fn line_to(&self, x: f32, y: f32) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.line_to(x, y))
+    }
+
+    /// Cubic Bézier with two control points.
+    #[allow(clippy::too_many_arguments)] // six coordinates is the operator's arity
+    fn curve_to(&self, x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.curve_to(x1, y1, x2, y2, x3, y3))
+    }
+
+    /// Closes the current subpath.
+    fn close(&self) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.close())
+    }
+
+    /// Strokes the current path.
+    fn stroke(&self) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.stroke())
+    }
+
+    /// Fills the current path, nonzero winding.
+    fn fill(&self) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.fill())
+    }
+
+    /// Sets the fill color from an `(r, g, b)` tuple.
+    fn set_fill(&self, rgb: (f32, f32, f32)) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.set_fill(Color::Rgb(rgb.0, rgb.1, rgb.2)))
+    }
+
+    /// Sets the stroke color from an `(r, g, b)` tuple.
+    fn set_stroke(&self, rgb: (f32, f32, f32)) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.set_stroke(Color::Rgb(rgb.0, rgb.1, rgb.2)))
+    }
+
+    /// Sets the stroke line width.
+    fn set_line_width(&self, width: f32) -> PyResult<()> {
+        self.with_canvas(|canvas| canvas.set_line_width(width))
+    }
+}
+
+/// Wraps a Python object exposing a callable `draw` attribute as a Rust
+/// `Draw` implementor, so it can sit in a page's content alongside
+/// `Text`/`Image`/`Link`/`Paragraph` and paint in the same position.
+struct PyDraw {
+    obj: Py<PyAny>,
+}
+
+impl PyDraw {
+    fn new(obj: &Bound<'_, PyAny>) -> PyDraw {
+        PyDraw {
+            obj: obj.clone().unbind(),
+        }
+    }
+}
+
+impl Draw for PyDraw {
+    /// Moves `canvas` into a fresh `Canvas`, calls the wrapped
+    /// object's `draw(canvas)` under a reacquired GIL, and moves the
+    /// (possibly painted-on) canvas back. A raised Python exception is
+    /// stashed in `DRAW_ERROR` for `draw_error_or` to re-raise untouched;
+    /// this call returns a sentinel `pdfboss_write::Error` instead, since
+    /// that type cannot carry a `PyErr`.
+    fn draw(&self, canvas: &mut CoreCanvas) -> pdfboss_write::Result<()> {
+        let taken = std::mem::take(canvas);
+        let outcome = Python::with_gil(|py| -> PyResult<CoreCanvas> {
+            let shim = Py::new(py, Canvas::new(taken))?;
+            self.obj
+                .bind(py)
+                .call_method1("draw", (shim.clone_ref(py),))?;
+            let shim_ref = shim.borrow(py);
+            let mut guard = shim_ref
+                .inner
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            guard
+                .take()
+                .ok_or_else(|| PdfError::new_err("canvas shim lost its canvas unexpectedly"))
+        });
+        match outcome {
+            Ok(restored) => {
+                *canvas = restored;
+                Ok(())
+            }
+            Err(err) => {
+                DRAW_ERROR.with(|cell| *cell.borrow_mut() = Some(err));
+                Err(pdfboss_write::Error::Other(
+                    "python draw() raised an exception".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+/// True when `obj` has an attribute named `draw` that is itself callable
+/// — the draw protocol's entire contract. Neither `hasattr` nor the
+/// callable check alone is enough: a non-callable `draw` attribute is not
+/// a draw object.
+fn has_callable_draw(obj: &Bound<'_, PyAny>) -> bool {
+    obj.getattr("draw")
+        .map(|attr| attr.is_callable())
+        .unwrap_or(false)
+}
+
 /// One page: its size and the content composed onto it with `|`. `size`
 /// is resolved case-insensitively at lowering, via the same
 /// `page_size_by_name` the markdown composer uses.
@@ -324,13 +822,15 @@ impl WritePage {
         }
     }
 
-    /// Composes one more element onto the page: `Text`, `Image` or
-    /// `Link`. Returns a new `Page`; the receiver is unchanged.
+    /// Composes one more element onto the page: `Text`, `Image`, `Link`,
+    /// `Paragraph`, or any object with a callable `draw` attribute (the
+    /// draw protocol). Returns a new `Page`; the receiver is unchanged.
     fn __or__(&self, rhs: &Bound<'_, PyAny>) -> PyResult<WritePage> {
         let is_element = rhs.downcast::<Text>().is_ok()
             || rhs.downcast::<Image>().is_ok()
-            || rhs.downcast::<Link>().is_ok();
-        if !is_element {
+            || rhs.downcast::<Link>().is_ok()
+            || rhs.downcast::<Paragraph>().is_ok();
+        if !is_element && !has_callable_draw(rhs) {
             return Err(PyTypeError::new_err(format!(
                 "Page cannot compose with {}",
                 rhs.get_type().name()?
@@ -366,10 +866,11 @@ impl WritePage {
     }
 }
 
-/// Lowers one page-content handle, dispatching by its concrete pyclass.
-/// `WritePage::__or__` only ever stores `Text`, `Image` or `Link`
-/// handles, so the fallback error is unreachable in practice — it exists
-/// so a future bug here is a clear message, not a panic.
+/// Lowers one page-content handle, dispatching by its concrete pyclass,
+/// with a callable `draw` attribute as the catch-all for anything else.
+/// `WritePage::__or__` only ever stores handles matching one of these, so
+/// the fallback error is unreachable in practice — it exists so a future
+/// bug here is a clear message, not a panic.
 fn lower_content(item: &Bound<'_, PyAny>) -> PyResult<CoreContent> {
     if let Ok(text) = item.downcast::<Text>() {
         return Ok(text.borrow().lower());
@@ -380,19 +881,30 @@ fn lower_content(item: &Bound<'_, PyAny>) -> PyResult<CoreContent> {
     if let Ok(link) = item.downcast::<Link>() {
         return Ok(link.borrow().lower());
     }
+    if let Ok(paragraph) = item.downcast::<Paragraph>() {
+        return Ok(paragraph.borrow().lower());
+    }
+    if has_callable_draw(item) {
+        return Ok(CoreContent::custom(PyDraw::new(item)));
+    }
     Err(PdfError::new_err(format!(
         "unsupported page content: {}",
         item.get_type().name()?
     )))
 }
 
-/// A document under construction: pages in reading order, plus at most
-/// one `Metadata` slot. `|` accumulates cheap handle copies; nothing is
-/// built or read until `save`/`to_bytes`.
+/// A document under construction: pages in reading order, the singleton
+/// `Metadata`/`Outline`/`Viewer` slots, and the `Attachment`/`PageLabel`
+/// sequences. `|` accumulates cheap handle copies; nothing is built or
+/// read until `save`/`to_bytes`.
 #[pyclass(name = "Pdf", module = "pdfboss.write", frozen)]
 struct WritePdf {
     pages: Vec<Py<WritePage>>,
     metadata: Option<Py<WriteMetadata>>,
+    outline: Option<Py<Outline>>,
+    attachments: Vec<Py<Attachment>>,
+    page_labels: Vec<Py<PageLabel>>,
+    viewer: Option<Py<Viewer>>,
 }
 
 #[pymethods]
@@ -402,20 +914,23 @@ impl WritePdf {
         WritePdf {
             pages: Vec::new(),
             metadata: None,
+            outline: None,
+            attachments: Vec::new(),
+            page_labels: Vec::new(),
+            viewer: None,
         }
     }
 
-    /// Composes one more `Page` (appended) or `Metadata` (the singleton
-    /// slot) onto the document. Returns a new `Pdf`; the receiver is
-    /// unchanged. A second `Metadata` raises `TypeError`.
+    /// Composes one more `Page` or `Attachment` or `PageLabel` (each
+    /// appended), or `Metadata`/`Outline`/`Viewer` (each a singleton slot)
+    /// onto the document. Returns a new `Pdf`; the receiver is unchanged.
+    /// A second `Metadata`, `Outline` or `Viewer` raises `TypeError`.
     fn __or__(&self, rhs: &Bound<'_, PyAny>) -> PyResult<WritePdf> {
+        let py = rhs.py();
         if let Ok(page) = rhs.downcast::<WritePage>() {
-            let mut pages = clone_py_vec(rhs.py(), &self.pages);
-            pages.push(page.clone().unbind());
-            return Ok(WritePdf {
-                pages,
-                metadata: self.metadata.as_ref().map(|meta| meta.clone_ref(rhs.py())),
-            });
+            let mut next = self.shallow_clone(py);
+            next.pages.push(page.clone().unbind());
+            return Ok(next);
         }
         if let Ok(meta) = rhs.downcast::<WriteMetadata>() {
             if self.metadata.is_some() {
@@ -423,10 +938,39 @@ impl WritePdf {
                     "Pdf already has Metadata — one per document",
                 ));
             }
-            return Ok(WritePdf {
-                pages: clone_py_vec(rhs.py(), &self.pages),
-                metadata: Some(meta.clone().unbind()),
-            });
+            let mut next = self.shallow_clone(py);
+            next.metadata = Some(meta.clone().unbind());
+            return Ok(next);
+        }
+        if let Ok(outline) = rhs.downcast::<Outline>() {
+            if self.outline.is_some() {
+                return Err(PyTypeError::new_err(
+                    "Pdf already has Outline — one per document",
+                ));
+            }
+            let mut next = self.shallow_clone(py);
+            next.outline = Some(outline.clone().unbind());
+            return Ok(next);
+        }
+        if let Ok(viewer) = rhs.downcast::<Viewer>() {
+            if self.viewer.is_some() {
+                return Err(PyTypeError::new_err(
+                    "Pdf already has Viewer — one per document",
+                ));
+            }
+            let mut next = self.shallow_clone(py);
+            next.viewer = Some(viewer.clone().unbind());
+            return Ok(next);
+        }
+        if let Ok(attachment) = rhs.downcast::<Attachment>() {
+            let mut next = self.shallow_clone(py);
+            next.attachments.push(attachment.clone().unbind());
+            return Ok(next);
+        }
+        if let Ok(label) = rhs.downcast::<PageLabel>() {
+            let mut next = self.shallow_clone(py);
+            next.page_labels.push(label.clone().unbind());
+            return Ok(next);
         }
         Err(PyTypeError::new_err(format!(
             "Pdf cannot compose with {}",
@@ -439,7 +983,8 @@ impl WritePdf {
     /// releases it for the actual serialization.
     fn save(&self, py: Python<'_>, path: PathBuf) -> PyResult<()> {
         let core = self.lower(py)?;
-        py.allow_threads(|| core.save(path)).map_err(pdf_err)
+        DRAW_ERROR.with(|cell| cell.borrow_mut().take());
+        py.allow_threads(|| core.save(path)).map_err(draw_error_or)
     }
 
     /// Serializes the document to file bytes, like `save`. May be called
@@ -447,21 +992,57 @@ impl WritePdf {
     /// accumulated handles, so the composed value is never consumed.
     fn to_bytes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
         let core = self.lower(py)?;
-        let bytes = py.allow_threads(|| core.to_bytes()).map_err(pdf_err)?;
+        DRAW_ERROR.with(|cell| cell.borrow_mut().take());
+        let bytes = py
+            .allow_threads(|| core.to_bytes())
+            .map_err(draw_error_or)?;
         Ok(PyBytes::new(py, &bytes))
     }
 }
 
 impl WritePdf {
+    /// Copies every field as cheap handle clones — the shared first step
+    /// of every `__or__` branch, which then overwrites or appends to
+    /// exactly one field.
+    fn shallow_clone(&self, py: Python<'_>) -> WritePdf {
+        WritePdf {
+            pages: clone_py_vec(py, &self.pages),
+            metadata: self.metadata.as_ref().map(|meta| meta.clone_ref(py)),
+            outline: self.outline.as_ref().map(|outline| outline.clone_ref(py)),
+            attachments: clone_py_vec(py, &self.attachments),
+            page_labels: clone_py_vec(py, &self.page_labels),
+            viewer: self.viewer.as_ref().map(|viewer| viewer.clone_ref(py)),
+        }
+    }
+
     fn lower(&self, py: Python<'_>) -> PyResult<CorePdf> {
         let mut pages = Vec::with_capacity(self.pages.len());
         for page in &self.pages {
             pages.push(page.borrow(py).lower(py)?);
         }
         let metadata = self.metadata.as_ref().map(|meta| meta.borrow(py).lower());
+        let outline = self
+            .outline
+            .as_ref()
+            .map(|outline| outline.borrow(py).lower(py));
+        let attachments = self
+            .attachments
+            .iter()
+            .map(|attachment| attachment.borrow(py).lower())
+            .collect();
+        let page_labels = self
+            .page_labels
+            .iter()
+            .map(|label| label.borrow(py).lower())
+            .collect();
+        let viewer = self.viewer.as_ref().map(|viewer| viewer.borrow(py).lower());
         Ok(CorePdf {
             metadata,
             pages,
+            outline,
+            attachments,
+            page_labels,
+            viewer,
             ..CorePdf::default()
         })
     }
@@ -481,6 +1062,13 @@ pub(crate) fn register(py: Python<'_>, parent: &Bound<'_, PyModule>) -> PyResult
     module.add_class::<Text>()?;
     module.add_class::<Image>()?;
     module.add_class::<Link>()?;
+    module.add_class::<Paragraph>()?;
+    module.add_class::<Bookmark>()?;
+    module.add_class::<Outline>()?;
+    module.add_class::<Attachment>()?;
+    module.add_class::<PageLabel>()?;
+    module.add_class::<Viewer>()?;
+    module.add_class::<Canvas>()?;
     module.add_class::<WriteMetadata>()?;
     module.add_class::<WritePage>()?;
     module.add_class::<WritePdf>()?;

--- a/crates/pdfboss-py/src/write.rs
+++ b/crates/pdfboss-py/src/write.rs
@@ -1,0 +1,492 @@
+//! Python bindings for pdfboss's write side: `pdfboss.write` composes a
+//! PDF from frozen pyclasses accumulated with `|`, each application
+//! copying handles cheaply and returning a new value. Composition never
+//! touches the Rust document model until `Pdf.save`/`Pdf.to_bytes`, which
+//! walk the accumulated pages and slots once, under the GIL, to build a
+//! `pdfboss_write::Pdf`, then release the GIL to serialize it.
+//!
+//! `Pdf`, `Page` and `Metadata` are named `WritePdf`, `WritePage` and
+//! `WriteMetadata` in Rust — the plain names collide with the
+//! `pdfboss_write` types they lower into — and exposed to Python as
+//! `Pdf`, `Page` and `Metadata` via `#[pyclass(name = "...")]`.
+
+use std::path::PathBuf;
+
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyModule};
+
+use pdfboss_core::Point;
+use pdfboss_write::{
+    Color, Content as CoreContent, Image as CoreImage, ImageData, Link as CoreLink,
+    LinkTarget as CoreLinkTarget, Metadata as CoreMetadata, Page as CorePage, Pdf as CorePdf,
+    Standard14 as CoreStandard14, Text as CoreText,
+};
+
+use crate::{page_size_by_name, pdf_err, PdfError};
+
+/// Shallow-clones a vector of `Py<T>` handles: cheap reference-count
+/// bumps, never a deep copy of the underlying Python object. Shared by
+/// every `__or__` that appends to an accumulated `Vec<Py<T>>`.
+fn clone_py_vec<T>(py: Python<'_>, items: &[Py<T>]) -> Vec<Py<T>> {
+    items.iter().map(|item| item.clone_ref(py)).collect()
+}
+
+/// One of the fourteen standard fonts every PDF consumer provides.
+#[pyclass(eq, frozen, name = "Standard14", module = "pdfboss.write")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Standard14 {
+    #[pyo3(name = "HELVETICA")]
+    Helvetica,
+    #[pyo3(name = "HELVETICA_BOLD")]
+    HelveticaBold,
+    #[pyo3(name = "HELVETICA_OBLIQUE")]
+    HelveticaOblique,
+    #[pyo3(name = "HELVETICA_BOLD_OBLIQUE")]
+    HelveticaBoldOblique,
+    #[pyo3(name = "TIMES_ROMAN")]
+    TimesRoman,
+    #[pyo3(name = "TIMES_BOLD")]
+    TimesBold,
+    #[pyo3(name = "TIMES_ITALIC")]
+    TimesItalic,
+    #[pyo3(name = "TIMES_BOLD_ITALIC")]
+    TimesBoldItalic,
+    #[pyo3(name = "COURIER")]
+    Courier,
+    #[pyo3(name = "COURIER_BOLD")]
+    CourierBold,
+    #[pyo3(name = "COURIER_OBLIQUE")]
+    CourierOblique,
+    #[pyo3(name = "COURIER_BOLD_OBLIQUE")]
+    CourierBoldOblique,
+    #[pyo3(name = "SYMBOL")]
+    Symbol,
+    #[pyo3(name = "ZAPF_DINGBATS")]
+    ZapfDingbats,
+}
+
+impl From<Standard14> for CoreStandard14 {
+    fn from(value: Standard14) -> CoreStandard14 {
+        match value {
+            Standard14::Helvetica => CoreStandard14::Helvetica,
+            Standard14::HelveticaBold => CoreStandard14::HelveticaBold,
+            Standard14::HelveticaOblique => CoreStandard14::HelveticaOblique,
+            Standard14::HelveticaBoldOblique => CoreStandard14::HelveticaBoldOblique,
+            Standard14::TimesRoman => CoreStandard14::TimesRoman,
+            Standard14::TimesBold => CoreStandard14::TimesBold,
+            Standard14::TimesItalic => CoreStandard14::TimesItalic,
+            Standard14::TimesBoldItalic => CoreStandard14::TimesBoldItalic,
+            Standard14::Courier => CoreStandard14::Courier,
+            Standard14::CourierBold => CoreStandard14::CourierBold,
+            Standard14::CourierOblique => CoreStandard14::CourierOblique,
+            Standard14::CourierBoldOblique => CoreStandard14::CourierBoldOblique,
+            Standard14::Symbol => CoreStandard14::Symbol,
+            Standard14::ZapfDingbats => CoreStandard14::ZapfDingbats,
+        }
+    }
+}
+
+/// One line of text at a fixed baseline origin.
+#[pyclass(frozen, module = "pdfboss.write")]
+struct Text {
+    value: String,
+    at: (f32, f32),
+    font: Standard14,
+    size: f32,
+    color: Option<(f32, f32, f32)>,
+}
+
+#[pymethods]
+impl Text {
+    #[new]
+    #[pyo3(signature = (value, at, font=Standard14::Helvetica, size=12.0, color=None))]
+    fn new(
+        value: String,
+        at: (f32, f32),
+        font: Standard14,
+        size: f32,
+        color: Option<(f32, f32, f32)>,
+    ) -> Text {
+        Text {
+            value,
+            at,
+            font,
+            size,
+            color,
+        }
+    }
+}
+
+impl Text {
+    /// Lowers to a composed content element; infallible — a `Text`
+    /// element carries nothing that can fail before the font actually
+    /// encodes it, which happens later, inside `Canvas::text`.
+    fn lower(&self) -> CoreContent {
+        let color = match self.color {
+            Some((r, g, b)) => Color::Rgb(r, g, b),
+            None => Color::BLACK,
+        };
+        CoreContent::Text(CoreText {
+            value: self.value.clone(),
+            at: Point::new(self.at.0, self.at.1),
+            font: self.font.into(),
+            size: self.size,
+            color,
+        })
+    }
+}
+
+/// Where an `Image`'s pixels come from: a path read at lowering, or raw
+/// bytes given directly. No I/O happens at construction time.
+enum ImageSource {
+    Path(String),
+    Bytes(Vec<u8>),
+}
+
+/// A raster image placed at a point.
+#[pyclass(frozen, module = "pdfboss.write")]
+struct Image {
+    source: ImageSource,
+    at: (f32, f32),
+    width: Option<f32>,
+    height: Option<f32>,
+}
+
+#[pymethods]
+impl Image {
+    #[new]
+    #[pyo3(signature = (data, at, width=None, height=None))]
+    fn new(
+        data: &Bound<'_, PyAny>,
+        at: (f32, f32),
+        width: Option<f32>,
+        height: Option<f32>,
+    ) -> PyResult<Image> {
+        let source = if let Ok(path) = data.extract::<String>() {
+            ImageSource::Path(path)
+        } else if let Ok(bytes) = data.extract::<Vec<u8>>() {
+            ImageSource::Bytes(bytes)
+        } else {
+            return Err(PyTypeError::new_err(format!(
+                "Image data must be str (path) or bytes, got {}",
+                data.get_type().name()?
+            )));
+        };
+        Ok(Image {
+            source,
+            at,
+            width,
+            height,
+        })
+    }
+}
+
+impl Image {
+    /// Reads the source bytes (a filesystem read for a path source) and
+    /// decodes them, at lowering time only — construction does no I/O.
+    fn lower(&self) -> PyResult<CoreContent> {
+        let bytes = match &self.source {
+            ImageSource::Bytes(data) => data.clone(),
+            ImageSource::Path(path) => std::fs::read(path)
+                .map_err(|e| PdfError::new_err(format!("failed to read image {path:?}: {e}")))?,
+        };
+        let data = ImageData::decode(&bytes).map_err(pdf_err)?;
+        Ok(CoreContent::Image(CoreImage {
+            data,
+            at: Point::new(self.at.0, self.at.1),
+            width: self.width,
+            height: self.height,
+        }))
+    }
+}
+
+/// Where a `Link` leads: exactly one of `url` or `page` is given at
+/// construction.
+enum LinkTargetValue {
+    Uri(String),
+    Page(usize),
+}
+
+/// A clickable rectangle, lowered into a link annotation on the page.
+#[pyclass(frozen, module = "pdfboss.write")]
+struct Link {
+    rect: (f32, f32, f32, f32),
+    target: LinkTargetValue,
+}
+
+#[pymethods]
+impl Link {
+    #[new]
+    #[pyo3(signature = (rect, url=None, page=None))]
+    fn new(rect: (f32, f32, f32, f32), url: Option<String>, page: Option<usize>) -> PyResult<Link> {
+        let target = match (url, page) {
+            (Some(url), None) => LinkTargetValue::Uri(url),
+            (None, Some(page)) => LinkTargetValue::Page(page),
+            (None, None) => {
+                return Err(PyTypeError::new_err(
+                    "Link needs exactly one of url or page",
+                ))
+            }
+            (Some(_), Some(_)) => {
+                return Err(PyTypeError::new_err(
+                    "Link accepts only one of url or page, not both",
+                ))
+            }
+        };
+        Ok(Link { rect, target })
+    }
+}
+
+impl Link {
+    fn lower(&self) -> CoreContent {
+        let target = match &self.target {
+            LinkTargetValue::Uri(uri) => CoreLinkTarget::Uri(uri.clone()),
+            LinkTargetValue::Page(index) => CoreLinkTarget::Page(*index),
+        };
+        CoreContent::Link(CoreLink {
+            rect: [self.rect.0, self.rect.1, self.rect.2, self.rect.3],
+            target,
+        })
+    }
+}
+
+/// Document information written to the `/Info` dictionary. Dates are
+/// deferred: the write surface stays clock-free, so nothing here reads
+/// the current time.
+#[pyclass(name = "Metadata", module = "pdfboss.write", frozen)]
+struct WriteMetadata {
+    title: Option<String>,
+    author: Option<String>,
+    subject: Option<String>,
+    keywords: Option<String>,
+    creator: Option<String>,
+    producer: Option<String>,
+}
+
+#[pymethods]
+impl WriteMetadata {
+    #[new]
+    #[pyo3(signature = (title=None, author=None, subject=None, keywords=None, creator=None, producer=None))]
+    fn new(
+        title: Option<String>,
+        author: Option<String>,
+        subject: Option<String>,
+        keywords: Option<String>,
+        creator: Option<String>,
+        producer: Option<String>,
+    ) -> WriteMetadata {
+        WriteMetadata {
+            title,
+            author,
+            subject,
+            keywords,
+            creator,
+            producer,
+        }
+    }
+}
+
+impl WriteMetadata {
+    fn lower(&self) -> CoreMetadata {
+        CoreMetadata {
+            title: self.title.clone(),
+            author: self.author.clone(),
+            subject: self.subject.clone(),
+            keywords: self.keywords.clone(),
+            creator: self.creator.clone(),
+            producer: self.producer.clone(),
+            creation_date: None,
+            modification_date: None,
+        }
+    }
+}
+
+/// One page: its size and the content composed onto it with `|`. `size`
+/// is resolved case-insensitively at lowering, via the same
+/// `page_size_by_name` the markdown composer uses.
+#[pyclass(name = "Page", module = "pdfboss.write", frozen)]
+struct WritePage {
+    size: String,
+    landscape: bool,
+    content: Vec<Py<PyAny>>,
+}
+
+#[pymethods]
+impl WritePage {
+    #[new]
+    #[pyo3(signature = (size="a4", landscape=false))]
+    fn new(size: &str, landscape: bool) -> WritePage {
+        WritePage {
+            size: size.to_string(),
+            landscape,
+            content: Vec::new(),
+        }
+    }
+
+    /// Composes one more element onto the page: `Text`, `Image` or
+    /// `Link`. Returns a new `Page`; the receiver is unchanged.
+    fn __or__(&self, rhs: &Bound<'_, PyAny>) -> PyResult<WritePage> {
+        let is_element = rhs.downcast::<Text>().is_ok()
+            || rhs.downcast::<Image>().is_ok()
+            || rhs.downcast::<Link>().is_ok();
+        if !is_element {
+            return Err(PyTypeError::new_err(format!(
+                "Page cannot compose with {}",
+                rhs.get_type().name()?
+            )));
+        }
+        let mut content = clone_py_vec(rhs.py(), &self.content);
+        content.push(rhs.clone().unbind());
+        Ok(WritePage {
+            size: self.size.clone(),
+            landscape: self.landscape,
+            content,
+        })
+    }
+}
+
+impl WritePage {
+    fn lower(&self, py: Python<'_>) -> PyResult<CorePage> {
+        let size = page_size_by_name(&self.size)?;
+        let size = if self.landscape {
+            size.landscape()
+        } else {
+            size
+        };
+        let mut content = Vec::with_capacity(self.content.len());
+        for item in &self.content {
+            content.push(lower_content(item.bind(py))?);
+        }
+        Ok(CorePage {
+            size,
+            content,
+            ..CorePage::default()
+        })
+    }
+}
+
+/// Lowers one page-content handle, dispatching by its concrete pyclass.
+/// `WritePage::__or__` only ever stores `Text`, `Image` or `Link`
+/// handles, so the fallback error is unreachable in practice — it exists
+/// so a future bug here is a clear message, not a panic.
+fn lower_content(item: &Bound<'_, PyAny>) -> PyResult<CoreContent> {
+    if let Ok(text) = item.downcast::<Text>() {
+        return Ok(text.borrow().lower());
+    }
+    if let Ok(image) = item.downcast::<Image>() {
+        return image.borrow().lower();
+    }
+    if let Ok(link) = item.downcast::<Link>() {
+        return Ok(link.borrow().lower());
+    }
+    Err(PdfError::new_err(format!(
+        "unsupported page content: {}",
+        item.get_type().name()?
+    )))
+}
+
+/// A document under construction: pages in reading order, plus at most
+/// one `Metadata` slot. `|` accumulates cheap handle copies; nothing is
+/// built or read until `save`/`to_bytes`.
+#[pyclass(name = "Pdf", module = "pdfboss.write", frozen)]
+struct WritePdf {
+    pages: Vec<Py<WritePage>>,
+    metadata: Option<Py<WriteMetadata>>,
+}
+
+#[pymethods]
+impl WritePdf {
+    #[new]
+    fn new() -> WritePdf {
+        WritePdf {
+            pages: Vec::new(),
+            metadata: None,
+        }
+    }
+
+    /// Composes one more `Page` (appended) or `Metadata` (the singleton
+    /// slot) onto the document. Returns a new `Pdf`; the receiver is
+    /// unchanged. A second `Metadata` raises `TypeError`.
+    fn __or__(&self, rhs: &Bound<'_, PyAny>) -> PyResult<WritePdf> {
+        if let Ok(page) = rhs.downcast::<WritePage>() {
+            let mut pages = clone_py_vec(rhs.py(), &self.pages);
+            pages.push(page.clone().unbind());
+            return Ok(WritePdf {
+                pages,
+                metadata: self.metadata.as_ref().map(|meta| meta.clone_ref(rhs.py())),
+            });
+        }
+        if let Ok(meta) = rhs.downcast::<WriteMetadata>() {
+            if self.metadata.is_some() {
+                return Err(PyTypeError::new_err(
+                    "Pdf already has Metadata — one per document",
+                ));
+            }
+            return Ok(WritePdf {
+                pages: clone_py_vec(rhs.py(), &self.pages),
+                metadata: Some(meta.clone().unbind()),
+            });
+        }
+        Err(PyTypeError::new_err(format!(
+            "Pdf cannot compose with {}",
+            rhs.get_type().name()?
+        )))
+    }
+
+    /// Serializes and writes the document to `path`. Lowers the
+    /// accumulated pages and slots into a Rust `Pdf` under the GIL, then
+    /// releases it for the actual serialization.
+    fn save(&self, py: Python<'_>, path: PathBuf) -> PyResult<()> {
+        let core = self.lower(py)?;
+        py.allow_threads(|| core.save(path)).map_err(pdf_err)
+    }
+
+    /// Serializes the document to file bytes, like `save`. May be called
+    /// more than once — each call lowers a fresh Rust `Pdf` from the
+    /// accumulated handles, so the composed value is never consumed.
+    fn to_bytes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let core = self.lower(py)?;
+        let bytes = py.allow_threads(|| core.to_bytes()).map_err(pdf_err)?;
+        Ok(PyBytes::new(py, &bytes))
+    }
+}
+
+impl WritePdf {
+    fn lower(&self, py: Python<'_>) -> PyResult<CorePdf> {
+        let mut pages = Vec::with_capacity(self.pages.len());
+        for page in &self.pages {
+            pages.push(page.borrow(py).lower(py)?);
+        }
+        let metadata = self.metadata.as_ref().map(|meta| meta.borrow(py).lower());
+        Ok(CorePdf {
+            metadata,
+            pages,
+            ..CorePdf::default()
+        })
+    }
+}
+
+/// Builds the `write` submodule, registers its classes, and makes it
+/// importable as `pdfboss._pdfboss.write`.
+///
+/// `PyModule::new` + `add_submodule` alone only exposes the submodule as
+/// an *attribute* of `_pdfboss` (`_pdfboss.write.Pdf` works via attribute
+/// access); `import pdfboss._pdfboss.write` or `from
+/// pdfboss._pdfboss.write import Pdf` additionally need the submodule
+/// registered in `sys.modules` under its dotted name.
+pub(crate) fn register(py: Python<'_>, parent: &Bound<'_, PyModule>) -> PyResult<()> {
+    let module = PyModule::new(py, "write")?;
+    module.add_class::<Standard14>()?;
+    module.add_class::<Text>()?;
+    module.add_class::<Image>()?;
+    module.add_class::<Link>()?;
+    module.add_class::<WriteMetadata>()?;
+    module.add_class::<WritePage>()?;
+    module.add_class::<WritePdf>()?;
+    parent.add_submodule(&module)?;
+    py.import("sys")?
+        .getattr("modules")?
+        .set_item("pdfboss._pdfboss.write", &module)?;
+    Ok(())
+}

--- a/crates/pdfboss-py/src/write.rs
+++ b/crates/pdfboss-py/src/write.rs
@@ -753,32 +753,46 @@ impl PyDraw {
 }
 
 impl Draw for PyDraw {
-    /// Moves `canvas` into a fresh `Canvas`, calls the wrapped
-    /// object's `draw(canvas)` under a reacquired GIL, and moves the
-    /// (possibly painted-on) canvas back. A raised Python exception is
-    /// stashed in `DRAW_ERROR` for `draw_error_or` to re-raise untouched;
-    /// this call returns a sentinel `pdfboss_write::Error` instead, since
-    /// that type cannot carry a `PyErr`.
+    /// Moves `canvas` into a fresh `Canvas`, calls the wrapped object's
+    /// `draw(canvas)` under a reacquired GIL, and reclaims the
+    /// (possibly painted-on) canvas back into `*canvas` — unconditionally,
+    /// whether `draw` raised or not, so a shim the Python object smuggled
+    /// out (say, stashed on `self` before raising) is left holding no
+    /// canvas either way and errors on any further use. Only when the
+    /// shim itself could never be created (`Py::new` failing) is there
+    /// nothing to reclaim. A raised Python exception is stashed in
+    /// `DRAW_ERROR` for `draw_error_or` to re-raise untouched; this call
+    /// returns a sentinel `pdfboss_write::Error` instead, since that type
+    /// cannot carry a `PyErr`.
     fn draw(&self, canvas: &mut CoreCanvas) -> pdfboss_write::Result<()> {
         let taken = std::mem::take(canvas);
-        let outcome = Python::with_gil(|py| -> PyResult<CoreCanvas> {
+        let outcome = Python::with_gil(|py| -> PyResult<(CoreCanvas, Option<PyErr>)> {
             let shim = Py::new(py, Canvas::new(taken))?;
-            self.obj
+            let draw_result = self
+                .obj
                 .bind(py)
-                .call_method1("draw", (shim.clone_ref(py),))?;
+                .call_method1("draw", (shim.clone_ref(py),));
             let shim_ref = shim.borrow(py);
             let mut guard = shim_ref
                 .inner
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner);
-            guard
+            let restored = guard
                 .take()
-                .ok_or_else(|| PdfError::new_err("canvas shim lost its canvas unexpectedly"))
+                .ok_or_else(|| PdfError::new_err("canvas shim lost its canvas unexpectedly"))?;
+            Ok((restored, draw_result.err()))
         });
         match outcome {
-            Ok(restored) => {
+            Ok((restored, None)) => {
                 *canvas = restored;
                 Ok(())
+            }
+            Ok((restored, Some(err))) => {
+                *canvas = restored;
+                DRAW_ERROR.with(|cell| *cell.borrow_mut() = Some(err));
+                Err(pdfboss_write::Error::Other(
+                    "python draw() raised an exception".to_string(),
+                ))
             }
             Err(err) => {
                 DRAW_ERROR.with(|cell| *cell.borrow_mut() = Some(err));

--- a/crates/pdfboss-write/src/canvas.rs
+++ b/crates/pdfboss-write/src/canvas.rs
@@ -5,11 +5,14 @@
 //!
 //! Resource naming contract: the font first used gets resource name `F1`,
 //! the next distinct font `F2`, …; image handles map to `Im1`, `Im2`, … in
-//! [`add_image`](Canvas::add_image) order. Assembly builds the matching
-//! `/Resources` dictionary from [`CanvasParts`].
+//! [`add_image`](Canvas::add_image) order; groups registered with
+//! [`group`](Canvas::group) map to `Gp1`, `Gp2`, …; distinct `/ExtGState`
+//! entries pushed by the alpha/blend-mode setters map to `Gs1`, `Gs2`, ….
+//! Assembly builds the matching `/Resources` dictionary from
+//! [`CanvasParts`].
 
 use pdfboss_core::content::Op;
-use pdfboss_core::{Matrix, Name, Point};
+use pdfboss_core::{Dict, Matrix, Name, Object, Point};
 
 use crate::color::Color;
 use crate::error::Result;
@@ -47,6 +50,93 @@ pub enum LineJoin {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ImageHandle(pub(crate) usize);
 
+/// Handle to a sub-canvas registered with [`Canvas::group`], painted with
+/// [`Canvas::draw_group`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GroupHandle(pub(crate) usize);
+
+/// A separable blend mode (ISO 32000 §11.3.5, Table 136), set with
+/// [`Canvas::set_blend_mode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendMode {
+    /// Source color replaces the backdrop.
+    Normal,
+    /// Product of source and backdrop.
+    Multiply,
+    /// Complement of the product of the complements.
+    Screen,
+    /// Multiply or screen, chosen by the backdrop.
+    Overlay,
+    /// The darker of source and backdrop, per component.
+    Darken,
+    /// The lighter of source and backdrop, per component.
+    Lighten,
+    /// Brightens the backdrop toward the source.
+    ColorDodge,
+    /// Darkens the backdrop toward the source.
+    ColorBurn,
+    /// Multiply or screen, chosen by the source (Overlay with roles swapped).
+    HardLight,
+    /// A softer variant of `HardLight`.
+    SoftLight,
+    /// Absolute difference of source and backdrop.
+    Difference,
+    /// Like `Difference`, with lower contrast.
+    Exclusion,
+}
+
+impl BlendMode {
+    /// The `/BM` name for this mode.
+    fn pdf_name(self) -> &'static str {
+        match self {
+            BlendMode::Normal => "Normal",
+            BlendMode::Multiply => "Multiply",
+            BlendMode::Screen => "Screen",
+            BlendMode::Overlay => "Overlay",
+            BlendMode::Darken => "Darken",
+            BlendMode::Lighten => "Lighten",
+            BlendMode::ColorDodge => "ColorDodge",
+            BlendMode::ColorBurn => "ColorBurn",
+            BlendMode::HardLight => "HardLight",
+            BlendMode::SoftLight => "SoftLight",
+            BlendMode::Difference => "Difference",
+            BlendMode::Exclusion => "Exclusion",
+        }
+    }
+}
+
+/// One deduped `/ExtGState` entry. Each [`Canvas`] setter writes only its
+/// own key, so at most one field is ever set — a `gs` referencing `/ca`
+/// alone must leave `/CA` and `/BM` untouched (ISO 32000 §8.4.5).
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub(crate) struct GState {
+    pub(crate) fill_alpha: Option<f32>,
+    pub(crate) stroke_alpha: Option<f32>,
+    pub(crate) blend_mode: Option<BlendMode>,
+}
+
+impl GState {
+    /// The `/ExtGState` dictionary for this entry.
+    pub(crate) fn ext_gstate_dict(self) -> Dict {
+        let mut dict = Dict::new();
+        if let Some(alpha) = self.fill_alpha {
+            dict.insert(name("ca"), Object::Real(f64::from(alpha)));
+        }
+        if let Some(alpha) = self.stroke_alpha {
+            dict.insert(name("CA"), Object::Real(f64::from(alpha)));
+        }
+        if let Some(mode) = self.blend_mode {
+            dict.insert(name("BM"), Object::Name(name(mode.pdf_name())));
+        }
+        dict
+    }
+}
+
+/// A `Name` from a string literal.
+fn name(text: &str) -> Name {
+    Name(text.to_string())
+}
+
 /// The accumulated output of a finished canvas.
 #[derive(Debug)]
 pub struct CanvasParts {
@@ -56,6 +146,12 @@ pub struct CanvasParts {
     pub fonts: Vec<Standard14>,
     /// Images in registration order; index `i` is resource `Im{i+1}`.
     pub images: Vec<ImageData>,
+    /// Sub-canvases registered with [`Canvas::group`], paired with their
+    /// `/BBox`; index `i` is resource `Gp{i+1}`.
+    pub(crate) groups: Vec<(CanvasParts, [f32; 4])>,
+    /// Distinct `/ExtGState` entries in first-use order; index `i` is
+    /// resource `Gs{i+1}`.
+    pub(crate) gstates: Vec<GState>,
 }
 
 /// An imperative painter producing content-stream operators.
@@ -64,6 +160,8 @@ pub struct Canvas {
     ops: Vec<Op>,
     fonts: Vec<Standard14>,
     images: Vec<ImageData>,
+    groups: Vec<(CanvasParts, [f32; 4])>,
+    gstates: Vec<GState>,
 }
 
 impl Canvas {
@@ -275,6 +373,63 @@ impl Canvas {
         self.ops.push(Op::Restore);
     }
 
+    /// Registers a finished sub-canvas as a form group, with `bbox`
+    /// (`[llx, lly, urx, ury]`) becoming the form's `/BBox`. Paint it with
+    /// [`draw_group`](Canvas::draw_group).
+    pub fn group(&mut self, canvas: Canvas, bbox: [f32; 4]) -> GroupHandle {
+        let handle = GroupHandle(self.groups.len());
+        self.groups.push((canvas.into_parts(), bbox));
+        handle
+    }
+
+    /// Paints a registered group under `matrix` (`q cm /GpN Do Q`). Two
+    /// calls with the same `group` reference the same form resource.
+    pub fn draw_group(&mut self, group: GroupHandle, matrix: Matrix) {
+        self.ops.push(Op::Save);
+        self.ops.push(Op::Concat(matrix));
+        self.ops
+            .push(Op::XObject(Name(format!("Gp{}", group.0 + 1))));
+        self.ops.push(Op::Restore);
+    }
+
+    /// Sets the nonstroking alpha constant (`gs` referencing `/ca`).
+    pub fn set_fill_alpha(&mut self, alpha: f32) {
+        self.push_gstate(GState {
+            fill_alpha: Some(alpha),
+            ..GState::default()
+        });
+    }
+
+    /// Sets the stroking alpha constant (`gs` referencing `/CA`).
+    pub fn set_stroke_alpha(&mut self, alpha: f32) {
+        self.push_gstate(GState {
+            stroke_alpha: Some(alpha),
+            ..GState::default()
+        });
+    }
+
+    /// Sets the blend mode (`gs` referencing `/BM`).
+    pub fn set_blend_mode(&mut self, mode: BlendMode) {
+        self.push_gstate(GState {
+            blend_mode: Some(mode),
+            ..GState::default()
+        });
+    }
+
+    /// Emits a `gs` referencing `state`'s resource, reusing an identical
+    /// prior entry instead of adding a duplicate.
+    fn push_gstate(&mut self, state: GState) {
+        let index = match self.gstates.iter().position(|seen| *seen == state) {
+            Some(index) => index,
+            None => {
+                self.gstates.push(state);
+                self.gstates.len() - 1
+            }
+        };
+        self.ops
+            .push(Op::SetExtGState(Name(format!("Gs{}", index + 1))));
+    }
+
     /// Pushes a raw operator — the escape hatch for anything the methods
     /// above don't cover. Resource-referencing operators are the caller's
     /// responsibility to keep consistent with the naming contract.
@@ -293,15 +448,19 @@ impl Canvas {
             ops: self.ops,
             fonts: self.fonts,
             images: self.images,
+            groups: self.groups,
+            gstates: self.gstates,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use pdfboss_core::content::parse_content;
     use pdfboss_core::Name;
 
     use super::*;
+    use crate::content::serialize_ops;
     use crate::error::Error;
 
     fn name(text: &str) -> Name {
@@ -629,5 +788,160 @@ mod tests {
             ]
         );
         assert_eq!(canvas.into_parts().images.len(), 2);
+    }
+
+    #[test]
+    fn group_registers_subcanvas_parts_and_bbox() {
+        let mut sub = Canvas::new();
+        sub.rect(1.0, 2.0, 3.0, 4.0);
+        sub.fill();
+        let mut canvas = Canvas::new();
+        let handle = canvas.group(sub, [0.0, 0.0, 50.0, 20.0]);
+        assert_eq!(handle, GroupHandle(0));
+        let parts = canvas.into_parts();
+        assert_eq!(parts.groups.len(), 1);
+        let (group_parts, bbox) = &parts.groups[0];
+        assert_eq!(*bbox, [0.0, 0.0, 50.0, 20.0]);
+        assert_eq!(group_parts.ops, [Op::Rect(1.0, 2.0, 3.0, 4.0), Op::Fill]);
+    }
+
+    #[test]
+    fn second_group_gets_index_one() {
+        let mut canvas = Canvas::new();
+        let first = canvas.group(Canvas::new(), [0.0, 0.0, 1.0, 1.0]);
+        let second = canvas.group(Canvas::new(), [0.0, 0.0, 1.0, 1.0]);
+        assert_eq!(first, GroupHandle(0));
+        assert_eq!(second, GroupHandle(1));
+    }
+
+    #[test]
+    fn draw_group_emits_save_cm_xobject_restore_and_round_trips() {
+        let mut canvas = Canvas::new();
+        let handle = canvas.group(Canvas::new(), [0.0, 0.0, 10.0, 10.0]);
+        let matrix = Matrix {
+            a: 1.0,
+            b: 0.0,
+            c: 0.0,
+            d: 1.0,
+            e: 72.0,
+            f: 144.0,
+        };
+        canvas.draw_group(handle, matrix);
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::Save,
+                Op::Concat(matrix),
+                Op::XObject(name("Gp1")),
+                Op::Restore,
+            ]
+        );
+        let bytes = serialize_ops(canvas.ops());
+        let parsed = parse_content(&bytes).unwrap();
+        assert_eq!(parsed, canvas.ops());
+    }
+
+    #[test]
+    fn two_draws_of_one_group_reference_the_same_resource_name() {
+        let mut canvas = Canvas::new();
+        let handle = canvas.group(Canvas::new(), [0.0, 0.0, 10.0, 10.0]);
+        canvas.draw_group(handle, Matrix::identity());
+        canvas.draw_group(handle, Matrix::translate(5.0, 5.0));
+        let names: Vec<&Op> = canvas
+            .ops()
+            .iter()
+            .filter(|op| matches!(op, Op::XObject(_)))
+            .collect();
+        assert_eq!(
+            names,
+            [&Op::XObject(name("Gp1")), &Op::XObject(name("Gp1"))]
+        );
+    }
+
+    #[test]
+    fn second_registered_group_gets_gp2() {
+        let mut canvas = Canvas::new();
+        let first = canvas.group(Canvas::new(), [0.0, 0.0, 1.0, 1.0]);
+        let second = canvas.group(Canvas::new(), [0.0, 0.0, 1.0, 1.0]);
+        canvas.draw_group(first, Matrix::identity());
+        canvas.draw_group(second, Matrix::identity());
+        let names: Vec<&Op> = canvas
+            .ops()
+            .iter()
+            .filter(|op| matches!(op, Op::XObject(_)))
+            .collect();
+        assert_eq!(
+            names,
+            [&Op::XObject(name("Gp1")), &Op::XObject(name("Gp2"))]
+        );
+    }
+
+    #[test]
+    fn nested_groups_recurse() {
+        let mut innermost = Canvas::new();
+        innermost.fill();
+        let mut outer = Canvas::new();
+        let inner_handle = outer.group(innermost, [0.0, 0.0, 1.0, 1.0]);
+        outer.draw_group(inner_handle, Matrix::identity());
+        let mut canvas = Canvas::new();
+        let outer_handle = canvas.group(outer, [0.0, 0.0, 2.0, 2.0]);
+        canvas.draw_group(outer_handle, Matrix::identity());
+        let parts = canvas.into_parts();
+        let (outer_parts, _) = &parts.groups[0];
+        assert_eq!(outer_parts.groups.len(), 1);
+        let (inner_parts, _) = &outer_parts.groups[0];
+        assert_eq!(inner_parts.ops, [Op::Fill]);
+    }
+
+    #[test]
+    fn set_fill_alpha_pushes_gs_referencing_gs1() {
+        let mut canvas = Canvas::new();
+        canvas.set_fill_alpha(0.5);
+        assert_eq!(canvas.ops(), [Op::SetExtGState(name("Gs1"))]);
+        let parts = canvas.into_parts();
+        assert_eq!(parts.gstates.len(), 1);
+        assert_eq!(parts.gstates[0].fill_alpha, Some(0.5));
+        assert_eq!(parts.gstates[0].stroke_alpha, None);
+        assert_eq!(parts.gstates[0].blend_mode, None);
+    }
+
+    #[test]
+    fn set_stroke_alpha_and_blend_mode_get_distinct_resources() {
+        let mut canvas = Canvas::new();
+        canvas.set_fill_alpha(0.5);
+        canvas.set_stroke_alpha(0.5);
+        canvas.set_blend_mode(BlendMode::Multiply);
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::SetExtGState(name("Gs1")),
+                Op::SetExtGState(name("Gs2")),
+                Op::SetExtGState(name("Gs3")),
+            ]
+        );
+        assert_eq!(canvas.into_parts().gstates.len(), 3);
+    }
+
+    #[test]
+    fn identical_setter_calls_dedupe_to_one_resource() {
+        let mut canvas = Canvas::new();
+        canvas.set_fill_alpha(0.5);
+        canvas.set_fill_alpha(0.5);
+        assert_eq!(
+            canvas.ops(),
+            [Op::SetExtGState(name("Gs1")), Op::SetExtGState(name("Gs1"))]
+        );
+        assert_eq!(canvas.into_parts().gstates.len(), 1);
+    }
+
+    #[test]
+    fn gstate_setters_round_trip() {
+        let mut canvas = Canvas::new();
+        canvas.set_fill_alpha(0.25);
+        canvas.set_stroke_alpha(0.75);
+        canvas.set_blend_mode(BlendMode::Screen);
+        let bytes = serialize_ops(canvas.ops());
+        let parsed = parse_content(&bytes).unwrap();
+        assert_eq!(parsed, canvas.ops());
     }
 }

--- a/crates/pdfboss-write/src/element.rs
+++ b/crates/pdfboss-write/src/element.rs
@@ -4,11 +4,12 @@
 //! operators the caller already painted there directly — elements paint
 //! over manual canvas work, never under it.
 
+use pdfboss_core::content::Op;
 use pdfboss_core::Point;
 
 use crate::canvas::Canvas;
 use crate::color::Color;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::font::Standard14;
 use crate::image::ImageData;
 use crate::pdf::{LinkAnnotation, LinkTarget};
@@ -109,6 +110,148 @@ pub struct Link {
     pub target: LinkTarget,
 }
 
+/// Horizontal alignment for a [`Paragraph`].
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum ParagraphAlign {
+    /// Flush to the rect's left edge.
+    #[default]
+    Left,
+    /// Centered within the rect width.
+    Center,
+    /// Flush to the rect's right edge.
+    Right,
+    /// Flush to both edges: word spacing stretches every line but the
+    /// last.
+    Justify,
+}
+
+/// A block of text wrapped, aligned, and (for [`ParagraphAlign::Justify`])
+/// stretched to fill a rectangle.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Paragraph {
+    /// The text to lay out. `\n` forces a line break; other whitespace runs
+    /// between words collapse to a single space.
+    pub text: String,
+    /// The box to wrap into, `[x0, y0, x1, y1]` in page user-space units.
+    pub rect: [f32; 4],
+    /// Face to draw in.
+    pub font: Standard14,
+    /// Font size, in points.
+    pub size: f32,
+    /// Line-to-line advance, in points. `None` defaults to `1.2 * size`.
+    pub leading: Option<f32>,
+    /// Horizontal alignment within the rect.
+    pub align: ParagraphAlign,
+}
+
+impl Default for Paragraph {
+    fn default() -> Paragraph {
+        Paragraph {
+            text: String::new(),
+            rect: [0.0, 0.0, 0.0, 0.0],
+            font: Standard14::Helvetica,
+            size: 11.0,
+            leading: None,
+            align: ParagraphAlign::Left,
+        }
+    }
+}
+
+/// Greedily wraps `text` to `max_width`: `\n` forces a break, other
+/// whitespace runs between words collapse to single spaces, and a blank
+/// source line yields an empty line so its vertical advance survives. A
+/// word wider than `max_width` on its own still gets a line — no
+/// hyphenation.
+fn wrap_lines(text: &str, font: Standard14, size: f32, max_width: f32) -> Result<Vec<Vec<&str>>> {
+    let mut lines = Vec::new();
+    for source_line in text.split('\n') {
+        let words: Vec<&str> = source_line.split_whitespace().collect();
+        if words.is_empty() {
+            lines.push(Vec::new());
+            continue;
+        }
+        let mut current: Vec<&str> = Vec::new();
+        let mut current_text = String::new();
+        for word in words {
+            let candidate = if current.is_empty() {
+                word.to_string()
+            } else {
+                format!("{current_text} {word}")
+            };
+            let width = font.text_width(&candidate, size)?;
+            if current.is_empty() || width <= max_width {
+                current.push(word);
+                current_text = candidate;
+                continue;
+            }
+            lines.push(std::mem::take(&mut current));
+            current_text = word.to_string();
+            current.push(word);
+        }
+        lines.push(current);
+    }
+    Ok(lines)
+}
+
+/// The number of lines whose baseline fits between `y0` and the first
+/// baseline at `y1 - size`, stepping down by `leading` per further line. A
+/// small epsilon absorbs floating-point rounding at exact boundaries.
+fn lines_that_fit(y0: f32, y1: f32, size: f32, leading: f32) -> usize {
+    const EPSILON: f32 = 1e-3;
+    let first_baseline = y1 - size;
+    if first_baseline < y0 - EPSILON {
+        return 0;
+    }
+    (((first_baseline - y0) / leading) + EPSILON).floor() as usize + 1
+}
+
+impl Draw for Paragraph {
+    fn draw(&self, canvas: &mut Canvas) -> Result<()> {
+        let [x0, y0, x1, y1] = self.rect;
+        let width = x1 - x0;
+        let leading = self.leading.unwrap_or(1.2 * self.size);
+        let lines = wrap_lines(&self.text, self.font, self.size, width)?;
+        let fits = lines_that_fit(y0, y1, self.size, leading);
+        if lines.len() > fits {
+            return Err(Error::Other(format!(
+                "paragraph overflows its rect: {fits} lines fit, {} needed",
+                lines.len()
+            )));
+        }
+        let last = lines.len().saturating_sub(1);
+        let mut stretched = false;
+        for (index, words) in lines.iter().enumerate() {
+            if words.is_empty() {
+                continue;
+            }
+            let baseline = y1 - self.size - index as f32 * leading;
+            let line_text = words.join(" ");
+            let line_width = self.font.text_width(&line_text, self.size)?;
+            let is_final = index == last;
+            let stretch = match self.align {
+                ParagraphAlign::Justify if !is_final && words.len() >= 2 => {
+                    Some((width - line_width) / (words.len() as f32 - 1.0))
+                }
+                _ => None,
+            };
+            let x = match self.align {
+                ParagraphAlign::Right => x1 - line_width,
+                ParagraphAlign::Center => x0 + (width - line_width) / 2.0,
+                ParagraphAlign::Left | ParagraphAlign::Justify => x0,
+            };
+            if let Some(spacing) = stretch {
+                canvas.op(Op::SetWordSpacing(spacing));
+                stretched = true;
+            }
+            canvas.text(&line_text, x, baseline, self.font, self.size)?;
+        }
+        if stretched {
+            canvas.op(Op::SetWordSpacing(0.0));
+        }
+        Ok(())
+    }
+}
+
 /// One piece of composed page content.
 pub enum Content {
     /// A line of text.
@@ -117,6 +260,8 @@ pub enum Content {
     Image(Image),
     /// A clickable link area.
     Link(Link),
+    /// A wrapped, aligned block of text.
+    Paragraph(Paragraph),
     /// Anything implementing [`Draw`].
     Custom(Box<dyn Draw>),
 }
@@ -127,6 +272,7 @@ impl std::fmt::Debug for Content {
             Content::Text(text) => f.debug_tuple("Text").field(text).finish(),
             Content::Image(image) => f.debug_tuple("Image").field(image).finish(),
             Content::Link(link) => f.debug_tuple("Link").field(link).finish(),
+            Content::Paragraph(paragraph) => f.debug_tuple("Paragraph").field(paragraph).finish(),
             Content::Custom(..) => f.write_str("Custom(..)"),
         }
     }
@@ -147,6 +293,12 @@ impl From<Image> for Content {
 impl From<Link> for Content {
     fn from(value: Link) -> Content {
         Content::Link(value)
+    }
+}
+
+impl From<Paragraph> for Content {
+    fn from(value: Paragraph) -> Content {
+        Content::Paragraph(value)
     }
 }
 
@@ -172,6 +324,7 @@ pub(crate) fn lower(
                 rect: link.rect,
                 target: link.target,
             }),
+            Content::Paragraph(paragraph) => paragraph.draw(canvas)?,
             Content::Custom(drawable) => drawable.draw(canvas)?,
         }
     }
@@ -328,6 +481,231 @@ mod tests {
                 Op::EndText,
             ]
         );
+    }
+
+    #[test]
+    fn paragraph_default_is_helvetica_11_left_and_none_leading() {
+        let paragraph = Paragraph::default();
+        assert_eq!(paragraph.text, "");
+        assert_eq!(paragraph.font, Standard14::Helvetica);
+        assert_eq!(paragraph.size, 11.0);
+        assert_eq!(paragraph.leading, None);
+        assert_eq!(paragraph.align, ParagraphAlign::Left);
+    }
+
+    #[test]
+    fn content_from_paragraph_debug_prints_paragraph() {
+        let content = Content::from(Paragraph::default());
+        assert_eq!(
+            format!("{content:?}"),
+            format!("Paragraph({:?})", Paragraph::default())
+        );
+    }
+
+    #[test]
+    fn paragraph_wraps_at_word_boundaries_courier_metrics() {
+        let mut canvas = Canvas::new();
+        let mut links = Vec::new();
+        let paragraph = Paragraph {
+            text: "aaaaaaaaa bbbbbbbbbb cccccccccc".into(),
+            rect: [0.0, 0.0, 120.0, 100.0],
+            font: Standard14::Courier,
+            size: 10.0,
+            ..Paragraph::default()
+        };
+        lower(vec![paragraph.into()], &mut canvas, &mut links).unwrap();
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::BeginText,
+                Op::SetFont(Name("F1".into()), 10.0),
+                Op::TextMove(0.0, 90.0),
+                Op::ShowText(b"aaaaaaaaa bbbbbbbbbb".to_vec()),
+                Op::EndText,
+                Op::BeginText,
+                Op::SetFont(Name("F1".into()), 10.0),
+                Op::TextMove(0.0, 78.0),
+                Op::ShowText(b"cccccccccc".to_vec()),
+                Op::EndText,
+            ]
+        );
+    }
+
+    #[test]
+    fn paragraph_overflow_reports_lines_fit_and_needed() {
+        let mut canvas = Canvas::new();
+        let mut links = Vec::new();
+        let paragraph = Paragraph {
+            text: "aaaaaaaaa bbbbbbbbbb cccccccccc".into(),
+            rect: [0.0, 80.0, 120.0, 95.0],
+            font: Standard14::Courier,
+            size: 10.0,
+            ..Paragraph::default()
+        };
+        let err = lower(vec![paragraph.into()], &mut canvas, &mut links).unwrap_err();
+        match err {
+            Error::Other(msg) => {
+                assert_eq!(msg, "paragraph overflows its rect: 1 lines fit, 2 needed")
+            }
+            other => panic!("expected Error::Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn paragraph_justify_stretches_non_final_lines_and_resets_once() {
+        let mut canvas = Canvas::new();
+        let mut links = Vec::new();
+        let paragraph = Paragraph {
+            text: "aaaaaaa bbbbbbb ddddd".into(),
+            rect: [0.0, 0.0, 120.0, 100.0],
+            font: Standard14::Courier,
+            size: 10.0,
+            align: ParagraphAlign::Justify,
+            ..Paragraph::default()
+        };
+        lower(vec![paragraph.into()], &mut canvas, &mut links).unwrap();
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::SetWordSpacing(30.0),
+                Op::BeginText,
+                Op::SetFont(Name("F1".into()), 10.0),
+                Op::TextMove(0.0, 90.0),
+                Op::ShowText(b"aaaaaaa bbbbbbb".to_vec()),
+                Op::EndText,
+                Op::BeginText,
+                Op::SetFont(Name("F1".into()), 10.0),
+                Op::TextMove(0.0, 78.0),
+                Op::ShowText(b"ddddd".to_vec()),
+                Op::EndText,
+                Op::SetWordSpacing(0.0),
+            ]
+        );
+
+        let bytes = crate::content::serialize_ops(canvas.ops());
+        let parsed = parse_content(&bytes).unwrap();
+        let stretched: Vec<f32> = parsed
+            .iter()
+            .filter_map(|op| match op {
+                Op::SetWordSpacing(value) if *value > 0.0 => Some(*value),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(stretched, [30.0]);
+        assert!(parsed.contains(&Op::SetWordSpacing(0.0)));
+    }
+
+    #[test]
+    fn paragraph_center_and_right_align_offset_by_rect_width() {
+        let mut links = Vec::new();
+        let base = Paragraph {
+            text: "aaaaaaaaa".into(),
+            rect: [0.0, 0.0, 120.0, 50.0],
+            font: Standard14::Courier,
+            size: 10.0,
+            ..Paragraph::default()
+        };
+
+        let mut center_canvas = Canvas::new();
+        lower(
+            vec![Paragraph {
+                align: ParagraphAlign::Center,
+                ..base.clone()
+            }
+            .into()],
+            &mut center_canvas,
+            &mut links,
+        )
+        .unwrap();
+        assert_eq!(center_canvas.ops()[2], Op::TextMove(33.0, 40.0));
+
+        let mut right_canvas = Canvas::new();
+        lower(
+            vec![Paragraph {
+                align: ParagraphAlign::Right,
+                ..base
+            }
+            .into()],
+            &mut right_canvas,
+            &mut links,
+        )
+        .unwrap();
+        assert_eq!(right_canvas.ops()[2], Op::TextMove(66.0, 40.0));
+    }
+
+    #[test]
+    fn paragraph_blank_line_keeps_advance_without_drawing() {
+        let mut canvas = Canvas::new();
+        let mut links = Vec::new();
+        let paragraph = Paragraph {
+            text: "a\n\nb".into(),
+            rect: [0.0, 0.0, 100.0, 100.0],
+            font: Standard14::Helvetica,
+            size: 10.0,
+            ..Paragraph::default()
+        };
+        lower(vec![paragraph.into()], &mut canvas, &mut links).unwrap();
+        let moves: Vec<&Op> = canvas
+            .ops()
+            .iter()
+            .filter(|op| matches!(op, Op::TextMove(..)))
+            .collect();
+        assert_eq!(
+            moves,
+            [&Op::TextMove(0.0, 90.0), &Op::TextMove(0.0, 66.0)],
+            "blank line should still consume a leading slot"
+        );
+        let shows: Vec<&Op> = canvas
+            .ops()
+            .iter()
+            .filter(|op| matches!(op, Op::ShowText(..)))
+            .collect();
+        assert_eq!(
+            shows,
+            [&Op::ShowText(b"a".to_vec()), &Op::ShowText(b"b".to_vec()),]
+        );
+    }
+
+    #[test]
+    fn paragraph_leading_override_changes_line_advance() {
+        let mut canvas = Canvas::new();
+        let mut links = Vec::new();
+        let paragraph = Paragraph {
+            text: "aaaaaaaaaa bbbbbbbbbb".into(),
+            rect: [0.0, 0.0, 60.0, 100.0],
+            font: Standard14::Courier,
+            size: 10.0,
+            leading: Some(20.0),
+            ..Paragraph::default()
+        };
+        lower(vec![paragraph.into()], &mut canvas, &mut links).unwrap();
+        let moves: Vec<&Op> = canvas
+            .ops()
+            .iter()
+            .filter(|op| matches!(op, Op::TextMove(..)))
+            .collect();
+        assert_eq!(moves, [&Op::TextMove(0.0, 90.0), &Op::TextMove(0.0, 70.0)]);
+    }
+
+    #[test]
+    fn paragraph_propagates_unencodable_character_error_untouched() {
+        let mut canvas = Canvas::new();
+        let mut links = Vec::new();
+        let paragraph = Paragraph {
+            text: "\u{2318}".into(),
+            rect: [0.0, 0.0, 100.0, 100.0],
+            font: Standard14::Helvetica,
+            size: 10.0,
+            ..Paragraph::default()
+        };
+        let err = lower(vec![paragraph.into()], &mut canvas, &mut links).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Unencodable {
+                ch: '\u{2318}',
+                font: "Helvetica"
+            }
+        ));
     }
 
     #[test]

--- a/crates/pdfboss-write/src/element.rs
+++ b/crates/pdfboss-write/src/element.rs
@@ -1,0 +1,362 @@
+//! The compose element vocabulary: painted content one step above raw
+//! canvas operators. A [`Content`] value sits in [`crate::pdf::Page::content`]
+//! and lowers onto the page's [`Canvas`] at assemble time, after any
+//! operators the caller already painted there directly — elements paint
+//! over manual canvas work, never under it.
+
+use pdfboss_core::Point;
+
+use crate::canvas::Canvas;
+use crate::color::Color;
+use crate::error::Result;
+use crate::font::Standard14;
+use crate::image::ImageData;
+use crate::pdf::{LinkAnnotation, LinkTarget};
+
+/// Something that paints itself onto a [`Canvas`]. `Send` so a
+/// [`Content::Custom`] value never blocks a `Pdf` from crossing a thread
+/// boundary.
+pub trait Draw: Send {
+    /// Paints this value's content onto `canvas`.
+    fn draw(&self, canvas: &mut Canvas) -> Result<()>;
+}
+
+/// One line of text at a fixed baseline origin.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Text {
+    /// The characters to show.
+    pub value: String,
+    /// Baseline origin, in page user-space units.
+    pub at: Point,
+    /// Face to draw in.
+    pub font: Standard14,
+    /// Font size, in points.
+    pub size: f32,
+    /// Fill color.
+    pub color: Color,
+}
+
+impl Default for Text {
+    fn default() -> Text {
+        Text {
+            value: String::new(),
+            at: Point::default(),
+            font: Standard14::Helvetica,
+            size: 12.0,
+            color: Color::BLACK,
+        }
+    }
+}
+
+impl Draw for Text {
+    fn draw(&self, canvas: &mut Canvas) -> Result<()> {
+        canvas.set_fill(self.color);
+        canvas.text(&self.value, self.at.x, self.at.y, self.font, self.size)
+    }
+}
+
+/// A raster image placed at a point.
+///
+/// No `Default`: there is no meaningful default for `data`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Image {
+    /// The pixels to embed.
+    pub data: ImageData,
+    /// Placement origin (the box's bottom-left corner), in page user-space
+    /// units.
+    pub at: Point,
+    /// Explicit width, in points. `None` derives it from `height` (by
+    /// aspect) or, with `height` also `None`, from the image's pixel width
+    /// at 72 dpi.
+    pub width: Option<f32>,
+    /// Explicit height, in points. `None` derives it from `width` (by
+    /// aspect) or, with `width` also `None`, from the image's pixel height
+    /// at 72 dpi.
+    pub height: Option<f32>,
+}
+
+impl Image {
+    /// The box this image paints into: the natural size at 72 dpi when
+    /// neither dimension is given, the other dimension scaled by aspect
+    /// when one is given, or the exact box when both are given.
+    pub fn placed_size(&self) -> (f32, f32) {
+        let natural_width = self.data.width() as f32;
+        let natural_height = self.data.height() as f32;
+        match (self.width, self.height) {
+            (Some(width), Some(height)) => (width, height),
+            (Some(width), None) => (width, width * natural_height / natural_width),
+            (None, Some(height)) => (height * natural_width / natural_height, height),
+            (None, None) => (natural_width, natural_height),
+        }
+    }
+}
+
+impl Draw for Image {
+    fn draw(&self, canvas: &mut Canvas) -> Result<()> {
+        let (width, height) = self.placed_size();
+        let handle = canvas.add_image(self.data.clone());
+        canvas.draw_image(handle, self.at.x, self.at.y, width, height);
+        Ok(())
+    }
+}
+
+/// A clickable rectangle, lowered into a [`LinkAnnotation`] on the page.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Link {
+    /// The clickable area, `[x0, y0, x1, y1]` in the page's user space.
+    pub rect: [f32; 4],
+    /// Where the link goes.
+    pub target: LinkTarget,
+}
+
+/// One piece of composed page content.
+pub enum Content {
+    /// A line of text.
+    Text(Text),
+    /// A placed image.
+    Image(Image),
+    /// A clickable link area.
+    Link(Link),
+    /// Anything implementing [`Draw`].
+    Custom(Box<dyn Draw>),
+}
+
+impl std::fmt::Debug for Content {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Content::Text(text) => f.debug_tuple("Text").field(text).finish(),
+            Content::Image(image) => f.debug_tuple("Image").field(image).finish(),
+            Content::Link(link) => f.debug_tuple("Link").field(link).finish(),
+            Content::Custom(..) => f.write_str("Custom(..)"),
+        }
+    }
+}
+
+impl From<Text> for Content {
+    fn from(value: Text) -> Content {
+        Content::Text(value)
+    }
+}
+
+impl From<Image> for Content {
+    fn from(value: Image) -> Content {
+        Content::Image(value)
+    }
+}
+
+impl From<Link> for Content {
+    fn from(value: Link) -> Content {
+        Content::Link(value)
+    }
+}
+
+impl Content {
+    /// Wraps any [`Draw`] value as custom content.
+    pub fn custom(value: impl Draw + 'static) -> Content {
+        Content::Custom(Box::new(value))
+    }
+}
+
+/// Paints `content` onto `canvas`, in order, after any operators already
+/// there; link elements are appended to `links` instead of painted.
+pub(crate) fn lower(
+    content: Vec<Content>,
+    canvas: &mut Canvas,
+    links: &mut Vec<LinkAnnotation>,
+) -> Result<()> {
+    for item in content {
+        match item {
+            Content::Text(text) => text.draw(canvas)?,
+            Content::Image(image) => image.draw(canvas)?,
+            Content::Link(link) => links.push(LinkAnnotation {
+                rect: link.rect,
+                target: link.target,
+            }),
+            Content::Custom(drawable) => drawable.draw(canvas)?,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use pdfboss_core::content::{parse_content, Op};
+    use pdfboss_core::{Document, Name};
+    use pdfboss_output::extract_text;
+
+    use super::*;
+    use crate::pdf::{Page, PageSize};
+    use crate::Pdf;
+
+    #[test]
+    fn elements_lower_in_sequence_order_after_canvas_ops() {
+        let mut page = Page::new(PageSize::A4);
+        page.canvas
+            .text("under", 72.0, 100.0, Standard14::Helvetica, 10.0)
+            .unwrap();
+        page.content.push(Content::from(Text {
+            value: "over".into(),
+            at: Point::new(72.0, 700.0),
+            size: 24.0,
+            ..Text::default()
+        }));
+        let ops_before = page.canvas.ops().len();
+        let bytes = Pdf {
+            pages: vec![page],
+            ..Pdf::default()
+        }
+        .to_bytes()
+        .unwrap();
+        let doc = Document::load(bytes).unwrap();
+        let loaded = doc.page(0).unwrap();
+        let text = extract_text(&doc, &loaded).unwrap();
+        assert!(text.contains("under") && text.contains("over"));
+        assert!(ops_before > 0);
+
+        let stream = loaded.content(&doc).unwrap();
+        let ops = parse_content(&stream).unwrap();
+        let index_of = |needle: &[u8]| {
+            ops.iter()
+                .position(|op| matches!(op, Op::ShowText(s) if s == needle))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "no ShowText carrying {:?} in {:?}",
+                        String::from_utf8_lossy(needle),
+                        ops
+                    )
+                })
+        };
+        let under_index = index_of(b"under");
+        let over_index = index_of(b"over");
+        assert!(
+            under_index < over_index,
+            "expected \"under\" ({under_index}) before \"over\" ({over_index})"
+        );
+    }
+
+    #[test]
+    fn custom_draw_paints_through_the_canvas() {
+        struct Letterhead;
+        impl Draw for Letterhead {
+            fn draw(&self, canvas: &mut Canvas) -> Result<()> {
+                canvas.set_line_width(0.5);
+                canvas.move_to(72.0, 806.0);
+                canvas.line_to(523.0, 806.0);
+                canvas.stroke();
+                canvas.text("ACME GmbH", 72.0, 812.0, Standard14::Helvetica, 8.0)
+            }
+        }
+        let custom = Content::custom(Letterhead);
+        assert_eq!(format!("{custom:?}"), "Custom(..)");
+        let mut page = Page::new(PageSize::A4);
+        page.content.push(custom);
+        let bytes = Pdf {
+            pages: vec![page],
+            ..Pdf::default()
+        }
+        .to_bytes()
+        .unwrap();
+        let doc = Document::load(bytes).unwrap();
+        let loaded = doc.page(0).unwrap();
+        let text = extract_text(&doc, &loaded).unwrap();
+        assert!(text.contains("ACME GmbH"));
+    }
+
+    #[test]
+    fn image_placed_size_is_natural_at_72dpi_when_both_none() {
+        let image = Image {
+            data: ImageData::gray8(16, 8, vec![0u8; 128]).unwrap(),
+            at: Point::new(10.0, 10.0),
+            width: None,
+            height: None,
+        };
+        assert_eq!(image.placed_size(), (16.0, 8.0));
+    }
+
+    #[test]
+    fn image_element_scales_by_aspect_when_one_dimension_is_given() {
+        let image = Image {
+            data: ImageData::gray8(16, 8, vec![0u8; 128]).unwrap(),
+            at: Point::new(10.0, 10.0),
+            width: Some(32.0),
+            height: None,
+        };
+        assert_eq!(image.placed_size(), (32.0, 16.0));
+    }
+
+    #[test]
+    fn image_placed_size_scales_by_aspect_when_only_height_is_given() {
+        let image = Image {
+            data: ImageData::gray8(16, 8, vec![0u8; 128]).unwrap(),
+            at: Point::new(10.0, 10.0),
+            width: None,
+            height: Some(4.0),
+        };
+        assert_eq!(image.placed_size(), (8.0, 4.0));
+    }
+
+    #[test]
+    fn image_placed_size_is_exact_when_both_dimensions_are_given() {
+        let image = Image {
+            data: ImageData::gray8(16, 8, vec![0u8; 128]).unwrap(),
+            at: Point::new(10.0, 10.0),
+            width: Some(50.0),
+            height: Some(90.0),
+        };
+        assert_eq!(image.placed_size(), (50.0, 90.0));
+    }
+
+    #[test]
+    fn text_draw_sets_fill_then_shows_text() {
+        let mut canvas = Canvas::new();
+        let text = Text {
+            value: "hi".into(),
+            at: Point::new(1.0, 2.0),
+            font: Standard14::Helvetica,
+            size: 10.0,
+            color: Color::Rgb(1.0, 0.0, 0.0),
+        };
+        text.draw(&mut canvas).unwrap();
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::SetFillRGB(1.0, 0.0, 0.0),
+                Op::BeginText,
+                Op::SetFont(Name("F1".into()), 10.0),
+                Op::TextMove(1.0, 2.0),
+                Op::ShowText(b"hi".to_vec()),
+                Op::EndText,
+            ]
+        );
+    }
+
+    #[test]
+    fn image_draw_uses_placed_size() {
+        use pdfboss_core::Matrix;
+
+        let mut canvas = Canvas::new();
+        let image = Image {
+            data: ImageData::gray8(2, 2, vec![0u8; 4]).unwrap(),
+            at: Point::new(5.0, 6.0),
+            width: Some(40.0),
+            height: None,
+        };
+        image.draw(&mut canvas).unwrap();
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::Save,
+                Op::Concat(Matrix {
+                    a: 40.0,
+                    b: 0.0,
+                    c: 0.0,
+                    d: 40.0,
+                    e: 5.0,
+                    f: 6.0,
+                }),
+                Op::XObject(Name("Im1".into())),
+                Op::Restore,
+            ]
+        );
+    }
+}

--- a/crates/pdfboss-write/src/element.rs
+++ b/crates/pdfboss-write/src/element.rs
@@ -205,6 +205,10 @@ fn lines_that_fit(y0: f32, y1: f32, size: f32, leading: f32) -> usize {
     (((first_baseline - y0) / leading) + EPSILON).floor() as usize + 1
 }
 
+/// `Tw` (word spacing) is persistent text state that `BeginText` does not
+/// clear, so a stretch an earlier line left active must be reset before the
+/// first following line that does not itself stretch — not only once, at
+/// the very end.
 impl Draw for Paragraph {
     fn draw(&self, canvas: &mut Canvas) -> Result<()> {
         let [x0, y0, x1, y1] = self.rect;
@@ -218,8 +222,8 @@ impl Draw for Paragraph {
                 lines.len()
             )));
         }
-        let last = lines.len().saturating_sub(1);
-        let mut stretched = false;
+        let last_visible = lines.iter().rposition(|words| !words.is_empty());
+        let mut stretch_active = false;
         for (index, words) in lines.iter().enumerate() {
             if words.is_empty() {
                 continue;
@@ -227,7 +231,7 @@ impl Draw for Paragraph {
             let baseline = y1 - self.size - index as f32 * leading;
             let line_text = words.join(" ");
             let line_width = self.font.text_width(&line_text, self.size)?;
-            let is_final = index == last;
+            let is_final = Some(index) == last_visible;
             let stretch = match self.align {
                 ParagraphAlign::Justify if !is_final && words.len() >= 2 => {
                     Some((width - line_width) / (words.len() as f32 - 1.0))
@@ -239,13 +243,17 @@ impl Draw for Paragraph {
                 ParagraphAlign::Center => x0 + (width - line_width) / 2.0,
                 ParagraphAlign::Left | ParagraphAlign::Justify => x0,
             };
+            if stretch.is_none() && stretch_active {
+                canvas.op(Op::SetWordSpacing(0.0));
+                stretch_active = false;
+            }
             if let Some(spacing) = stretch {
                 canvas.op(Op::SetWordSpacing(spacing));
-                stretched = true;
+                stretch_active = true;
             }
             canvas.text(&line_text, x, baseline, self.font, self.size)?;
         }
-        if stretched {
+        if stretch_active {
             canvas.op(Op::SetWordSpacing(0.0));
         }
         Ok(())
@@ -573,13 +581,15 @@ mod tests {
                 Op::TextMove(0.0, 90.0),
                 Op::ShowText(b"aaaaaaa bbbbbbb".to_vec()),
                 Op::EndText,
+                Op::SetWordSpacing(0.0),
                 Op::BeginText,
                 Op::SetFont(Name("F1".into()), 10.0),
                 Op::TextMove(0.0, 78.0),
                 Op::ShowText(b"ddddd".to_vec()),
                 Op::EndText,
-                Op::SetWordSpacing(0.0),
-            ]
+            ],
+            "the reset must land before the final line's BeginText, not after it \
+             (Tw is persistent text state that BeginText does not clear)"
         );
 
         let bytes = crate::content::serialize_ops(canvas.ops());
@@ -593,6 +603,141 @@ mod tests {
             .collect();
         assert_eq!(stretched, [30.0]);
         assert!(parsed.contains(&Op::SetWordSpacing(0.0)));
+    }
+
+    #[test]
+    fn paragraph_justify_final_line_with_multiple_words_gets_no_leftover_spacing() {
+        let mut canvas = Canvas::new();
+        let mut links = Vec::new();
+        let paragraph = Paragraph {
+            text: "aaaaaaa bbbbbbb ccccc dd".into(),
+            rect: [0.0, 0.0, 120.0, 100.0],
+            font: Standard14::Courier,
+            size: 10.0,
+            align: ParagraphAlign::Justify,
+            ..Paragraph::default()
+        };
+        lower(vec![paragraph.into()], &mut canvas, &mut links).unwrap();
+        let expected = [
+            Op::SetWordSpacing(30.0),
+            Op::BeginText,
+            Op::SetFont(Name("F1".into()), 10.0),
+            Op::TextMove(0.0, 90.0),
+            Op::ShowText(b"aaaaaaa bbbbbbb".to_vec()),
+            Op::EndText,
+            Op::SetWordSpacing(0.0),
+            Op::BeginText,
+            Op::SetFont(Name("F1".into()), 10.0),
+            Op::TextMove(0.0, 78.0),
+            Op::ShowText(b"ccccc dd".to_vec()),
+            Op::EndText,
+        ];
+        assert_eq!(
+            canvas.ops(),
+            expected,
+            "the final line has 2 words (a space glyph) — a leftover non-zero \
+             Tw here would visibly over-stretch it, which is exactly the bug"
+        );
+
+        let bytes = crate::content::serialize_ops(canvas.ops());
+        let parsed = parse_content(&bytes).unwrap();
+        let reset_index = parsed
+            .iter()
+            .position(|op| *op == Op::SetWordSpacing(0.0))
+            .expect("a zero reset must be present");
+        let final_show_index = parsed
+            .iter()
+            .position(|op| matches!(op, Op::ShowText(s) if s == b"ccccc dd"))
+            .expect("final line's ShowText must be present");
+        assert!(
+            reset_index < final_show_index,
+            "reset (index {reset_index}) must precede the final line's ShowText \
+             (index {final_show_index}): {parsed:?}"
+        );
+        let stray_nonzero_between = parsed[reset_index..final_show_index]
+            .iter()
+            .any(|op| matches!(op, Op::SetWordSpacing(value) if *value != 0.0));
+        assert!(
+            !stray_nonzero_between,
+            "no non-zero word spacing may sit between the reset and the final \
+             line's ShowText: {:?}",
+            &parsed[reset_index..final_show_index]
+        );
+    }
+
+    #[test]
+    fn paragraph_trailing_blank_line_does_not_become_the_justify_final_line() {
+        let text = "aaaaaaa bbbbbbb ccccc dd\n";
+
+        let mut canvas = Canvas::new();
+        let mut links = Vec::new();
+        let paragraph = Paragraph {
+            text: text.into(),
+            rect: [0.0, 0.0, 120.0, 100.0],
+            font: Standard14::Courier,
+            size: 10.0,
+            align: ParagraphAlign::Justify,
+            ..Paragraph::default()
+        };
+        lower(vec![paragraph.into()], &mut canvas, &mut links).unwrap();
+        assert_eq!(
+            canvas.ops(),
+            [
+                Op::SetWordSpacing(30.0),
+                Op::BeginText,
+                Op::SetFont(Name("F1".into()), 10.0),
+                Op::TextMove(0.0, 90.0),
+                Op::ShowText(b"aaaaaaa bbbbbbb".to_vec()),
+                Op::EndText,
+                Op::SetWordSpacing(0.0),
+                Op::BeginText,
+                Op::SetFont(Name("F1".into()), 10.0),
+                Op::TextMove(0.0, 78.0),
+                Op::ShowText(b"ccccc dd".to_vec()),
+                Op::EndText,
+            ],
+            "the trailing blank line (from the trailing \\n) must not steal the \
+             'final line never stretches' exemption from \"ccccc dd\""
+        );
+
+        let tight_rect_without_trailing_newline = Paragraph {
+            text: "aaaaaaa bbbbbbb ccccc dd".into(),
+            rect: [0.0, 0.0, 120.0, 24.0],
+            font: Standard14::Courier,
+            size: 10.0,
+            align: ParagraphAlign::Justify,
+            ..Paragraph::default()
+        };
+        let mut fits_canvas = Canvas::new();
+        lower(
+            vec![tight_rect_without_trailing_newline.into()],
+            &mut fits_canvas,
+            &mut links,
+        )
+        .expect("two visible lines fit in a rect sized for exactly two lines");
+
+        let tight_rect_with_trailing_newline = Paragraph {
+            text: text.into(),
+            rect: [0.0, 0.0, 120.0, 24.0],
+            font: Standard14::Courier,
+            size: 10.0,
+            align: ParagraphAlign::Justify,
+            ..Paragraph::default()
+        };
+        let mut overflow_canvas = Canvas::new();
+        let err = lower(
+            vec![tight_rect_with_trailing_newline.into()],
+            &mut overflow_canvas,
+            &mut links,
+        )
+        .unwrap_err();
+        match err {
+            Error::Other(msg) => assert_eq!(
+                msg, "paragraph overflows its rect: 2 lines fit, 3 needed",
+                "the trailing blank line must still count toward vertical advance"
+            ),
+            other => panic!("expected Error::Other, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/pdfboss-write/src/lib.rs
+++ b/crates/pdfboss-write/src/lib.rs
@@ -27,6 +27,7 @@ pub mod pdf;
 pub mod ser;
 pub mod sink;
 pub mod writer;
+mod xmp;
 
 pub use canvas::{Canvas, CanvasParts, ImageHandle, LineCap, LineJoin};
 pub use color::Color;

--- a/crates/pdfboss-write/src/lib.rs
+++ b/crates/pdfboss-write/src/lib.rs
@@ -33,6 +33,6 @@ pub use content::serialize_ops;
 pub use error::{Error, Result};
 pub use font::Standard14;
 pub use image::ImageData;
-pub use pdf::{Date, LinkAnnotation, Metadata, Page, PageSize, Pdf};
+pub use pdf::{Date, LinkAnnotation, LinkTarget, Metadata, Page, PageSize, Pdf};
 pub use sink::{AsyncByteSink, Immediate};
 pub use writer::{WriteOptions, Writer, XrefStyle};

--- a/crates/pdfboss-write/src/lib.rs
+++ b/crates/pdfboss-write/src/lib.rs
@@ -31,7 +31,7 @@ pub mod writer;
 pub use canvas::{Canvas, CanvasParts, ImageHandle, LineCap, LineJoin};
 pub use color::Color;
 pub use content::serialize_ops;
-pub use element::{Content, Draw, Image, Link, Text};
+pub use element::{Content, Draw, Image, Link, Paragraph, ParagraphAlign, Text};
 pub use error::{Error, Result};
 pub use font::Standard14;
 pub use image::ImageData;

--- a/crates/pdfboss-write/src/lib.rs
+++ b/crates/pdfboss-write/src/lib.rs
@@ -37,7 +37,8 @@ pub use error::{Error, Result};
 pub use font::Standard14;
 pub use image::ImageData;
 pub use pdf::{
-    Attachment, Bookmark, Date, LinkAnnotation, LinkTarget, Metadata, Outline, Page, PageSize, Pdf,
+    Attachment, Bookmark, Date, LabelStyle, LinkAnnotation, LinkTarget, Metadata, Outline, Page,
+    PageLabel, PageLayout, PageMode, PageSize, Pdf, Viewer,
 };
 pub use sink::{AsyncByteSink, Immediate};
 pub use writer::{WriteOptions, Writer, XrefStyle};

--- a/crates/pdfboss-write/src/lib.rs
+++ b/crates/pdfboss-write/src/lib.rs
@@ -36,6 +36,8 @@ pub use element::{Content, Draw, Image, Link, Paragraph, ParagraphAlign, Text};
 pub use error::{Error, Result};
 pub use font::Standard14;
 pub use image::ImageData;
-pub use pdf::{Bookmark, Date, LinkAnnotation, LinkTarget, Metadata, Outline, Page, PageSize, Pdf};
+pub use pdf::{
+    Attachment, Bookmark, Date, LinkAnnotation, LinkTarget, Metadata, Outline, Page, PageSize, Pdf,
+};
 pub use sink::{AsyncByteSink, Immediate};
 pub use writer::{WriteOptions, Writer, XrefStyle};

--- a/crates/pdfboss-write/src/lib.rs
+++ b/crates/pdfboss-write/src/lib.rs
@@ -19,6 +19,7 @@
 pub mod canvas;
 pub mod color;
 pub mod content;
+pub mod element;
 pub mod error;
 pub mod font;
 pub mod image;
@@ -30,6 +31,7 @@ pub mod writer;
 pub use canvas::{Canvas, CanvasParts, ImageHandle, LineCap, LineJoin};
 pub use color::Color;
 pub use content::serialize_ops;
+pub use element::{Content, Draw, Image, Link, Text};
 pub use error::{Error, Result};
 pub use font::Standard14;
 pub use image::ImageData;

--- a/crates/pdfboss-write/src/lib.rs
+++ b/crates/pdfboss-write/src/lib.rs
@@ -29,7 +29,7 @@ pub mod sink;
 pub mod writer;
 mod xmp;
 
-pub use canvas::{Canvas, CanvasParts, ImageHandle, LineCap, LineJoin};
+pub use canvas::{BlendMode, Canvas, CanvasParts, GroupHandle, ImageHandle, LineCap, LineJoin};
 pub use color::Color;
 pub use content::serialize_ops;
 pub use element::{Content, Draw, Image, Link, Paragraph, ParagraphAlign, Text};

--- a/crates/pdfboss-write/src/lib.rs
+++ b/crates/pdfboss-write/src/lib.rs
@@ -35,6 +35,6 @@ pub use element::{Content, Draw, Image, Link, Paragraph, ParagraphAlign, Text};
 pub use error::{Error, Result};
 pub use font::Standard14;
 pub use image::ImageData;
-pub use pdf::{Date, LinkAnnotation, LinkTarget, Metadata, Page, PageSize, Pdf};
+pub use pdf::{Bookmark, Date, LinkAnnotation, LinkTarget, Metadata, Outline, Page, PageSize, Pdf};
 pub use sink::{AsyncByteSink, Immediate};
 pub use writer::{WriteOptions, Writer, XrefStyle};

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -144,14 +144,25 @@ pub struct Page {
     pub links: Vec<LinkAnnotation>,
 }
 
-/// A clickable rectangle on a page that opens a URI (a `/Link` annotation
-/// with a `/URI` action; ISO 32000 §12.5.6.5, §12.6.4.7).
+/// A clickable rectangle on a page that opens a URI or jumps to a page in
+/// the same document (a `/Link` annotation with a `/URI` or `/GoTo`
+/// action; ISO 32000 §12.5.6.5, §12.6.4.7, §12.3.2).
 #[derive(Debug, Clone, PartialEq)]
 pub struct LinkAnnotation {
     /// The clickable area, `[x0, y0, x1, y1]` in the page's user space.
     pub rect: [f32; 4],
-    /// The URI opened on click.
-    pub uri: String,
+    /// Where the link goes.
+    pub target: LinkTarget,
+}
+
+/// Where a [`LinkAnnotation`] leads.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LinkTarget {
+    /// An external URI, opened with a `/URI` action.
+    Uri(String),
+    /// A page within the same document, by index, opened with a `/GoTo`
+    /// action landing at the top of the page.
+    Page(usize),
 }
 
 impl Page {
@@ -220,9 +231,10 @@ impl Pdf {
         }
         let mut w = Writer::new(options);
         let pages_root = w.reserve();
+        let page_count = pages.len();
+        let page_refs: Vec<ObjRef> = pages.iter().map(|_| w.reserve()).collect();
         let mut font_cache: Vec<(Standard14, ObjRef)> = Vec::new();
-        let mut kids = Vec::with_capacity(pages.len());
-        for page in pages {
+        for (index, page) in pages.into_iter().enumerate() {
             let Page {
                 size,
                 rotation,
@@ -280,39 +292,63 @@ impl Pdf {
             dict.insert(name("Contents"), Object::Ref(content));
             dict.insert(name("Resources"), Object::Dict(resources));
             if !links.is_empty() {
-                let annots = links
-                    .iter()
-                    .map(|link| {
-                        let mut action = Dict::new();
-                        action.insert(name("S"), Object::Name(name("URI")));
-                        action.insert(name("URI"), text_string(&link.uri));
-                        let mut annot = Dict::new();
-                        annot.insert(name("Type"), Object::Name(name("Annot")));
-                        annot.insert(name("Subtype"), Object::Name(name("Link")));
-                        annot.insert(
-                            name("Rect"),
-                            Object::Array(
-                                link.rect
-                                    .iter()
-                                    .map(|v| Object::Real(f64::from(*v)))
-                                    .collect(),
-                            ),
-                        );
-                        annot.insert(
-                            name("Border"),
-                            Object::Array(vec![Object::Int(0), Object::Int(0), Object::Int(0)]),
-                        );
-                        annot.insert(name("A"), Object::Dict(action));
-                        Object::Ref(w.put(Object::Dict(annot)))
-                    })
-                    .collect();
+                let mut annots = Vec::with_capacity(links.len());
+                for link in links {
+                    let action = match link.target {
+                        LinkTarget::Uri(uri) => {
+                            let mut action = Dict::new();
+                            action.insert(name("S"), Object::Name(name("URI")));
+                            action.insert(name("URI"), text_string(&uri));
+                            action
+                        }
+                        LinkTarget::Page(target_index) => {
+                            let target = page_refs.get(target_index).copied().ok_or_else(|| {
+                                Error::Other(format!(
+                                    "link target page {target_index} is out of range: the document has {page_count} pages"
+                                ))
+                            })?;
+                            let mut action = Dict::new();
+                            action.insert(name("S"), Object::Name(name("GoTo")));
+                            action.insert(
+                                name("D"),
+                                Object::Array(vec![
+                                    Object::Ref(target),
+                                    Object::Name(name("XYZ")),
+                                    Object::Null,
+                                    Object::Null,
+                                    Object::Null,
+                                ]),
+                            );
+                            action
+                        }
+                    };
+                    let mut annot = Dict::new();
+                    annot.insert(name("Type"), Object::Name(name("Annot")));
+                    annot.insert(name("Subtype"), Object::Name(name("Link")));
+                    annot.insert(
+                        name("Rect"),
+                        Object::Array(
+                            link.rect
+                                .iter()
+                                .map(|v| Object::Real(f64::from(*v)))
+                                .collect(),
+                        ),
+                    );
+                    annot.insert(
+                        name("Border"),
+                        Object::Array(vec![Object::Int(0), Object::Int(0), Object::Int(0)]),
+                    );
+                    annot.insert(name("A"), Object::Dict(action));
+                    annots.push(Object::Ref(w.put(Object::Dict(annot))));
+                }
                 dict.insert(name("Annots"), Object::Array(annots));
             }
             if rotation != 0 {
                 dict.insert(name("Rotate"), Object::Int(i64::from(rotation)));
             }
-            kids.push(Object::Ref(w.put(Object::Dict(dict))));
+            w.fill(page_refs[index], Object::Dict(dict))?;
         }
+        let kids: Vec<Object> = page_refs.iter().copied().map(Object::Ref).collect();
         let mut tree = Dict::new();
         tree.insert(name("Type"), Object::Name(name("Pages")));
         tree.insert(name("Count"), Object::Int(kids.len() as i64));

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -743,10 +743,19 @@ fn embedded_files_dict(w: &mut Writer, mut attachments: Vec<Attachment>) -> Resu
 /// when there are none. Ranges are reordered by `first_page` to satisfy
 /// the number tree's sorted-key requirement. A non-empty set must include
 /// a range starting at page 0; a repeated `first_page` is an error naming
-/// the page.
+/// the page; a `start_at` of 0 is an error naming the page, since ISO
+/// 32000 page-label numbering starts at 1.
 fn page_labels_dict(mut labels: Vec<PageLabel>) -> Result<Option<Dict>> {
     if labels.is_empty() {
         return Ok(None);
+    }
+    for label in &labels {
+        if label.start_at == 0 {
+            return Err(Error::Other(format!(
+                "page label at page {} has start_at 0: numbering starts at 1",
+                label.first_page
+            )));
+        }
     }
     labels.sort_by_key(|label| label.first_page);
     if labels[0].first_page != 0 {

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -58,6 +58,20 @@ impl PageSize {
             height: width,
         }
     }
+
+    /// Parses one of the five named sizes case-insensitively: `a3`, `a4`,
+    /// `a5`, `letter`, `legal`. `None` for anything else — a custom size
+    /// has no name to parse.
+    pub fn by_name(name: &str) -> Option<PageSize> {
+        match name.to_ascii_lowercase().as_str() {
+            "a3" => Some(PageSize::A3),
+            "a4" => Some(PageSize::A4),
+            "a5" => Some(PageSize::A5),
+            "letter" => Some(PageSize::Letter),
+            "legal" => Some(PageSize::Legal),
+            _ => None,
+        }
+    }
 }
 
 /// A calendar date and time with a UTC offset, for `/CreationDate` and
@@ -1023,6 +1037,25 @@ mod tests {
             .dimensions(),
             (10.0, 20.0)
         );
+    }
+
+    #[test]
+    fn by_name_parses_the_five_named_sizes_case_insensitively() {
+        for (name, expected) in [
+            ("a3", PageSize::A3),
+            ("A4", PageSize::A4),
+            ("a5", PageSize::A5),
+            ("Letter", PageSize::Letter),
+            ("LEGAL", PageSize::Legal),
+        ] {
+            assert_eq!(PageSize::by_name(name), Some(expected), "{name}");
+        }
+    }
+
+    #[test]
+    fn by_name_rejects_anything_else() {
+        assert_eq!(PageSize::by_name("tabloid"), None);
+        assert_eq!(PageSize::by_name(""), None);
     }
 
     #[test]

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -8,6 +8,7 @@ use pdfboss_core::{Dict, Name, ObjRef, Object};
 
 use crate::canvas::Canvas;
 use crate::content::serialize_ops;
+use crate::element::{self, Content};
 use crate::error::{Error, Result};
 use crate::font::Standard14;
 use crate::sink::AsyncByteSink;
@@ -140,6 +141,9 @@ pub struct Page {
     pub rotation: i32,
     /// The page's painted content.
     pub canvas: Canvas,
+    /// Composed elements, painted onto `canvas` at assemble time, after
+    /// any content already painted there directly.
+    pub content: Vec<Content>,
     /// Clickable link areas, emitted as `/Annots`.
     pub links: Vec<LinkAnnotation>,
 }
@@ -238,17 +242,19 @@ impl Pdf {
             let Page {
                 size,
                 rotation,
-                canvas,
-                links,
+                mut canvas,
+                content,
+                mut links,
             } = page;
             if rotation % 90 != 0 {
                 return Err(Error::Other(format!(
                     "page rotation {rotation} is not a multiple of 90"
                 )));
             }
+            element::lower(content, &mut canvas, &mut links)?;
             let (width, height) = size.dimensions();
             let parts = canvas.into_parts();
-            let content = w.put_stream(Dict::new(), serialize_ops(&parts.ops));
+            let content_ref = w.put_stream(Dict::new(), serialize_ops(&parts.ops));
             let mut fonts = Dict::new();
             for (index, face) in parts.fonts.iter().enumerate() {
                 let cached = font_cache
@@ -289,7 +295,7 @@ impl Pdf {
                     Object::Real(f64::from(height)),
                 ]),
             );
-            dict.insert(name("Contents"), Object::Ref(content));
+            dict.insert(name("Contents"), Object::Ref(content_ref));
             dict.insert(name("Resources"), Object::Dict(resources));
             if !links.is_empty() {
                 let mut annots = Vec::with_capacity(links.len());

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -207,7 +207,7 @@ pub enum LinkTarget {
     /// An external URI, opened with a `/URI` action.
     Uri(String),
     /// A page within the same document, by index, opened with a `/GoTo`
-    /// action landing at the top of the page.
+    /// action that keeps the viewer's current position and zoom.
     Page(usize),
 }
 
@@ -234,7 +234,8 @@ pub struct Outline {
 pub struct Bookmark {
     /// Text shown in the outline panel.
     pub title: String,
-    /// Target page index, jumped to at the page's top-left corner.
+    /// Target page index, opened keeping the viewer's current position
+    /// and zoom.
     pub page: usize,
     /// Nested bookmarks, in reading order.
     pub children: Vec<Bookmark>,
@@ -346,8 +347,8 @@ pub struct Viewer {
     pub layout: Option<PageLayout>,
     /// `/PageMode`, omitted when `None`.
     pub mode: Option<PageMode>,
-    /// Page index opened at its top-left corner via `/OpenAction`,
-    /// omitted when `None`.
+    /// Page index opened via `/OpenAction`, keeping the viewer's current
+    /// position and zoom, omitted when `None`.
     pub open_to: Option<usize>,
 }
 

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -108,6 +108,34 @@ impl Date {
         ));
         out
     }
+
+    /// Formats as an ISO-8601 date-time, `YYYY-MM-DDTHH:mm:SS±HH:MM` — with
+    /// a literal `Z` in place of the offset when the date is exactly UTC.
+    /// Used for the XMP `xmp:CreateDate`/`xmp:ModifyDate` elements.
+    pub(crate) fn to_iso8601(self) -> String {
+        let Date {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            utc_offset_minutes,
+        } = self;
+        let mut out = format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}");
+        if utc_offset_minutes == 0 {
+            out.push('Z');
+            return out;
+        }
+        let sign = if utc_offset_minutes < 0 { '-' } else { '+' };
+        let magnitude = utc_offset_minutes.unsigned_abs();
+        out.push_str(&format!(
+            "{sign}{:02}:{:02}",
+            magnitude / 60,
+            magnitude % 60
+        ));
+        out
+    }
 }
 
 /// Document information written to the `/Info` dictionary. Every field is
@@ -393,10 +421,20 @@ impl Pdf {
         tree.insert(name("Count"), Object::Int(kids.len() as i64));
         tree.insert(name("Kids"), Object::Array(kids));
         w.fill(pages_root, Object::Dict(tree))?;
-        if let Some(info) = metadata.and_then(info_dict) {
-            let info_ref = w.put(Object::Dict(info));
-            w.set_info(info_ref);
-        }
+        let xmp_ref = match metadata {
+            Some(meta) => {
+                let packet = crate::xmp::packet(&meta);
+                if let Some(info) = info_dict(meta) {
+                    let info_ref = w.put(Object::Dict(info));
+                    w.set_info(info_ref);
+                }
+                let mut xmp_dict = Dict::new();
+                xmp_dict.insert(name("Type"), Object::Name(name("Metadata")));
+                xmp_dict.insert(name("Subtype"), Object::Name(name("XML")));
+                Some(w.put_stream_raw(xmp_dict, packet))
+            }
+            None => None,
+        };
         let outline_ref = match outline {
             Some(outline) if !outline.bookmarks.is_empty() => {
                 let root_ref = w.reserve();
@@ -424,6 +462,9 @@ impl Pdf {
         catalog.insert(name("Pages"), Object::Ref(pages_root));
         if let Some(outline_ref) = outline_ref {
             catalog.insert(name("Outlines"), Object::Ref(outline_ref));
+        }
+        if let Some(xmp_ref) = xmp_ref {
+            catalog.insert(name("Metadata"), Object::Ref(xmp_ref));
         }
         let root = w.put(Object::Dict(catalog));
         Ok((w, root))
@@ -661,6 +702,48 @@ mod tests {
             utc_offset_minutes: -330,
         };
         assert_eq!(date.to_pdf_string(), "D:19991231235958-05'30");
+    }
+
+    #[test]
+    fn iso8601_utc_formats_with_z() {
+        let date = Date {
+            year: 2026,
+            month: 8,
+            day: 27,
+            hour: 12,
+            minute: 30,
+            second: 15,
+            utc_offset_minutes: 0,
+        };
+        assert_eq!(date.to_iso8601(), "2026-08-27T12:30:15Z");
+    }
+
+    #[test]
+    fn iso8601_positive_offset_pads_single_digits() {
+        let date = Date {
+            year: 987,
+            month: 1,
+            day: 2,
+            hour: 3,
+            minute: 4,
+            second: 5,
+            utc_offset_minutes: 120,
+        };
+        assert_eq!(date.to_iso8601(), "0987-01-02T03:04:05+02:00");
+    }
+
+    #[test]
+    fn iso8601_negative_offset_keeps_minutes() {
+        let date = Date {
+            year: 1999,
+            month: 12,
+            day: 31,
+            hour: 23,
+            minute: 59,
+            second: 58,
+            utc_offset_minutes: -330,
+        };
+        assert_eq!(date.to_iso8601(), "1999-12-31T23:59:58-05:30");
     }
 
     /// Two pages with text and an image — enough to exercise fonts,

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -237,6 +237,27 @@ impl Bookmark {
     }
 }
 
+/// A document-level attachment, embedded via the catalog's `/Names
+/// /EmbeddedFiles` name tree (ISO 32000 §7.11.4). Unlike a page's painted
+/// content, an attachment carries no rendering — only the bytes and the
+/// metadata a viewer shows about them.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Attachment {
+    /// The file name: written as both the filespec's `/F` and `/UF`, and
+    /// as the name-tree key.
+    pub name: String,
+    /// The attachment's raw bytes, stored as the embedded-file stream
+    /// (compressed like any other stream, per [`WriteOptions::compress`]).
+    pub data: Vec<u8>,
+    /// MIME type, written as the embedded-file stream's `/Subtype`.
+    /// `None` writes `application/octet-stream`.
+    pub mime: Option<String>,
+    /// `/Params /ModDate`, written only when given.
+    pub modified: Option<Date>,
+    /// `/Desc` on the filespec, written only when given.
+    pub description: Option<String>,
+}
+
 /// A document under construction. The fields are the composition:
 /// singleton slots are `Option`s, pages keep the order given.
 #[derive(Debug, Default)]
@@ -247,6 +268,10 @@ pub struct Pdf {
     pub pages: Vec<Page>,
     /// Bookmark panel, if any.
     pub outline: Option<Outline>,
+    /// Document-level attachments. Reordered by `name`, lexicographically
+    /// by bytes, at emission — the name-tree keys must be sorted, so the
+    /// order given here is not preserved. Duplicate names are an error.
+    pub attachments: Vec<Attachment>,
     /// File-emission options.
     pub options: WriteOptions,
 }
@@ -287,6 +312,7 @@ impl Pdf {
             metadata,
             pages,
             outline,
+            attachments,
             options,
         } = self;
         if pages.is_empty() {
@@ -457,6 +483,7 @@ impl Pdf {
             }
             _ => None,
         };
+        let names = embedded_files_dict(&mut w, attachments)?;
         let mut catalog = Dict::new();
         catalog.insert(name("Type"), Object::Name(name("Catalog")));
         catalog.insert(name("Pages"), Object::Ref(pages_root));
@@ -465,6 +492,9 @@ impl Pdf {
         }
         if let Some(xmp_ref) = xmp_ref {
             catalog.insert(name("Metadata"), Object::Ref(xmp_ref));
+        }
+        if let Some(names) = names {
+            catalog.insert(name("Names"), Object::Dict(names));
         }
         let root = w.put(Object::Dict(catalog));
         Ok((w, root))
@@ -513,6 +543,75 @@ fn info_dict(meta: Metadata) -> Option<Dict> {
         return None;
     }
     Some(dict)
+}
+
+/// Default MIME type for an [`Attachment`] whose `mime` is `None`.
+const DEFAULT_ATTACHMENT_MIME: &str = "application/octet-stream";
+
+/// Builds the catalog's `/Names` dictionary from `attachments`, or `None`
+/// when there are none. Attachments are reordered by `name`, bytewise, to
+/// satisfy the name tree's sorted-key requirement — string comparison in
+/// Rust is already a byte comparison, so sorting `String` values sorts
+/// their bytes. A repeated name is an error naming the duplicate.
+fn embedded_files_dict(w: &mut Writer, mut attachments: Vec<Attachment>) -> Result<Option<Dict>> {
+    if attachments.is_empty() {
+        return Ok(None);
+    }
+    attachments.sort_by(|a, b| a.name.cmp(&b.name));
+    for pair in attachments.windows(2) {
+        if pair[0].name == pair[1].name {
+            return Err(Error::Other(format!(
+                "duplicate attachment name: {:?}",
+                pair[0].name
+            )));
+        }
+    }
+    let mut entries = Vec::with_capacity(attachments.len() * 2);
+    for attachment in attachments {
+        let Attachment {
+            name: file_name,
+            data,
+            mime,
+            modified,
+            description,
+        } = attachment;
+        let mime = mime.unwrap_or_else(|| DEFAULT_ATTACHMENT_MIME.to_string());
+
+        let mut params = Dict::new();
+        params.insert(name("Size"), Object::Int(data.len() as i64));
+        if let Some(modified) = modified {
+            params.insert(
+                name("ModDate"),
+                Object::String(modified.to_pdf_string().into_bytes()),
+            );
+        }
+        let mut stream_dict = Dict::new();
+        stream_dict.insert(name("Type"), Object::Name(name("EmbeddedFile")));
+        stream_dict.insert(name("Subtype"), Object::Name(Name(mime)));
+        stream_dict.insert(name("Params"), Object::Dict(params));
+        let stream_ref = w.put_stream(stream_dict, data);
+
+        let mut ef = Dict::new();
+        ef.insert(name("F"), Object::Ref(stream_ref));
+
+        let mut filespec = Dict::new();
+        filespec.insert(name("Type"), Object::Name(name("Filespec")));
+        filespec.insert(name("F"), text_string(&file_name));
+        filespec.insert(name("UF"), text_string(&file_name));
+        if let Some(description) = description {
+            filespec.insert(name("Desc"), text_string(&description));
+        }
+        filespec.insert(name("EF"), Object::Dict(ef));
+        let filespec_ref = w.put(Object::Dict(filespec));
+
+        entries.push(text_string(&file_name));
+        entries.push(Object::Ref(filespec_ref));
+    }
+    let mut name_tree = Dict::new();
+    name_tree.insert(name("Names"), Object::Array(entries));
+    let mut embedded_files = Dict::new();
+    embedded_files.insert(name("EmbeddedFiles"), Object::Dict(name_tree));
+    Ok(Some(embedded_files))
 }
 
 /// One bookmark's reserved object number, mirroring the tree shape so the

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use pdfboss_core::{Dict, Name, ObjRef, Object};
 
-use crate::canvas::Canvas;
+use crate::canvas::{Canvas, CanvasParts};
 use crate::content::serialize_ops;
 use crate::element::{self, Content};
 use crate::error::{Error, Result};
@@ -368,7 +368,9 @@ impl Pdf {
     /// Fonts are shared document-wide: each distinct [`Standard14`] face
     /// gets one font object, in first-use order. Images are embedded per
     /// page with no cross-page deduplication — the same raster drawn on
-    /// two pages is stored twice.
+    /// two pages is stored twice. Groups follow the same rule: a canvas
+    /// registered with `Canvas::group` on two different pages produces two
+    /// Form XObjects — cross-page group sharing is deferred.
     pub fn to_bytes(self) -> Result<Vec<u8>> {
         let (w, root) = self.assemble()?;
         w.finish(root)
@@ -432,18 +434,7 @@ impl Pdf {
             let content_ref = w.put_stream(Dict::new(), serialize_ops(&parts.ops));
             let mut fonts = Dict::new();
             for (index, face) in parts.fonts.iter().enumerate() {
-                let cached = font_cache
-                    .iter()
-                    .find(|(seen, _)| seen == face)
-                    .map(|(_, r)| *r);
-                let font_ref = match cached {
-                    Some(r) => r,
-                    None => {
-                        let r = w.put(Object::Dict(face.font_dict()));
-                        font_cache.push((*face, r));
-                        r
-                    }
-                };
+                let font_ref = cached_font(&mut w, &mut font_cache, face);
                 fonts.insert(Name(format!("F{}", index + 1)), Object::Ref(font_ref));
             }
             let mut xobjects = Dict::new();
@@ -451,12 +442,24 @@ impl Pdf {
                 let image_ref = image.build_xobject(&mut w);
                 xobjects.insert(Name(format!("Im{}", index + 1)), Object::Ref(image_ref));
             }
+            for (index, (group_parts, bbox)) in parts.groups.into_iter().enumerate() {
+                let group_ref = build_form(&mut w, group_parts, bbox, &mut font_cache)?;
+                xobjects.insert(Name(format!("Gp{}", index + 1)), Object::Ref(group_ref));
+            }
+            let mut ext_gstates = Dict::new();
+            for (index, state) in parts.gstates.iter().enumerate() {
+                let gstate_ref = w.put(Object::Dict(state.ext_gstate_dict()));
+                ext_gstates.insert(Name(format!("Gs{}", index + 1)), Object::Ref(gstate_ref));
+            }
             let mut resources = Dict::new();
             if !fonts.is_empty() {
                 resources.insert(name("Font"), Object::Dict(fonts));
             }
             if !xobjects.is_empty() {
                 resources.insert(name("XObject"), Object::Dict(xobjects));
+            }
+            if !ext_gstates.is_empty() {
+                resources.insert(name("ExtGState"), Object::Dict(ext_gstates));
             }
             let mut dict = Dict::new();
             dict.insert(name("Type"), Object::Name(name("Page")));
@@ -915,6 +918,76 @@ fn fill_bookmarks(
         total += 1 + subtree_count;
     }
     Ok((refs[0].r, refs[last_index].r, total))
+}
+
+/// The document-wide font object for `face`: an existing entry from
+/// `font_cache` when one matches, otherwise a freshly built one that is
+/// cached for the next lookup. Shared by the page loop and every nested
+/// [`build_form`] so a face used both on a page and inside a group still
+/// gets exactly one font object.
+fn cached_font(
+    w: &mut Writer,
+    font_cache: &mut Vec<(Standard14, ObjRef)>,
+    face: &Standard14,
+) -> ObjRef {
+    if let Some((_, r)) = font_cache.iter().find(|(seen, _)| seen == face) {
+        return *r;
+    }
+    let r = w.put(Object::Dict(face.font_dict()));
+    font_cache.push((*face, r));
+    r
+}
+
+/// Builds one Form XObject from a registered group's parts: `/Type
+/// /XObject /Subtype /Form /BBox /Resources`, with the sub-canvas's
+/// operators as its content stream. Recurses for groups nested inside
+/// groups, and shares `font_cache` with the page loop so nested forms
+/// never duplicate a font already emitted elsewhere in the document.
+fn build_form(
+    w: &mut Writer,
+    parts: CanvasParts,
+    bbox: [f32; 4],
+    font_cache: &mut Vec<(Standard14, ObjRef)>,
+) -> Result<ObjRef> {
+    let content = serialize_ops(&parts.ops);
+    let mut fonts = Dict::new();
+    for (index, face) in parts.fonts.iter().enumerate() {
+        let font_ref = cached_font(w, font_cache, face);
+        fonts.insert(Name(format!("F{}", index + 1)), Object::Ref(font_ref));
+    }
+    let mut xobjects = Dict::new();
+    for (index, image) in parts.images.iter().enumerate() {
+        let image_ref = image.build_xobject(w);
+        xobjects.insert(Name(format!("Im{}", index + 1)), Object::Ref(image_ref));
+    }
+    for (index, (group_parts, group_bbox)) in parts.groups.into_iter().enumerate() {
+        let group_ref = build_form(w, group_parts, group_bbox, font_cache)?;
+        xobjects.insert(Name(format!("Gp{}", index + 1)), Object::Ref(group_ref));
+    }
+    let mut ext_gstates = Dict::new();
+    for (index, state) in parts.gstates.iter().enumerate() {
+        let gstate_ref = w.put(Object::Dict(state.ext_gstate_dict()));
+        ext_gstates.insert(Name(format!("Gs{}", index + 1)), Object::Ref(gstate_ref));
+    }
+    let mut resources = Dict::new();
+    if !fonts.is_empty() {
+        resources.insert(name("Font"), Object::Dict(fonts));
+    }
+    if !xobjects.is_empty() {
+        resources.insert(name("XObject"), Object::Dict(xobjects));
+    }
+    if !ext_gstates.is_empty() {
+        resources.insert(name("ExtGState"), Object::Dict(ext_gstates));
+    }
+    let mut dict = Dict::new();
+    dict.insert(name("Type"), Object::Name(name("XObject")));
+    dict.insert(name("Subtype"), Object::Name(name("Form")));
+    dict.insert(
+        name("BBox"),
+        Object::Array(bbox.iter().map(|v| Object::Real(f64::from(*v))).collect()),
+    );
+    dict.insert(name("Resources"), Object::Dict(resources));
+    Ok(w.put_stream(dict, content))
 }
 
 /// Encodes a text string (ISO 32000 §7.9.2.2): pure ASCII passes through

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -179,6 +179,36 @@ impl Page {
     }
 }
 
+/// A document's bookmark panel: an ordered forest of [`Bookmark`] nodes,
+/// each linking to a page via an explicit `/XYZ` destination.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Outline {
+    /// Top-level bookmarks, in reading order.
+    pub bookmarks: Vec<Bookmark>,
+}
+
+/// One outline entry: a title, the page it jumps to, and nested children.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Bookmark {
+    /// Text shown in the outline panel.
+    pub title: String,
+    /// Target page index, jumped to at the page's top-left corner.
+    pub page: usize,
+    /// Nested bookmarks, in reading order.
+    pub children: Vec<Bookmark>,
+}
+
+impl Bookmark {
+    /// A leaf bookmark: `title` targeting `page`, with no children.
+    pub fn new(title: impl Into<String>, page: usize) -> Bookmark {
+        Bookmark {
+            title: title.into(),
+            page,
+            children: Vec::new(),
+        }
+    }
+}
+
 /// A document under construction. The fields are the composition:
 /// singleton slots are `Option`s, pages keep the order given.
 #[derive(Debug, Default)]
@@ -187,6 +217,8 @@ pub struct Pdf {
     pub metadata: Option<Metadata>,
     /// Pages, in reading order.
     pub pages: Vec<Page>,
+    /// Bookmark panel, if any.
+    pub outline: Option<Outline>,
     /// File-emission options.
     pub options: WriteOptions,
 }
@@ -226,6 +258,7 @@ impl Pdf {
         let Pdf {
             metadata,
             pages,
+            outline,
             options,
         } = self;
         if pages.is_empty() {
@@ -364,9 +397,34 @@ impl Pdf {
             let info_ref = w.put(Object::Dict(info));
             w.set_info(info_ref);
         }
+        let outline_ref = match outline {
+            Some(outline) if !outline.bookmarks.is_empty() => {
+                let root_ref = w.reserve();
+                let refs = reserve_bookmarks(&mut w, &outline.bookmarks);
+                let (first, last, count) = fill_bookmarks(
+                    &mut w,
+                    outline.bookmarks,
+                    &refs,
+                    root_ref,
+                    &page_refs,
+                    page_count,
+                )?;
+                let mut dict = Dict::new();
+                dict.insert(name("Type"), Object::Name(name("Outlines")));
+                dict.insert(name("First"), Object::Ref(first));
+                dict.insert(name("Last"), Object::Ref(last));
+                dict.insert(name("Count"), Object::Int(count));
+                w.fill(root_ref, Object::Dict(dict))?;
+                Some(root_ref)
+            }
+            _ => None,
+        };
         let mut catalog = Dict::new();
         catalog.insert(name("Type"), Object::Name(name("Catalog")));
         catalog.insert(name("Pages"), Object::Ref(pages_root));
+        if let Some(outline_ref) = outline_ref {
+            catalog.insert(name("Outlines"), Object::Ref(outline_ref));
+        }
         let root = w.put(Object::Dict(catalog));
         Ok((w, root))
     }
@@ -414,6 +472,95 @@ fn info_dict(meta: Metadata) -> Option<Dict> {
         return None;
     }
     Some(dict)
+}
+
+/// One bookmark's reserved object number, mirroring the tree shape so the
+/// fill pass can wire parent, sibling and child refs before any of their
+/// dictionary bodies exist.
+struct BookmarkRef {
+    r: ObjRef,
+    children: Vec<BookmarkRef>,
+}
+
+/// Reserves an object number for every node in `bookmarks`, recursively —
+/// the reserve half of the reserve/fill idiom: an outline item's `/Parent`,
+/// `/Prev`, `/Next`, `/First` and `/Last` may all point at nodes that do
+/// not have a body yet.
+fn reserve_bookmarks(w: &mut Writer, bookmarks: &[Bookmark]) -> Vec<BookmarkRef> {
+    bookmarks
+        .iter()
+        .map(|bookmark| BookmarkRef {
+            r: w.reserve(),
+            children: reserve_bookmarks(w, &bookmark.children),
+        })
+        .collect()
+}
+
+/// Fills one sibling chain of outline items against their already-reserved
+/// refs: `/Title`, `/Parent`, the `/Prev`/`/Next` chain, `/Dest`, and — for
+/// any bookmark with children — `/First`/`/Last`/`/Count` from a recursive
+/// fill of that subtree. Returns the chain's first and last refs and the
+/// total number of items in the whole subtree, which doubles as `/Count`
+/// wherever the caller needs it (every bookmark is open).
+fn fill_bookmarks(
+    w: &mut Writer,
+    bookmarks: Vec<Bookmark>,
+    refs: &[BookmarkRef],
+    parent: ObjRef,
+    page_refs: &[ObjRef],
+    page_count: usize,
+) -> Result<(ObjRef, ObjRef, i64)> {
+    let last_index = bookmarks.len() - 1;
+    let mut total = 0i64;
+    for (index, bookmark) in bookmarks.into_iter().enumerate() {
+        let Bookmark {
+            title,
+            page,
+            children,
+        } = bookmark;
+        let dest = page_refs.get(page).copied().ok_or_else(|| {
+            Error::Other(format!(
+                "bookmark target page {page} is out of range: the document has {page_count} pages"
+            ))
+        })?;
+        let mut dict = Dict::new();
+        dict.insert(name("Title"), text_string(&title));
+        dict.insert(name("Parent"), Object::Ref(parent));
+        if index > 0 {
+            dict.insert(name("Prev"), Object::Ref(refs[index - 1].r));
+        }
+        if index < last_index {
+            dict.insert(name("Next"), Object::Ref(refs[index + 1].r));
+        }
+        dict.insert(
+            name("Dest"),
+            Object::Array(vec![
+                Object::Ref(dest),
+                Object::Name(name("XYZ")),
+                Object::Null,
+                Object::Null,
+                Object::Null,
+            ]),
+        );
+        let mut subtree_count = 0i64;
+        if !children.is_empty() {
+            let (first, last, count) = fill_bookmarks(
+                w,
+                children,
+                &refs[index].children,
+                refs[index].r,
+                page_refs,
+                page_count,
+            )?;
+            dict.insert(name("First"), Object::Ref(first));
+            dict.insert(name("Last"), Object::Ref(last));
+            dict.insert(name("Count"), Object::Int(count));
+            subtree_count = count;
+        }
+        w.fill(refs[index].r, Object::Dict(dict))?;
+        total += 1 + subtree_count;
+    }
+    Ok((refs[0].r, refs[last_index].r, total))
 }
 
 /// Encodes a text string (ISO 32000 §7.9.2.2): pure ASCII passes through

--- a/crates/pdfboss-write/src/pdf.rs
+++ b/crates/pdfboss-write/src/pdf.rs
@@ -258,6 +258,85 @@ pub struct Attachment {
     pub description: Option<String>,
 }
 
+/// A page-numbering style for a [`PageLabel`] range, written as its `/S`
+/// (ISO 32000 §12.4.2, Table 159).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LabelStyle {
+    /// Arabic numerals: 1, 2, 3…
+    Decimal,
+    /// Uppercase Roman numerals: I, II, III…
+    RomanUpper,
+    /// Lowercase Roman numerals: i, ii, iii…
+    RomanLower,
+    /// Uppercase letters: A, B, …, Z, AA…
+    LettersUpper,
+    /// Lowercase letters: a, b, …, z, aa…
+    LettersLower,
+}
+
+/// One page-numbering range, taking effect from `first_page` (0-based)
+/// until the next range's `first_page` or the document's end (ISO 32000
+/// §12.4.2). A document's `page_labels` must include a range with
+/// `first_page == 0` whenever it is non-empty.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageLabel {
+    /// 0-based page index where this range begins.
+    pub first_page: usize,
+    /// Numbering style, written as `/S`; `None` omits it, showing only
+    /// `prefix` for every page in the range.
+    pub style: Option<LabelStyle>,
+    /// Text prepended to every number in the range, written as `/P`.
+    pub prefix: Option<String>,
+    /// The number shown on `first_page`, written as `/St` only when not
+    /// `1`. Conventionally `1`.
+    pub start_at: u32,
+}
+
+/// Initial page-layout mode, written as the catalog's `/PageLayout` (ISO
+/// 32000 §7.7.2, Table 27).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PageLayout {
+    /// One page at a time.
+    SinglePage,
+    /// One continuously scrolling column of pages.
+    OneColumn,
+    /// Two columns, an odd-numbered page on the left.
+    TwoColumnLeft,
+    /// Two columns, an odd-numbered page on the right.
+    TwoColumnRight,
+    /// Two pages at a time, an odd-numbered page on the left.
+    TwoPageLeft,
+    /// Two pages at a time, an odd-numbered page on the right.
+    TwoPageRight,
+}
+
+/// Initial navigation-panel mode, written as the catalog's `/PageMode`
+/// (ISO 32000 §7.7.2, Table 28).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PageMode {
+    /// No panel open.
+    UseNone,
+    /// The outline (bookmarks) panel.
+    UseOutlines,
+    /// The page-thumbnails panel.
+    UseThumbs,
+    /// Full-screen presentation mode.
+    FullScreen,
+}
+
+/// Viewer preferences written to the catalog: initial layout, navigation
+/// mode, and the page opened at document start (ISO 32000 §7.7.2).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Viewer {
+    /// `/PageLayout`, omitted when `None`.
+    pub layout: Option<PageLayout>,
+    /// `/PageMode`, omitted when `None`.
+    pub mode: Option<PageMode>,
+    /// Page index opened at its top-left corner via `/OpenAction`,
+    /// omitted when `None`.
+    pub open_to: Option<usize>,
+}
+
 /// A document under construction. The fields are the composition:
 /// singleton slots are `Option`s, pages keep the order given.
 #[derive(Debug, Default)]
@@ -272,6 +351,13 @@ pub struct Pdf {
     /// by bytes, at emission — the name-tree keys must be sorted, so the
     /// order given here is not preserved. Duplicate names are an error.
     pub attachments: Vec<Attachment>,
+    /// Page-numbering ranges shown in viewer UI as `/PageLabels`.
+    /// Reordered by `first_page` at emission. Must include a range
+    /// starting at page 0 when non-empty; duplicate `first_page` values
+    /// are an error.
+    pub page_labels: Vec<PageLabel>,
+    /// Viewer preferences, if any.
+    pub viewer: Option<Viewer>,
     /// File-emission options.
     pub options: WriteOptions,
 }
@@ -313,6 +399,8 @@ impl Pdf {
             pages,
             outline,
             attachments,
+            page_labels,
+            viewer,
             options,
         } = self;
         if pages.is_empty() {
@@ -484,6 +572,7 @@ impl Pdf {
             _ => None,
         };
         let names = embedded_files_dict(&mut w, attachments)?;
+        let page_labels_entry = page_labels_dict(page_labels)?;
         let mut catalog = Dict::new();
         catalog.insert(name("Type"), Object::Name(name("Catalog")));
         catalog.insert(name("Pages"), Object::Ref(pages_root));
@@ -495,6 +584,42 @@ impl Pdf {
         }
         if let Some(names) = names {
             catalog.insert(name("Names"), Object::Dict(names));
+        }
+        if let Some(page_labels_entry) = page_labels_entry {
+            catalog.insert(name("PageLabels"), Object::Dict(page_labels_entry));
+        }
+        if let Some(viewer) = viewer {
+            let Viewer {
+                layout,
+                mode,
+                open_to,
+            } = viewer;
+            if let Some(layout) = layout {
+                catalog.insert(
+                    name("PageLayout"),
+                    Object::Name(name(page_layout_name(layout))),
+                );
+            }
+            if let Some(mode) = mode {
+                catalog.insert(name("PageMode"), Object::Name(name(page_mode_name(mode))));
+            }
+            if let Some(open_to) = open_to {
+                let target = page_refs.get(open_to).copied().ok_or_else(|| {
+                    Error::Other(format!(
+                        "open_to target page {open_to} is out of range: the document has {page_count} pages"
+                    ))
+                })?;
+                catalog.insert(
+                    name("OpenAction"),
+                    Object::Array(vec![
+                        Object::Ref(target),
+                        Object::Name(name("XYZ")),
+                        Object::Null,
+                        Object::Null,
+                        Object::Null,
+                    ]),
+                );
+            }
         }
         let root = w.put(Object::Dict(catalog));
         Ok((w, root))
@@ -612,6 +737,86 @@ fn embedded_files_dict(w: &mut Writer, mut attachments: Vec<Attachment>) -> Resu
     let mut embedded_files = Dict::new();
     embedded_files.insert(name("EmbeddedFiles"), Object::Dict(name_tree));
     Ok(Some(embedded_files))
+}
+
+/// Builds the catalog's `/PageLabels` dictionary from `labels`, or `None`
+/// when there are none. Ranges are reordered by `first_page` to satisfy
+/// the number tree's sorted-key requirement. A non-empty set must include
+/// a range starting at page 0; a repeated `first_page` is an error naming
+/// the page.
+fn page_labels_dict(mut labels: Vec<PageLabel>) -> Result<Option<Dict>> {
+    if labels.is_empty() {
+        return Ok(None);
+    }
+    labels.sort_by_key(|label| label.first_page);
+    if labels[0].first_page != 0 {
+        return Err(Error::Other("page labels must start at page 0".to_string()));
+    }
+    for pair in labels.windows(2) {
+        if pair[0].first_page == pair[1].first_page {
+            return Err(Error::Other(format!(
+                "duplicate page label at page {}",
+                pair[0].first_page
+            )));
+        }
+    }
+    let mut nums = Vec::with_capacity(labels.len() * 2);
+    for label in labels {
+        let PageLabel {
+            first_page,
+            style,
+            prefix,
+            start_at,
+        } = label;
+        let mut range = Dict::new();
+        if let Some(style) = style {
+            range.insert(name("S"), Object::Name(name(label_style_name(style))));
+        }
+        if let Some(prefix) = prefix {
+            range.insert(name("P"), text_string(&prefix));
+        }
+        if start_at != 1 {
+            range.insert(name("St"), Object::Int(i64::from(start_at)));
+        }
+        nums.push(Object::Int(first_page as i64));
+        nums.push(Object::Dict(range));
+    }
+    let mut dict = Dict::new();
+    dict.insert(name("Nums"), Object::Array(nums));
+    Ok(Some(dict))
+}
+
+/// The `/S` name for a [`LabelStyle`].
+fn label_style_name(style: LabelStyle) -> &'static str {
+    match style {
+        LabelStyle::Decimal => "D",
+        LabelStyle::RomanUpper => "R",
+        LabelStyle::RomanLower => "r",
+        LabelStyle::LettersUpper => "A",
+        LabelStyle::LettersLower => "a",
+    }
+}
+
+/// The `/PageLayout` name for a [`PageLayout`].
+fn page_layout_name(layout: PageLayout) -> &'static str {
+    match layout {
+        PageLayout::SinglePage => "SinglePage",
+        PageLayout::OneColumn => "OneColumn",
+        PageLayout::TwoColumnLeft => "TwoColumnLeft",
+        PageLayout::TwoColumnRight => "TwoColumnRight",
+        PageLayout::TwoPageLeft => "TwoPageLeft",
+        PageLayout::TwoPageRight => "TwoPageRight",
+    }
+}
+
+/// The `/PageMode` name for a [`PageMode`].
+fn page_mode_name(mode: PageMode) -> &'static str {
+    match mode {
+        PageMode::UseNone => "UseNone",
+        PageMode::UseOutlines => "UseOutlines",
+        PageMode::UseThumbs => "UseThumbs",
+        PageMode::FullScreen => "FullScreen",
+    }
 }
 
 /// One bookmark's reserved object number, mirroring the tree shape so the

--- a/crates/pdfboss-write/src/xmp.rs
+++ b/crates/pdfboss-write/src/xmp.rs
@@ -1,0 +1,191 @@
+//! XMP metadata packet generation. The packet is derived from the same
+//! `Metadata` value written to the `/Info` dictionary, so the two never
+//! drift apart. No `xmpMM:InstanceID`, no `xmpMM:DocumentID`, no generated
+//! timestamps: every value traces back to a caller-supplied field, keeping
+//! the packet as reproducible as the rest of the writer.
+
+use crate::pdf::Metadata;
+
+/// The fixed packet-wrapper id from the XMP specification — not a per-file
+/// document or instance identifier, the same constant appears in every
+/// XMP packet ever written.
+const PACKET_ID: &str = "W5M0MpCehiHzreSzNTczkc9d";
+
+/// Builds a minimal RDF/XMP packet from `meta`. Each `dc:`/`pdf:`/`xmp:`
+/// element is present only when its `Metadata` field is `Some`.
+pub(crate) fn packet(meta: &Metadata) -> Vec<u8> {
+    let mut elements = String::new();
+    if let Some(title) = &meta.title {
+        elements.push_str(&alt_element("dc:title", title));
+    }
+    if let Some(author) = &meta.author {
+        elements.push_str(&seq_element("dc:creator", author));
+    }
+    if let Some(subject) = &meta.subject {
+        elements.push_str(&alt_element("dc:description", subject));
+    }
+    if let Some(keywords) = &meta.keywords {
+        elements.push_str(&leaf_element("pdf:Keywords", keywords));
+    }
+    if let Some(producer) = &meta.producer {
+        elements.push_str(&leaf_element("pdf:Producer", producer));
+    }
+    if let Some(creator) = &meta.creator {
+        elements.push_str(&leaf_element("xmp:CreatorTool", creator));
+    }
+    if let Some(date) = meta.creation_date {
+        elements.push_str(&leaf_element("xmp:CreateDate", &date.to_iso8601()));
+    }
+    if let Some(date) = meta.modification_date {
+        elements.push_str(&leaf_element("xmp:ModifyDate", &date.to_iso8601()));
+    }
+    format!(
+        "<?xpacket begin=\"\u{feff}\" id=\"{PACKET_ID}\"?>\n\
+         <x:xmpmeta xmlns:x=\"adobe:ns:meta/\">\n\
+         <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n\
+         <rdf:Description rdf:about=\"\" \
+         xmlns:dc=\"http://purl.org/dc/elements/1.1/\" \
+         xmlns:pdf=\"http://ns.adobe.com/pdf/1.3/\" \
+         xmlns:xmp=\"http://ns.adobe.com/xap/1.0/\">\n\
+         {elements}</rdf:Description>\n\
+         </rdf:RDF>\n\
+         </x:xmpmeta>\n\
+         <?xpacket end=\"w\"?>"
+    )
+    .into_bytes()
+}
+
+/// One leaf element: `<tag>escaped-value</tag>`.
+fn leaf_element(tag: &str, value: &str) -> String {
+    format!("<{tag}>{}</{tag}>\n", escape(value))
+}
+
+/// An `rdf:Alt` element with a single `x-default` language alternative —
+/// the RDF shape XMP expects for free-text fields like title and
+/// description.
+fn alt_element(tag: &str, value: &str) -> String {
+    format!(
+        "<{tag}><rdf:Alt><rdf:li xml:lang=\"x-default\">{}</rdf:li></rdf:Alt></{tag}>\n",
+        escape(value)
+    )
+}
+
+/// An `rdf:Seq` element with a single entry — the RDF shape XMP expects
+/// for ordered lists like `dc:creator`.
+fn seq_element(tag: &str, value: &str) -> String {
+    format!(
+        "<{tag}><rdf:Seq><rdf:li>{}</rdf:li></rdf:Seq></{tag}>\n",
+        escape(value)
+    )
+}
+
+/// Escapes the five XML special characters in `value`.
+fn escape(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pdf::Date;
+
+    fn full_metadata() -> Metadata {
+        Metadata {
+            title: Some("Report".to_string()),
+            author: Some("Jane Doe".to_string()),
+            subject: Some("Quarterly numbers".to_string()),
+            keywords: Some("finance, quarterly".to_string()),
+            creator: Some("pdfboss".to_string()),
+            producer: Some("pdfboss-write".to_string()),
+            creation_date: Some(Date {
+                year: 2026,
+                month: 8,
+                day: 27,
+                hour: 12,
+                minute: 30,
+                second: 15,
+                utc_offset_minutes: 0,
+            }),
+            modification_date: Some(Date {
+                year: 2026,
+                month: 8,
+                day: 28,
+                hour: 9,
+                minute: 0,
+                second: 0,
+                utc_offset_minutes: 120,
+            }),
+        }
+    }
+
+    fn text(bytes: Vec<u8>) -> String {
+        String::from_utf8(bytes).expect("packet is valid UTF-8")
+    }
+
+    #[test]
+    fn full_metadata_maps_every_field() {
+        let xml = text(packet(&full_metadata()));
+        assert!(xml.contains(
+            "<dc:title><rdf:Alt><rdf:li xml:lang=\"x-default\">Report</rdf:li></rdf:Alt></dc:title>"
+        ));
+        assert!(
+            xml.contains("<dc:creator><rdf:Seq><rdf:li>Jane Doe</rdf:li></rdf:Seq></dc:creator>")
+        );
+        assert!(xml.contains(
+            "<dc:description><rdf:Alt><rdf:li xml:lang=\"x-default\">Quarterly numbers</rdf:li></rdf:Alt></dc:description>"
+        ));
+        assert!(xml.contains("<pdf:Keywords>finance, quarterly</pdf:Keywords>"));
+        assert!(xml.contains("<pdf:Producer>pdfboss-write</pdf:Producer>"));
+        assert!(xml.contains("<xmp:CreatorTool>pdfboss</xmp:CreatorTool>"));
+        assert!(xml.contains("<xmp:CreateDate>2026-08-27T12:30:15Z</xmp:CreateDate>"));
+        assert!(xml.contains("<xmp:ModifyDate>2026-08-28T09:00:00+02:00</xmp:ModifyDate>"));
+    }
+
+    #[test]
+    fn absent_fields_write_no_element() {
+        let xml = text(packet(&Metadata::default()));
+        assert!(!xml.contains("dc:title"));
+        assert!(!xml.contains("dc:creator"));
+        assert!(!xml.contains("dc:description"));
+        assert!(!xml.contains("pdf:Keywords"));
+        assert!(!xml.contains("pdf:Producer"));
+        assert!(!xml.contains("xmp:CreatorTool"));
+        assert!(!xml.contains("xmp:CreateDate"));
+        assert!(!xml.contains("xmp:ModifyDate"));
+    }
+
+    #[test]
+    fn never_contains_instance_or_document_ids() {
+        let xml = text(packet(&full_metadata()));
+        assert!(!xml.contains("InstanceID"));
+        assert!(!xml.contains("DocumentID"));
+        assert!(!xml.contains("xmpMM"));
+    }
+
+    #[test]
+    fn special_characters_are_escaped() {
+        let meta = Metadata {
+            title: Some("<&>\"'".to_string()),
+            ..Metadata::default()
+        };
+        let xml = text(packet(&meta));
+        assert!(xml.contains("&lt;&amp;&gt;&quot;&apos;"));
+        assert!(!xml.contains("<&>\"'"));
+    }
+
+    #[test]
+    fn same_metadata_produces_identical_packets() {
+        assert_eq!(packet(&full_metadata()), packet(&full_metadata()));
+    }
+}

--- a/crates/pdfboss-write/tests/roundtrip.rs
+++ b/crates/pdfboss-write/tests/roundtrip.rs
@@ -8,8 +8,9 @@ use pdfboss_core::{Dict, Document, Name, Object, Rect, Stream};
 use pdfboss_output::extract_text;
 use pdfboss_render::{render_page_reporting, RenderOptions};
 use pdfboss_write::{
-    Attachment, Bookmark, Color, Content, Date, Error, ImageData, Link, LinkAnnotation, LinkTarget,
-    Metadata, Outline, Page, PageSize, Paragraph, Pdf, Standard14, WriteOptions, XrefStyle,
+    Attachment, Bookmark, Color, Content, Date, Error, ImageData, LabelStyle, Link, LinkAnnotation,
+    LinkTarget, Metadata, Outline, Page, PageLabel, PageLayout, PageMode, PageSize, Paragraph, Pdf,
+    Standard14, Viewer, WriteOptions, XrefStyle,
 };
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
@@ -60,6 +61,8 @@ fn metadata_and_multipage_round_trip() {
         pages: vec![Page::new(PageSize::A4), second, Page::new(PageSize::Letter)],
         outline: None,
         attachments: Vec::new(),
+        page_labels: Vec::new(),
+        viewer: None,
         options: WriteOptions::default(),
     };
     let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
@@ -220,6 +223,8 @@ fn two_page_document() -> Pdf {
         pages: vec![first, second],
         outline: None,
         attachments: Vec::new(),
+        page_labels: Vec::new(),
+        viewer: None,
         options: WriteOptions::default(),
     }
 }
@@ -924,6 +929,222 @@ fn attachments_document_serializes_byte_identically() {
                 attachment("b.txt", b"B", Some("text/plain")),
                 attachment("a.txt", b"A", Some("text/plain")),
             ],
+            ..Pdf::default()
+        }
+        .to_bytes()
+        .unwrap()
+    }
+    assert_eq!(build(), build());
+}
+
+fn four_pages() -> Vec<Page> {
+    (0..4).map(|_| Page::new(PageSize::A4)).collect()
+}
+
+/// The design's own use case: roman-numeral front matter for pages 0–1,
+/// then a decimal range from page 2 on with a chapter prefix and a
+/// numbering offset — `/PageLabels /Nums` must carry both ranges, sorted
+/// by `first_page`, each with the right `/S`, `/P` and `/St`.
+#[test]
+fn page_labels_resolve_roman_front_matter_and_offset_decimal() {
+    let pdf = Pdf {
+        pages: four_pages(),
+        page_labels: vec![
+            PageLabel {
+                first_page: 0,
+                style: Some(LabelStyle::RomanLower),
+                prefix: None,
+                start_at: 1,
+            },
+            PageLabel {
+                first_page: 2,
+                style: Some(LabelStyle::Decimal),
+                prefix: Some("A-".to_string()),
+                start_at: 5,
+            },
+        ],
+        ..Pdf::default()
+    };
+    let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
+    let page_labels = catalog(&doc)
+        .get_dict("PageLabels")
+        .expect("/PageLabels present")
+        .clone();
+    let nums = page_labels.get_array("Nums").expect("/Nums present");
+    assert_eq!(nums.len(), 4, "two ranges make four Nums slots");
+
+    let keys: Vec<i64> = (0..2)
+        .map(|range_index| nums[range_index * 2].as_int().expect("key is an int"))
+        .collect();
+    assert_eq!(keys, vec![0, 2]);
+
+    let front_matter = nums[1].as_dict().expect("range dict");
+    assert_eq!(front_matter.get_name("S"), Some(&Name("r".into())));
+    assert!(front_matter.get("P").is_none());
+    assert!(front_matter.get("St").is_none());
+
+    let body = nums[3].as_dict().expect("range dict");
+    assert_eq!(body.get_name("S"), Some(&Name("D".into())));
+    assert_eq!(
+        decode_text_string(body.get("P").expect("/P present").as_str_bytes().unwrap()),
+        "A-"
+    );
+    assert_eq!(body.get_int("St"), Some(5));
+}
+
+#[test]
+fn page_labels_missing_zero_page_errors() {
+    let pdf = Pdf {
+        pages: four_pages(),
+        page_labels: vec![PageLabel {
+            first_page: 1,
+            style: Some(LabelStyle::Decimal),
+            prefix: None,
+            start_at: 1,
+        }],
+        ..Pdf::default()
+    };
+    let err = pdf.to_bytes().unwrap_err();
+    match err {
+        Error::Other(msg) => assert!(msg.contains("page 0"), "{msg}"),
+        other => panic!("expected Error::Other naming page 0, got {other:?}"),
+    }
+}
+
+#[test]
+fn page_labels_duplicate_first_page_errors() {
+    let pdf = Pdf {
+        pages: four_pages(),
+        page_labels: vec![
+            PageLabel {
+                first_page: 0,
+                style: None,
+                prefix: None,
+                start_at: 1,
+            },
+            PageLabel {
+                first_page: 0,
+                style: Some(LabelStyle::RomanUpper),
+                prefix: None,
+                start_at: 1,
+            },
+        ],
+        ..Pdf::default()
+    };
+    let err = pdf.to_bytes().unwrap_err();
+    match err {
+        Error::Other(msg) => assert!(msg.contains('0'), "{msg}"),
+        other => panic!("expected Error::Other naming the duplicate page, got {other:?}"),
+    }
+}
+
+#[test]
+fn no_page_labels_emits_no_page_labels_entry() {
+    let bytes = Pdf {
+        pages: vec![Page::new(PageSize::A4)],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    assert!(catalog(&doc).get("PageLabels").is_none());
+}
+
+/// Viewer preferences resolve structurally: `/PageLayout` and `/PageMode`
+/// as catalog names, `/OpenAction` as an `/XYZ` destination landing on the
+/// requested page.
+#[test]
+fn viewer_preferences_resolve_layout_mode_and_open_to() {
+    let pdf = Pdf {
+        pages: vec![Page::new(PageSize::A4), Page::new(PageSize::Letter)],
+        viewer: Some(Viewer {
+            layout: Some(PageLayout::TwoColumnLeft),
+            mode: Some(PageMode::UseOutlines),
+            open_to: Some(1),
+        }),
+        ..Pdf::default()
+    };
+    let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
+    let catalog = catalog(&doc);
+    assert_eq!(
+        catalog.get_name("PageLayout"),
+        Some(&Name("TwoColumnLeft".into()))
+    );
+    assert_eq!(
+        catalog.get_name("PageMode"),
+        Some(&Name("UseOutlines".into()))
+    );
+    let open_action = catalog
+        .get_array("OpenAction")
+        .expect("/OpenAction present");
+    assert_eq!(open_action.len(), 5);
+    assert_eq!(open_action[1].as_name(), Some(&Name("XYZ".into())));
+    assert!(open_action[2].is_null() && open_action[3].is_null() && open_action[4].is_null());
+    let target = doc
+        .resolve(&open_action[0])
+        .expect("/OpenAction target resolves");
+    let target = target.as_dict().expect("target is a dictionary");
+    assert_eq!(target.get_name("Type"), Some(&Name("Page".into())));
+    let media_box = target.get_array("MediaBox").expect("/MediaBox present");
+    assert_eq!(media_box[2].as_f64(), Some(612.0));
+    assert_eq!(media_box[3].as_f64(), Some(792.0));
+}
+
+#[test]
+fn no_viewer_emits_no_viewer_entries() {
+    let bytes = Pdf {
+        pages: vec![Page::new(PageSize::A4)],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let catalog = catalog(&doc);
+    assert!(catalog.get("PageLayout").is_none());
+    assert!(catalog.get("PageMode").is_none());
+    assert!(catalog.get("OpenAction").is_none());
+}
+
+#[test]
+fn viewer_open_to_out_of_range_errors() {
+    let pdf = Pdf {
+        pages: vec![Page::new(PageSize::A4)],
+        viewer: Some(Viewer {
+            open_to: Some(5),
+            ..Viewer::default()
+        }),
+        ..Pdf::default()
+    };
+    let err = pdf.to_bytes().unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("out of range"), "{msg}");
+    assert!(msg.contains("open_to"), "{msg}");
+}
+
+#[test]
+fn page_labels_and_viewer_document_serializes_byte_identically() {
+    fn build() -> Vec<u8> {
+        Pdf {
+            pages: four_pages(),
+            page_labels: vec![
+                PageLabel {
+                    first_page: 0,
+                    style: Some(LabelStyle::RomanLower),
+                    prefix: None,
+                    start_at: 1,
+                },
+                PageLabel {
+                    first_page: 2,
+                    style: Some(LabelStyle::Decimal),
+                    prefix: Some("A-".to_string()),
+                    start_at: 5,
+                },
+            ],
+            viewer: Some(Viewer {
+                layout: Some(PageLayout::TwoColumnLeft),
+                mode: Some(PageMode::UseOutlines),
+                open_to: Some(1),
+            }),
             ..Pdf::default()
         }
         .to_bytes()

--- a/crates/pdfboss-write/tests/roundtrip.rs
+++ b/crates/pdfboss-write/tests/roundtrip.rs
@@ -7,8 +7,8 @@ use pdfboss_core::{Document, Name, Rect};
 use pdfboss_output::extract_text;
 use pdfboss_render::{render_page_reporting, RenderOptions};
 use pdfboss_write::{
-    Color, Date, Error, ImageData, LinkAnnotation, LinkTarget, Metadata, Page, PageSize, Pdf,
-    Standard14, WriteOptions, XrefStyle,
+    Color, Content, Date, Error, ImageData, Link, LinkAnnotation, LinkTarget, Metadata, Page,
+    PageSize, Pdf, Standard14, WriteOptions, XrefStyle,
 };
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
@@ -322,6 +322,34 @@ fn goto_links_resolve_to_their_page() {
         resolved_page_types.push(page_type.0.clone());
     }
     assert_eq!(resolved_page_types, vec!["Page".to_string()]);
+}
+
+#[test]
+fn link_element_lands_in_page_links() {
+    let mut page = Page::new(PageSize::A4);
+    page.content.push(Content::from(Link {
+        rect: [10.0, 10.0, 60.0, 24.0],
+        target: LinkTarget::Uri("https://example.com".into()),
+    }));
+    let bytes = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let loaded = doc.page(0).unwrap();
+    let annots = loaded.dict().get_array("Annots").unwrap_or(&[]);
+    assert_eq!(annots.len(), 1);
+    let annot = doc.resolve(&annots[0]).unwrap();
+    let annot = annot.as_dict().unwrap();
+    assert_eq!(annot.get_name("Subtype"), Some(&Name("Link".into())));
+    let action = annot.get_dict("A").unwrap();
+    assert_eq!(action.get_name("S"), Some(&Name("URI".into())));
+    assert_eq!(
+        action.get("URI").unwrap().as_str_bytes(),
+        Some(b"https://example.com".as_slice())
+    );
 }
 
 #[test]

--- a/crates/pdfboss-write/tests/roundtrip.rs
+++ b/crates/pdfboss-write/tests/roundtrip.rs
@@ -3,12 +3,13 @@
 //! rasterized with `pdfboss-render`, so the writer is verified against the
 //! toolkit's own readers rather than against expected byte dumps.
 
-use pdfboss_core::{Document, Name, Rect};
+use pdfboss_core::object::decode_text_string;
+use pdfboss_core::{Dict, Document, Name, Object, Rect};
 use pdfboss_output::extract_text;
 use pdfboss_render::{render_page_reporting, RenderOptions};
 use pdfboss_write::{
-    Color, Content, Date, Error, ImageData, Link, LinkAnnotation, LinkTarget, Metadata, Page,
-    PageSize, Paragraph, Pdf, Standard14, WriteOptions, XrefStyle,
+    Bookmark, Color, Content, Date, Error, ImageData, Link, LinkAnnotation, LinkTarget, Metadata,
+    Outline, Page, PageSize, Paragraph, Pdf, Standard14, WriteOptions, XrefStyle,
 };
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
@@ -57,6 +58,7 @@ fn metadata_and_multipage_round_trip() {
             ..Metadata::default()
         }),
         pages: vec![Page::new(PageSize::A4), second, Page::new(PageSize::Letter)],
+        outline: None,
         options: WriteOptions::default(),
     };
     let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
@@ -215,6 +217,7 @@ fn two_page_document() -> Pdf {
             ..Metadata::default()
         }),
         pages: vec![first, second],
+        outline: None,
         options: WriteOptions::default(),
     }
 }
@@ -401,6 +404,172 @@ fn goto_link_out_of_range_errors() {
     .to_bytes()
     .unwrap_err();
     assert!(err.to_string().contains("out of range"));
+}
+
+/// Resolves an object to its dictionary, cloned so the borrow does not
+/// outlive a temporary `Document::resolve` result.
+fn resolve_dict(doc: &Document, obj: &Object) -> Dict {
+    doc.resolve(obj)
+        .expect("reference resolves")
+        .as_dict()
+        .expect("resolved object is a dictionary")
+        .clone()
+}
+
+/// The catalog dictionary reached from the trailer's `/Root`.
+fn catalog(doc: &Document) -> Dict {
+    let root = doc
+        .xref()
+        .trailer
+        .get("Root")
+        .expect("/Root present")
+        .clone();
+    resolve_dict(doc, &root)
+}
+
+/// Asserts an outline item's `/Dest` resolves to a `/Type /Page` dict whose
+/// `/MediaBox` matches `expected` — distinguishing "resolves to some page"
+/// from "resolves to the right page".
+fn assert_dest_page(doc: &Document, item: &Dict, expected: PageSize) {
+    let dest = item.get_array("Dest").expect("/Dest present");
+    assert_eq!(dest.len(), 5);
+    assert_eq!(dest[1].as_name(), Some(&Name("XYZ".into())));
+    assert!(dest[2].is_null() && dest[3].is_null() && dest[4].is_null());
+    let target = doc.resolve(&dest[0]).expect("/Dest target resolves");
+    let target = target.as_dict().expect("/Dest target is a dictionary");
+    assert_eq!(target.get_name("Type"), Some(&Name("Page".into())));
+    let media_box = target.get_array("MediaBox").expect("/MediaBox present");
+    let (width, height) = expected.dimensions();
+    assert_eq!(media_box[2].as_f64(), Some(f64::from(width)));
+    assert_eq!(media_box[3].as_f64(), Some(f64::from(height)));
+}
+
+fn title_of(item: &Dict) -> String {
+    decode_text_string(
+        item.get("Title")
+            .expect("/Title present")
+            .as_str_bytes()
+            .expect("/Title is a string"),
+    )
+}
+
+/// Two top-level bookmarks, the first with one nested child — each pointing
+/// at a page of a distinct size, so a `/Dest` that resolves to the wrong
+/// page shows up as a mismatched `/MediaBox` rather than passing by luck.
+#[test]
+fn outline_tree_walks_prev_next_and_dest_pages() {
+    let pages: Vec<Page> = [PageSize::A4, PageSize::Letter, PageSize::A5]
+        .into_iter()
+        .map(Page::new)
+        .collect();
+    let bookmarks = vec![
+        Bookmark {
+            title: "Chapter One".to_string(),
+            page: 0,
+            children: vec![Bookmark::new("Section 1.1", 1)],
+        },
+        Bookmark::new("Chapter Two", 2),
+    ];
+    let bytes = Pdf {
+        pages,
+        outline: Some(Outline { bookmarks }),
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+
+    let catalog = catalog(&doc);
+    let outlines_obj = catalog.get("Outlines").expect("/Outlines present").clone();
+    let outlines = resolve_dict(&doc, &outlines_obj);
+    assert_eq!(outlines.get_name("Type"), Some(&Name("Outlines".into())));
+    assert_eq!(outlines.get_int("Count"), Some(3));
+
+    let first_obj = outlines.get("First").expect("/First present").clone();
+    let chapter_one = resolve_dict(&doc, &first_obj);
+    assert_eq!(title_of(&chapter_one), "Chapter One");
+    assert_eq!(chapter_one.get_ref("Parent"), outlines_obj.as_ref());
+    assert!(chapter_one.get("Prev").is_none());
+    assert_eq!(chapter_one.get_int("Count"), Some(1));
+
+    let next_obj = chapter_one.get("Next").expect("/Next present").clone();
+    let chapter_two = resolve_dict(&doc, &next_obj);
+    assert_eq!(title_of(&chapter_two), "Chapter Two");
+    assert_eq!(chapter_two.get_ref("Prev"), first_obj.as_ref());
+    assert_eq!(chapter_two.get_ref("Parent"), outlines_obj.as_ref());
+    assert!(chapter_two.get("Next").is_none());
+    assert!(chapter_two.get("First").is_none());
+    assert!(chapter_two.get("Count").is_none());
+    assert_eq!(outlines.get("Last").unwrap().as_ref(), next_obj.as_ref());
+
+    let child_obj = chapter_one.get("First").expect("/First present").clone();
+    assert_eq!(
+        chapter_one.get("Last").unwrap().as_ref(),
+        child_obj.as_ref()
+    );
+    let section = resolve_dict(&doc, &child_obj);
+    assert_eq!(title_of(&section), "Section 1.1");
+    assert_eq!(section.get_ref("Parent"), first_obj.as_ref());
+    assert!(section.get("Prev").is_none());
+    assert!(section.get("Next").is_none());
+    assert!(section.get("First").is_none());
+    assert!(section.get("Count").is_none());
+
+    assert_dest_page(&doc, &chapter_one, PageSize::A4);
+    assert_dest_page(&doc, &section, PageSize::Letter);
+    assert_dest_page(&doc, &chapter_two, PageSize::A5);
+}
+
+#[test]
+fn outline_document_serializes_byte_identically() {
+    fn build() -> Vec<u8> {
+        Pdf {
+            pages: vec![Page::new(PageSize::A4), Page::new(PageSize::A4)],
+            outline: Some(Outline {
+                bookmarks: vec![
+                    Bookmark::new("One", 0),
+                    Bookmark {
+                        title: "Two".to_string(),
+                        page: 1,
+                        children: vec![Bookmark::new("Two.a", 0), Bookmark::new("Two.b", 1)],
+                    },
+                ],
+            }),
+            ..Pdf::default()
+        }
+        .to_bytes()
+        .unwrap()
+    }
+    assert_eq!(build(), build());
+}
+
+#[test]
+fn empty_outline_emits_no_outlines_entry() {
+    let bytes = Pdf {
+        pages: vec![Page::new(PageSize::A4)],
+        outline: Some(Outline::default()),
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    assert!(catalog(&doc).get("Outlines").is_none());
+}
+
+#[test]
+fn bookmark_out_of_range_page_errors() {
+    let err = Pdf {
+        pages: vec![Page::new(PageSize::A4)],
+        outline: Some(Outline {
+            bookmarks: vec![Bookmark::new("Nowhere", 9)],
+        }),
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("out of range"), "{msg}");
+    assert!(msg.contains("bookmark"), "{msg}");
 }
 
 #[test]

--- a/crates/pdfboss-write/tests/roundtrip.rs
+++ b/crates/pdfboss-write/tests/roundtrip.rs
@@ -4,7 +4,7 @@
 //! toolkit's own readers rather than against expected byte dumps.
 
 use pdfboss_core::object::decode_text_string;
-use pdfboss_core::{Dict, Document, Name, Object, Rect};
+use pdfboss_core::{Dict, Document, Name, Object, Rect, Stream};
 use pdfboss_output::extract_text;
 use pdfboss_render::{render_page_reporting, RenderOptions};
 use pdfboss_write::{
@@ -425,6 +425,139 @@ fn catalog(doc: &Document) -> Dict {
         .expect("/Root present")
         .clone();
     resolve_dict(doc, &root)
+}
+
+/// Resolves an object to its stream, cloned so the borrow does not outlive
+/// a temporary `Document::resolve` result.
+fn resolve_stream(doc: &Document, obj: &Object) -> Stream {
+    doc.resolve(obj)
+        .expect("reference resolves")
+        .as_stream()
+        .expect("resolved object is a stream")
+        .clone()
+}
+
+/// The catalog's `/Metadata` stream, decoded, or `None` when the catalog
+/// carries no such entry.
+fn xmp_packet(doc: &Document) -> Option<String> {
+    let entry = catalog(doc).get("Metadata")?.clone();
+    let stream = resolve_stream(doc, &entry);
+    assert_eq!(stream.dict.get_name("Type"), Some(&Name("Metadata".into())));
+    assert_eq!(stream.dict.get_name("Subtype"), Some(&Name("XML".into())));
+    assert!(
+        stream.dict.get("Filter").is_none(),
+        "the XMP stream must stay uncompressed regardless of WriteOptions::compress"
+    );
+    let bytes = doc.stream_data(&stream).expect("XMP stream decodes");
+    Some(String::from_utf8(bytes).expect("XMP packet is valid UTF-8"))
+}
+
+#[test]
+fn xmp_packet_maps_full_metadata_and_stays_uncompressed() {
+    let pdf = Pdf {
+        metadata: Some(Metadata {
+            title: Some("Q3 & Q4 Report".into()),
+            author: Some("Jane Doe".into()),
+            subject: Some("Quarterly numbers".into()),
+            keywords: Some("finance, quarterly".into()),
+            creator: Some("pdfboss".into()),
+            producer: Some("pdfboss-write".into()),
+            creation_date: Some(Date {
+                year: 2026,
+                month: 8,
+                day: 27,
+                hour: 12,
+                minute: 30,
+                second: 15,
+                utc_offset_minutes: 0,
+            }),
+            modification_date: Some(Date {
+                year: 2026,
+                month: 8,
+                day: 28,
+                hour: 9,
+                minute: 0,
+                second: 0,
+                utc_offset_minutes: 120,
+            }),
+        }),
+        pages: vec![Page::new(PageSize::A4)],
+        options: WriteOptions {
+            compress: true,
+            ..WriteOptions::default()
+        },
+        ..Pdf::default()
+    };
+    let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
+    let xml = xmp_packet(&doc).expect("/Metadata present when metadata is Some");
+    assert!(xml.contains("Q3 &amp; Q4 Report"), "{xml}");
+    assert!(xml.contains("Jane Doe"), "{xml}");
+    assert!(xml.contains("pdfboss-write"), "{xml}");
+    assert!(xml.contains("2026-08-27T12:30:15Z"), "{xml}");
+    assert!(xml.contains("2026-08-28T09:00:00+02:00"), "{xml}");
+    assert!(!xml.contains("InstanceID"), "{xml}");
+    assert!(!xml.contains("DocumentID"), "{xml}");
+    let meta = doc.metadata();
+    assert_eq!(meta.title.as_deref(), Some("Q3 & Q4 Report"));
+    assert_eq!(meta.author.as_deref(), Some("Jane Doe"));
+}
+
+#[test]
+fn xmp_packet_escapes_all_five_special_characters() {
+    let pdf = Pdf {
+        metadata: Some(Metadata {
+            title: Some("<&>\"'".into()),
+            ..Metadata::default()
+        }),
+        pages: vec![Page::new(PageSize::A4)],
+        ..Pdf::default()
+    };
+    let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
+    let xml = xmp_packet(&doc).expect("/Metadata present when metadata is Some");
+    assert!(xml.contains("&lt;&amp;&gt;&quot;&apos;"), "{xml}");
+    assert!(!xml.contains("<&>\"'"), "{xml}");
+}
+
+#[test]
+fn xmp_packet_is_deterministic_across_builds() {
+    fn build() -> Vec<u8> {
+        Pdf {
+            metadata: Some(Metadata {
+                title: Some("Determinism".into()),
+                creation_date: Some(Date {
+                    year: 2026,
+                    month: 8,
+                    day: 27,
+                    hour: 0,
+                    minute: 0,
+                    second: 0,
+                    utc_offset_minutes: 0,
+                }),
+                ..Metadata::default()
+            }),
+            pages: vec![Page::new(PageSize::A4)],
+            ..Pdf::default()
+        }
+        .to_bytes()
+        .unwrap()
+    }
+    let first = build();
+    let second = build();
+    assert_eq!(first, second);
+    let doc = Document::load(first).unwrap();
+    let xml = xmp_packet(&doc).expect("/Metadata present when metadata is Some");
+    assert!(xml.contains("Determinism"), "{xml}");
+}
+
+#[test]
+fn no_metadata_writes_no_xmp_stream() {
+    let pdf = Pdf {
+        metadata: None,
+        pages: vec![Page::new(PageSize::A4)],
+        ..Pdf::default()
+    };
+    let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
+    assert!(catalog(&doc).get("Metadata").is_none());
 }
 
 /// Asserts an outline item's `/Dest` resolves to a `/Type /Page` dict whose

--- a/crates/pdfboss-write/tests/roundtrip.rs
+++ b/crates/pdfboss-write/tests/roundtrip.rs
@@ -8,7 +8,7 @@ use pdfboss_output::extract_text;
 use pdfboss_render::{render_page_reporting, RenderOptions};
 use pdfboss_write::{
     Color, Content, Date, Error, ImageData, Link, LinkAnnotation, LinkTarget, Metadata, Page,
-    PageSize, Pdf, Standard14, WriteOptions, XrefStyle,
+    PageSize, Paragraph, Pdf, Standard14, WriteOptions, XrefStyle,
 };
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
@@ -349,6 +349,41 @@ fn link_element_lands_in_page_links() {
     assert_eq!(
         action.get("URI").unwrap().as_str_bytes(),
         Some(b"https://example.com".as_slice())
+    );
+}
+
+#[test]
+fn paragraph_wraps_and_extracts_across_lines() {
+    let mut page = Page::new(PageSize::A4);
+    page.content.push(Content::from(Paragraph {
+        text: "aaaaaaaaa bbbbbbbbbb cccccccccc".into(),
+        rect: [72.0, 680.0, 192.0, 780.0],
+        font: Standard14::Courier,
+        size: 10.0,
+        ..Paragraph::default()
+    }));
+    let bytes = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let loaded = doc.page(0).unwrap();
+    let text = extract_text(&doc, &loaded).unwrap();
+    assert!(
+        text.contains("aaaaaaaaa bbbbbbbbbb"),
+        "expected the first wrapped line intact, got {text:?}"
+    );
+    assert!(
+        text.contains("cccccccccc"),
+        "expected the second wrapped line intact, got {text:?}"
+    );
+    let first_line_pos = text.find("aaaaaaaaa").expect("first line present");
+    let second_line_pos = text.find("cccccccccc").expect("second line present");
+    assert!(
+        first_line_pos < second_line_pos,
+        "wrapped lines should extract in top-to-bottom order: {text:?}"
     );
 }
 

--- a/crates/pdfboss-write/tests/roundtrip.rs
+++ b/crates/pdfboss-write/tests/roundtrip.rs
@@ -1033,8 +1033,27 @@ fn page_labels_duplicate_first_page_errors() {
     };
     let err = pdf.to_bytes().unwrap_err();
     match err {
-        Error::Other(msg) => assert!(msg.contains('0'), "{msg}"),
+        Error::Other(msg) => assert!(msg.contains("duplicate page label at page 0"), "{msg}"),
         other => panic!("expected Error::Other naming the duplicate page, got {other:?}"),
+    }
+}
+
+#[test]
+fn page_labels_zero_start_at_errors() {
+    let pdf = Pdf {
+        pages: four_pages(),
+        page_labels: vec![PageLabel {
+            first_page: 0,
+            style: Some(LabelStyle::Decimal),
+            prefix: None,
+            start_at: 0,
+        }],
+        ..Pdf::default()
+    };
+    let err = pdf.to_bytes().unwrap_err();
+    match err {
+        Error::Other(msg) => assert!(msg.contains("page label at page 0 has start_at 0"), "{msg}"),
+        other => panic!("expected Error::Other naming the zero start_at, got {other:?}"),
     }
 }
 

--- a/crates/pdfboss-write/tests/roundtrip.rs
+++ b/crates/pdfboss-write/tests/roundtrip.rs
@@ -7,8 +7,8 @@ use pdfboss_core::{Document, Name, Rect};
 use pdfboss_output::extract_text;
 use pdfboss_render::{render_page_reporting, RenderOptions};
 use pdfboss_write::{
-    Color, Date, Error, ImageData, LinkAnnotation, Metadata, Page, PageSize, Pdf, Standard14,
-    WriteOptions, XrefStyle,
+    Color, Date, Error, ImageData, LinkAnnotation, LinkTarget, Metadata, Page, PageSize, Pdf,
+    Standard14, WriteOptions, XrefStyle,
 };
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
@@ -267,7 +267,7 @@ fn link_annotations_round_trip() {
         .unwrap();
     page.links.push(LinkAnnotation {
         rect: [72.0, 697.0, 130.0, 712.0],
-        uri: "https://example.com/docs".to_string(),
+        target: LinkTarget::Uri("https://example.com/docs".to_string()),
     });
     let bytes = Pdf {
         pages: vec![page],
@@ -284,6 +284,60 @@ fn link_annotations_round_trip() {
     assert!(contains(&bytes, b"https://example.com/docs"));
     let doc = Document::load(bytes).unwrap();
     assert_eq!(doc.page_count(), 1);
+}
+
+#[test]
+fn goto_links_resolve_to_their_page() {
+    let mut first = Page::new(PageSize::A4);
+    first
+        .canvas
+        .text("to appendix", 72.0, 700.0, Standard14::Helvetica, 12.0)
+        .unwrap();
+    first.links.push(LinkAnnotation {
+        rect: [72.0, 697.0, 150.0, 712.0],
+        target: LinkTarget::Page(1),
+    });
+    let second = Page::new(PageSize::A4);
+    let bytes = Pdf {
+        pages: vec![first, second],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    assert_eq!(doc.page_count(), 2);
+    let page = doc.page(0).unwrap();
+    let annots = page.dict().get_array("Annots").unwrap_or(&[]);
+    let mut resolved_page_types: Vec<String> = Vec::new();
+    for annot in annots {
+        let annot = doc.resolve(annot).unwrap();
+        let annot = annot.as_dict().unwrap();
+        let action = annot.get_dict("A").unwrap();
+        let subtype = action.get("S").unwrap().as_name().unwrap();
+        assert_eq!(subtype.0, "GoTo");
+        let destination = action.get_array("D").unwrap();
+        let target = doc.resolve(&destination[0]).unwrap();
+        let target = target.as_dict().unwrap();
+        let page_type = target.get("Type").unwrap().as_name().unwrap();
+        resolved_page_types.push(page_type.0.clone());
+    }
+    assert_eq!(resolved_page_types, vec!["Page".to_string()]);
+}
+
+#[test]
+fn goto_link_out_of_range_errors() {
+    let mut page = Page::new(PageSize::A4);
+    page.links.push(LinkAnnotation {
+        rect: [0.0, 0.0, 1.0, 1.0],
+        target: LinkTarget::Page(7),
+    });
+    let err = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap_err();
+    assert!(err.to_string().contains("out of range"));
 }
 
 #[test]

--- a/crates/pdfboss-write/tests/roundtrip.rs
+++ b/crates/pdfboss-write/tests/roundtrip.rs
@@ -8,8 +8,8 @@ use pdfboss_core::{Dict, Document, Name, Object, Rect, Stream};
 use pdfboss_output::extract_text;
 use pdfboss_render::{render_page_reporting, RenderOptions};
 use pdfboss_write::{
-    Bookmark, Color, Content, Date, Error, ImageData, Link, LinkAnnotation, LinkTarget, Metadata,
-    Outline, Page, PageSize, Paragraph, Pdf, Standard14, WriteOptions, XrefStyle,
+    Attachment, Bookmark, Color, Content, Date, Error, ImageData, Link, LinkAnnotation, LinkTarget,
+    Metadata, Outline, Page, PageSize, Paragraph, Pdf, Standard14, WriteOptions, XrefStyle,
 };
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
@@ -59,6 +59,7 @@ fn metadata_and_multipage_round_trip() {
         }),
         pages: vec![Page::new(PageSize::A4), second, Page::new(PageSize::Letter)],
         outline: None,
+        attachments: Vec::new(),
         options: WriteOptions::default(),
     };
     let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
@@ -218,6 +219,7 @@ fn two_page_document() -> Pdf {
         }),
         pages: vec![first, second],
         outline: None,
+        attachments: Vec::new(),
         options: WriteOptions::default(),
     }
 }
@@ -711,4 +713,221 @@ fn decode_sniffs_png_and_jpeg_by_content() {
     assert!(ImageData::decode(b"plain text").is_err());
     let jpeg = tiny_jpeg(4, 4);
     assert_eq!(ImageData::decode(&jpeg).unwrap().width(), 4);
+}
+
+/// The `/Names /EmbeddedFiles /Names` array, as raw entries: alternating
+/// name-tree keys and refs, straight off the catalog with no indirection
+/// in between (the writer nests `/Names` and `/EmbeddedFiles` directly).
+fn embedded_files_entries(doc: &Document) -> Vec<Object> {
+    catalog(doc)
+        .get_dict("Names")
+        .expect("/Names present")
+        .get_dict("EmbeddedFiles")
+        .expect("/EmbeddedFiles present")
+        .get_array("Names")
+        .expect("/EmbeddedFiles /Names array present")
+        .to_vec()
+}
+
+fn attachment(name: &str, data: &[u8], mime: Option<&str>) -> Attachment {
+    Attachment {
+        name: name.to_string(),
+        data: data.to_vec(),
+        mime: mime.map(str::to_string),
+        modified: None,
+        description: None,
+    }
+}
+
+#[test]
+fn no_attachments_emits_no_names_entry() {
+    let bytes = Pdf {
+        pages: vec![Page::new(PageSize::A4)],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    assert!(catalog(&doc).get("Names").is_none());
+}
+
+/// Two attachments given in reverse lexical order must land sorted in the
+/// emitted name tree, and each filespec's `/EF /F` stream must decode back
+/// to the exact bytes given.
+#[test]
+fn attachments_sort_by_name_and_round_trip_bytes() {
+    let pdf = Pdf {
+        pages: vec![Page::new(PageSize::A4)],
+        attachments: vec![
+            attachment("zeta.txt", b"zeta contents", Some("text/plain")),
+            attachment("alpha.txt", b"alpha contents", Some("text/plain")),
+        ],
+        ..Pdf::default()
+    };
+    let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
+    let entries = embedded_files_entries(&doc);
+    assert_eq!(entries.len(), 4, "two attachments make four array slots");
+
+    let key_at = |index: usize| {
+        decode_text_string(
+            entries[index]
+                .as_str_bytes()
+                .expect("name-tree key is a string"),
+        )
+    };
+    assert_eq!(key_at(0), "alpha.txt", "sorted before zeta.txt");
+    assert_eq!(key_at(2), "zeta.txt");
+
+    let alpha_filespec = resolve_dict(&doc, &entries[1]);
+    assert_eq!(
+        alpha_filespec.get_name("Type"),
+        Some(&Name("Filespec".into()))
+    );
+    assert_eq!(
+        decode_text_string(alpha_filespec.get("F").unwrap().as_str_bytes().unwrap()),
+        "alpha.txt"
+    );
+    assert_eq!(
+        decode_text_string(alpha_filespec.get("UF").unwrap().as_str_bytes().unwrap()),
+        "alpha.txt"
+    );
+    let ef = alpha_filespec.get_dict("EF").expect("/EF present");
+    let stream = resolve_stream(&doc, ef.get("F").expect("/EF /F present"));
+    assert_eq!(
+        stream.dict.get_name("Type"),
+        Some(&Name("EmbeddedFile".into()))
+    );
+    let decoded = doc.stream_data(&stream).expect("embedded stream decodes");
+    assert_eq!(decoded, b"alpha contents");
+}
+
+/// A mime type containing `/` must come out of the writer's existing
+/// `#xx` name-escaping as an escaped `/Subtype` — verified against the raw
+/// emitted bytes, since a re-parsed `Name` stores its escapes already
+/// resolved.
+#[test]
+fn attachment_subtype_escapes_mime_slash() {
+    let pdf = Pdf {
+        pages: vec![Page::new(PageSize::A4)],
+        attachments: vec![attachment("data.csv", b"a,b,c", Some("text/csv"))],
+        ..Pdf::default()
+    };
+    let bytes = pdf.to_bytes().unwrap();
+    assert!(
+        contains(&bytes, b"/Subtype /text#2Fcsv"),
+        "the mime's slash must be #-escaped in the emitted Subtype name"
+    );
+    let doc = Document::load(bytes).unwrap();
+    let entries = embedded_files_entries(&doc);
+    let filespec = resolve_dict(&doc, &entries[1]);
+    let ef = filespec.get_dict("EF").expect("/EF present");
+    let stream = resolve_stream(&doc, ef.get("F").expect("/EF /F present"));
+    assert_eq!(
+        stream.dict.get_name("Subtype"),
+        Some(&Name("text/csv".into())),
+        "decoded back to the unescaped mime"
+    );
+}
+
+/// `/Params` always carries `/Size`; `/ModDate` appears only when
+/// `modified` is supplied. A missing `mime` defaults to
+/// `application/octet-stream`, and `/Desc` appears only when given.
+#[test]
+fn attachment_params_size_and_conditional_moddate() {
+    let with_date = Attachment {
+        description: Some("has a date".to_string()),
+        modified: Some(Date {
+            year: 2026,
+            month: 8,
+            day: 28,
+            hour: 10,
+            minute: 0,
+            second: 0,
+            utc_offset_minutes: 0,
+        }),
+        ..attachment("with-date.bin", &[1, 2, 3, 4, 5], None)
+    };
+    let without_date = attachment("no-date.bin", &[9, 9], None);
+    let pdf = Pdf {
+        pages: vec![Page::new(PageSize::A4)],
+        attachments: vec![with_date, without_date],
+        ..Pdf::default()
+    };
+    let doc = Document::load(pdf.to_bytes().unwrap()).unwrap();
+    let entries = embedded_files_entries(&doc);
+    assert_eq!(entries.len(), 4);
+
+    // "no-date.bin" sorts before "with-date.bin".
+    let no_date_filespec = resolve_dict(&doc, &entries[1]);
+    let no_date_ef = no_date_filespec.get_dict("EF").expect("/EF present");
+    let no_date_stream = resolve_stream(&doc, no_date_ef.get("F").unwrap());
+    assert_eq!(
+        no_date_stream.dict.get_name("Subtype"),
+        Some(&Name("application/octet-stream".into())),
+        "no mime given defaults to application/octet-stream"
+    );
+    let no_date_params = no_date_stream
+        .dict
+        .get_dict("Params")
+        .expect("/Params present");
+    assert_eq!(no_date_params.get_int("Size"), Some(2));
+    assert!(no_date_params.get("ModDate").is_none());
+    assert!(no_date_filespec.get("Desc").is_none());
+
+    let with_date_filespec = resolve_dict(&doc, &entries[3]);
+    assert_eq!(
+        decode_text_string(
+            with_date_filespec
+                .get("Desc")
+                .unwrap()
+                .as_str_bytes()
+                .unwrap()
+        ),
+        "has a date"
+    );
+    let with_date_ef = with_date_filespec.get_dict("EF").expect("/EF present");
+    let with_date_stream = resolve_stream(&doc, with_date_ef.get("F").unwrap());
+    let with_date_params = with_date_stream
+        .dict
+        .get_dict("Params")
+        .expect("/Params present");
+    assert_eq!(with_date_params.get_int("Size"), Some(5));
+    assert_eq!(
+        with_date_params.get("ModDate").unwrap().as_str_bytes(),
+        Some(b"D:20260828100000Z".as_slice())
+    );
+}
+
+#[test]
+fn duplicate_attachment_name_errors() {
+    let pdf = Pdf {
+        pages: vec![Page::new(PageSize::A4)],
+        attachments: vec![
+            attachment("dup.txt", b"one", None),
+            attachment("dup.txt", b"two", None),
+        ],
+        ..Pdf::default()
+    };
+    let err = pdf.to_bytes().unwrap_err();
+    match err {
+        Error::Other(msg) => assert!(msg.contains("dup.txt"), "{msg}"),
+        other => panic!("expected Error::Other naming the duplicate, got {other:?}"),
+    }
+}
+
+#[test]
+fn attachments_document_serializes_byte_identically() {
+    fn build() -> Vec<u8> {
+        Pdf {
+            pages: vec![Page::new(PageSize::A4)],
+            attachments: vec![
+                attachment("b.txt", b"B", Some("text/plain")),
+                attachment("a.txt", b"A", Some("text/plain")),
+            ],
+            ..Pdf::default()
+        }
+        .to_bytes()
+        .unwrap()
+    }
+    assert_eq!(build(), build());
 }

--- a/crates/pdfboss-write/tests/roundtrip.rs
+++ b/crates/pdfboss-write/tests/roundtrip.rs
@@ -4,13 +4,13 @@
 //! toolkit's own readers rather than against expected byte dumps.
 
 use pdfboss_core::object::decode_text_string;
-use pdfboss_core::{Dict, Document, Name, Object, Rect, Stream};
+use pdfboss_core::{Dict, Document, Matrix, Name, Object, Rect, Stream};
 use pdfboss_output::extract_text;
 use pdfboss_render::{render_page_reporting, RenderOptions};
 use pdfboss_write::{
-    Attachment, Bookmark, Color, Content, Date, Error, ImageData, LabelStyle, Link, LinkAnnotation,
-    LinkTarget, Metadata, Outline, Page, PageLabel, PageLayout, PageMode, PageSize, Paragraph, Pdf,
-    Standard14, Viewer, WriteOptions, XrefStyle,
+    Attachment, BlendMode, Bookmark, Canvas, Color, Content, Date, Error, ImageData, LabelStyle,
+    Link, LinkAnnotation, LinkTarget, Metadata, Outline, Page, PageLabel, PageLayout, PageMode,
+    PageSize, Paragraph, Pdf, Standard14, Viewer, WriteOptions, XrefStyle,
 };
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
@@ -194,6 +194,254 @@ fn jpeg_passthrough_keeps_dct_stream() {
     assert_eq!(stream.dict.get_int("Width"), Some(5));
     assert_eq!(stream.dict.get_int("Height"), Some(7));
     assert_eq!(stream.data, jpeg);
+}
+
+fn letterhead() -> Canvas {
+    let mut canvas = Canvas::new();
+    canvas.set_fill(Color::Gray(0.9));
+    canvas.rect(0.0, 0.0, 200.0, 40.0);
+    canvas.fill();
+    canvas
+        .text("Letterhead", 5.0, 10.0, Standard14::Helvetica, 12.0)
+        .unwrap();
+    canvas
+}
+
+/// Resolves the page/form resource named `resource_name` under `/XObject`
+/// to its stream, cloned so the borrow does not outlive a temporary
+/// `Document::resolve` result.
+fn resolve_form(doc: &Document, resources: &Dict, resource_name: &str) -> Stream {
+    let xobjects = resources
+        .get_dict("XObject")
+        .expect("resources carry an XObject dict");
+    let entry = xobjects
+        .get(resource_name)
+        .unwrap_or_else(|| panic!("XObject resource {resource_name} present"));
+    doc.resolve(entry)
+        .expect("form reference resolves")
+        .as_stream()
+        .expect("form XObject is a stream")
+        .clone()
+}
+
+#[test]
+fn draw_group_paints_the_registered_subcanvas() {
+    let mut page = Page::new(PageSize::A4);
+    let handle = page.canvas.group(letterhead(), [0.0, 0.0, 200.0, 40.0]);
+    page.canvas
+        .draw_group(handle, Matrix::translate(50.0, 700.0));
+    let bytes = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let loaded = doc.page(0).unwrap();
+    let text = extract_text(&doc, &loaded).unwrap();
+    assert!(text.contains("Letterhead"), "extracted: {text:?}");
+    let form = resolve_form(&doc, &loaded.resources, "Gp1");
+    assert_eq!(form.dict.get_name("Type"), Some(&Name("XObject".into())));
+    assert_eq!(form.dict.get_name("Subtype"), Some(&Name("Form".into())));
+    assert_eq!(bbox_values(&form.dict), [0.0, 0.0, 200.0, 40.0]);
+}
+
+/// A form's `/BBox` as four `f64`s. Integral values round-trip through the
+/// object parser as `Object::Int`, not `Object::Real` (the crate's
+/// documented integral-`Real` corner), so numeric comparison goes through
+/// `as_f64` rather than comparing `Object` variants directly.
+fn bbox_values(dict: &Dict) -> [f64; 4] {
+    let array = dict.get_array("BBox").expect("BBox present");
+    let mut values = [0.0; 4];
+    for (slot, value) in values.iter_mut().zip(array) {
+        *slot = value.as_f64().expect("BBox entry is numeric");
+    }
+    values
+}
+
+/// Two pages each register their own copy of the same letterhead canvas.
+/// Cross-page form reuse is not implemented (groups live per-canvas, and a
+/// `Canvas` cannot be shared across pages) — this asserts the two resulting
+/// forms are structurally equal instead, and that the document-wide font
+/// cache is still shared between them.
+#[test]
+fn letterhead_group_on_two_pages_yields_structurally_equal_forms() {
+    let mut first = Page::new(PageSize::A4);
+    let first_handle = first.canvas.group(letterhead(), [0.0, 0.0, 200.0, 40.0]);
+    first
+        .canvas
+        .draw_group(first_handle, Matrix::translate(50.0, 700.0));
+    let mut second = Page::new(PageSize::A4);
+    let second_handle = second.canvas.group(letterhead(), [0.0, 0.0, 200.0, 40.0]);
+    second
+        .canvas
+        .draw_group(second_handle, Matrix::translate(50.0, 700.0));
+    let bytes = Pdf {
+        pages: vec![first, second],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let page0 = doc.page(0).unwrap();
+    let page1 = doc.page(1).unwrap();
+    assert!(extract_text(&doc, &page0).unwrap().contains("Letterhead"));
+    assert!(extract_text(&doc, &page1).unwrap().contains("Letterhead"));
+
+    let form0 = resolve_form(&doc, &page0.resources, "Gp1");
+    let form1 = resolve_form(&doc, &page1.resources, "Gp1");
+    assert_eq!(form0.dict.get_array("BBox"), form1.dict.get_array("BBox"));
+    assert_eq!(
+        doc.stream_data(&form0).unwrap(),
+        doc.stream_data(&form1).unwrap(),
+        "identical sub-canvases must serialize to identical form content"
+    );
+
+    let font0 = form0
+        .dict
+        .get_dict("Resources")
+        .and_then(|r| r.get_dict("Font"))
+        .and_then(|f| f.get_ref("F1"))
+        .expect("form0 references F1");
+    let font1 = form1
+        .dict
+        .get_dict("Resources")
+        .and_then(|r| r.get_dict("Font"))
+        .and_then(|f| f.get_ref("F1"))
+        .expect("form1 references F1");
+    assert_eq!(
+        font0, font1,
+        "the document-wide font cache must be shared with nested forms"
+    );
+
+    let gp0 = page0
+        .resources
+        .get_dict("XObject")
+        .and_then(|x| x.get_ref("Gp1"))
+        .expect("page0 Gp1 ref");
+    let gp1 = page1
+        .resources
+        .get_dict("XObject")
+        .and_then(|x| x.get_ref("Gp1"))
+        .expect("page1 Gp1 ref");
+    assert_ne!(
+        gp0, gp1,
+        "cross-page group reuse is deferred: each page gets its own form object"
+    );
+}
+
+#[test]
+fn drawing_one_group_twice_shares_the_same_form_xobject() {
+    let mut page = Page::new(PageSize::A4);
+    let handle = page.canvas.group(letterhead(), [0.0, 0.0, 200.0, 40.0]);
+    page.canvas
+        .draw_group(handle, Matrix::translate(10.0, 10.0));
+    page.canvas
+        .draw_group(handle, Matrix::translate(10.0, 400.0));
+    let bytes = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let loaded = doc.page(0).unwrap();
+    let xobjects = loaded
+        .resources
+        .get_dict("XObject")
+        .expect("XObject resource dict");
+    assert_eq!(
+        xobjects.len(),
+        1,
+        "two draw_group calls on one handle must reference one form"
+    );
+    let text = extract_text(&doc, &loaded).unwrap();
+    assert_eq!(
+        text.matches("Letterhead").count(),
+        2,
+        "the shared form paints once per draw_group call"
+    );
+}
+
+#[test]
+fn nested_groups_recurse_through_extraction() {
+    let mut inner = Canvas::new();
+    inner
+        .text("Inner", 2.0, 2.0, Standard14::Helvetica, 8.0)
+        .unwrap();
+    let mut outer = Canvas::new();
+    let inner_handle = outer.group(inner, [0.0, 0.0, 40.0, 12.0]);
+    outer.draw_group(inner_handle, Matrix::identity());
+    let mut page = Page::new(PageSize::A4);
+    let outer_handle = page.canvas.group(outer, [0.0, 0.0, 40.0, 12.0]);
+    page.canvas
+        .draw_group(outer_handle, Matrix::translate(100.0, 500.0));
+    let bytes = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let loaded = doc.page(0).unwrap();
+    let text = extract_text(&doc, &loaded).unwrap();
+    assert!(text.contains("Inner"), "extracted: {text:?}");
+}
+
+#[test]
+fn fill_alpha_resolves_to_ca_in_extgstate() {
+    let mut page = Page::new(PageSize::A4);
+    page.canvas.set_fill_alpha(0.5);
+    page.canvas.rect(0.0, 0.0, 10.0, 10.0);
+    page.canvas.fill();
+    let bytes = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let loaded = doc.page(0).unwrap();
+    let ext_gstates = loaded
+        .resources
+        .get_dict("ExtGState")
+        .expect("ExtGState resource dict");
+    let gs1_ref = ext_gstates.get_ref("Gs1").expect("Gs1 entry");
+    let gs1 = resolve_dict(&doc, &Object::Ref(gs1_ref));
+    assert_eq!(gs1.get_f64("ca"), Some(0.5));
+    assert!(gs1.get("CA").is_none());
+    assert!(gs1.get("BM").is_none());
+}
+
+#[test]
+fn stroke_alpha_and_blend_mode_resolve_to_distinct_extgstates() {
+    let mut page = Page::new(PageSize::A4);
+    page.canvas.set_stroke_alpha(0.75);
+    page.canvas.set_blend_mode(BlendMode::Multiply);
+    let bytes = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    }
+    .to_bytes()
+    .unwrap();
+    let doc = Document::load(bytes).unwrap();
+    let loaded = doc.page(0).unwrap();
+    let ext_gstates = loaded
+        .resources
+        .get_dict("ExtGState")
+        .expect("ExtGState resource dict");
+    assert_eq!(ext_gstates.len(), 2);
+    let gs1 = resolve_dict(
+        &doc,
+        &Object::Ref(ext_gstates.get_ref("Gs1").expect("Gs1 entry")),
+    );
+    assert_eq!(gs1.get_f64("CA"), Some(0.75));
+    assert!(gs1.get("ca").is_none());
+    let gs2 = resolve_dict(
+        &doc,
+        &Object::Ref(ext_gstates.get_ref("Gs2").expect("Gs2 entry")),
+    );
+    assert_eq!(gs2.get_name("BM"), Some(&Name("Multiply".into())));
 }
 
 fn two_page_document() -> Pdf {

--- a/python/pdfboss/__init__.py
+++ b/python/pdfboss/__init__.py
@@ -1,6 +1,6 @@
 """PDF parsing, text extraction and rendering in pure Rust."""
 
-from pdfboss import md
+from pdfboss import md, write
 from pdfboss._pdfboss import (
     AsyncDocument,
     AsyncElementIter,
@@ -32,4 +32,5 @@ __all__ = [
     "SpanIter",
     "__version__",
     "md",
+    "write",
 ]

--- a/python/pdfboss/_pdfboss.pyi
+++ b/python/pdfboss/_pdfboss.pyi
@@ -5,7 +5,8 @@ typed surface editors and type checkers see.
 """
 
 import os
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Iterator, Sequence
+from typing import Literal, Protocol, Self
 
 __version__: str
 """The installed pdfboss version, e.g. ``"0.18.0"``."""
@@ -624,3 +625,298 @@ def md_to_pdf(
     and reported through a single ``UserWarning`` naming what changed; a
     clean document warns about nothing.
     """
+
+class write:
+    """Type stubs for ``pdfboss._pdfboss.write``: composing new PDFs from
+    frozen pyclasses accumulated with ``|`` and lowered once at
+    ``Pdf.save``/``Pdf.to_bytes`` time.
+
+    Declared as a nested namespace class rather than a stub-package file
+    (``_pdfboss/write.pyi``) because pyo3 registers ``write`` as one
+    ``PyModule`` object, not a real subpackage on disk, and this single
+    ``_pdfboss.pyi`` file is the existing stub layout. Every name below is
+    actually an attribute of the real ``pdfboss._pdfboss.write`` module at
+    runtime, not of this class; cross-references below are written as
+    ``"write.Name"`` rather than a bare name, since a bare nested-class
+    name would resolve against this file's top-level (read-side) names —
+    ``Page`` above is a different class from ``write.Page`` below.
+    """
+
+    class Standard14:
+        """One of the fourteen standard fonts every PDF consumer
+        provides."""
+
+        HELVETICA: "write.Standard14"
+        HELVETICA_BOLD: "write.Standard14"
+        HELVETICA_OBLIQUE: "write.Standard14"
+        HELVETICA_BOLD_OBLIQUE: "write.Standard14"
+        TIMES_ROMAN: "write.Standard14"
+        TIMES_BOLD: "write.Standard14"
+        TIMES_ITALIC: "write.Standard14"
+        TIMES_BOLD_ITALIC: "write.Standard14"
+        COURIER: "write.Standard14"
+        COURIER_BOLD: "write.Standard14"
+        COURIER_OBLIQUE: "write.Standard14"
+        COURIER_BOLD_OBLIQUE: "write.Standard14"
+        SYMBOL: "write.Standard14"
+        ZAPF_DINGBATS: "write.Standard14"
+
+    class Draw(Protocol):
+        """The draw protocol: any object exposing a callable
+        ``draw(canvas)`` method composes onto a ``Page`` like ``Text`` or
+        ``Image``, painting through the canvas handed to it. The return
+        value is ignored, so any return type satisfies this protocol."""
+
+        def draw(self, canvas: "write.Canvas") -> object:
+            """Paints onto ``canvas``, in the page's content order."""
+
+    class Text:
+        """One line of text at a fixed baseline origin."""
+
+        def __init__(
+            self,
+            value: str,
+            at: tuple[float, float],
+            font: "write.Standard14" = ...,
+            size: float = 12.0,
+            color: tuple[float, float, float] | None = None,
+        ) -> None:
+            """``font`` defaults to ``Standard14.HELVETICA``. ``color`` is
+            an ``(r, g, b)`` tuple in ``[0, 1]``, defaulting to black."""
+
+    class Image:
+        """A raster image placed at a point."""
+
+        def __init__(
+            self,
+            data: str | bytes,
+            at: tuple[float, float],
+            width: float | None = None,
+            height: float | None = None,
+        ) -> None:
+            """``data`` is a filesystem path, read only at
+            ``save``/``to_bytes`` time, or raw image bytes decoded eagerly.
+            Raises ``TypeError`` for any other type. ``width``/``height``
+            default to the image's native size in points."""
+
+    class Link:
+        """A clickable rectangle, lowered into a link annotation on the
+        page."""
+
+        def __init__(
+            self,
+            rect: tuple[float, float, float, float],
+            url: str | None = None,
+            page: int | None = None,
+        ) -> None:
+            """Exactly one of ``url`` or ``page`` must be given; passing
+            neither or both raises ``TypeError``."""
+
+    class Paragraph:
+        """A block of text wrapped, aligned, and (for
+        ``align="justify"``) stretched to fill a rectangle."""
+
+        def __init__(
+            self,
+            text: str,
+            rect: tuple[float, float, float, float],
+            font: "write.Standard14" = ...,
+            size: float = 11.0,
+            leading: float | None = None,
+            align: Literal["left", "center", "right", "justify"] = "left",
+        ) -> None:
+            """``leading`` defaults to a size-derived line height. Raises
+            ``TypeError`` for an unknown ``align``, and ``PdfError`` at
+            lowering time if the wrapped text overflows ``rect``."""
+
+    class Metadata:
+        """Document information written to the ``/Info`` dictionary. Dates
+        are deferred: the write surface stays clock-free."""
+
+        def __init__(
+            self,
+            title: str | None = None,
+            author: str | None = None,
+            subject: str | None = None,
+            keywords: str | None = None,
+            creator: str | None = None,
+            producer: str | None = None,
+        ) -> None: ...
+
+    class Bookmark:
+        """One outline entry: a title, the page it jumps to, and nested
+        children, composed by nesting ``Bookmark`` instances rather than
+        ``|``."""
+
+        def __init__(
+            self,
+            title: str,
+            page: int,
+            *,
+            children: Sequence["write.Bookmark"] = (),
+        ) -> None: ...
+
+    class Outline:
+        """A document's bookmark panel: an ordered forest of ``Bookmark``
+        nodes. A singleton ``Pdf`` slot."""
+
+        def __init__(self, *bookmarks: "write.Bookmark") -> None: ...
+
+    class Attachment:
+        """A document-level attachment, embedded via the catalog's
+        embedded-files name tree. Carries no dates: the write surface
+        stays clock-free."""
+
+        def __init__(
+            self,
+            name: str,
+            data: bytes,
+            mime: str | None = None,
+            description: str | None = None,
+        ) -> None: ...
+
+    class PageLabel:
+        """One page-numbering range, taking effect from ``first_page``
+        until the next range or the document's end. A singleton-free
+        sequence: a ``Pdf`` may carry any number of these."""
+
+        def __init__(
+            self,
+            first_page: int,
+            style: Literal[
+                "decimal",
+                "roman-upper",
+                "roman-lower",
+                "letters-upper",
+                "letters-lower",
+            ]
+            | None = None,
+            prefix: str | None = None,
+            start_at: int = 1,
+        ) -> None:
+            """Raises ``TypeError`` for an unknown ``style``."""
+
+    class Viewer:
+        """Viewer preferences written to the catalog: initial layout,
+        navigation mode, and the page opened at document start. A
+        singleton ``Pdf`` slot."""
+
+        def __init__(
+            self,
+            layout: Literal[
+                "single-page",
+                "one-column",
+                "two-column-left",
+                "two-column-right",
+                "two-page-left",
+                "two-page-right",
+            ]
+            | None = None,
+            mode: Literal["use-none", "use-outlines", "use-thumbs", "full-screen"] | None = None,
+            open_to: int | None = None,
+        ) -> None:
+            """Raises ``TypeError`` for an unknown ``layout`` or ``mode``."""
+
+    class Canvas:
+        """The imperative painting surface handed to a draw object's
+        ``draw`` method: the page's in-progress canvas, moved in for the
+        call's duration and moved back out afterward. Has no public
+        constructor — only ``Page``'s draw protocol hands one out. Every
+        method raises ``PdfError`` once the canvas has been taken back
+        after ``draw`` returns; it must not outlive that call."""
+
+        def text(
+            self,
+            value: str,
+            at: tuple[float, float],
+            font: "write.Standard14" = ...,
+            size: float = 12.0,
+        ) -> None:
+            """Shows one line of text with its baseline origin at
+            ``at``."""
+
+        def line(
+            self, x1: float, y1: float, x2: float, y2: float, width: float = 1.0
+        ) -> None:
+            """Strokes a straight line from ``(x1, y1)`` to ``(x2, y2)`` at
+            ``width``."""
+
+        def rect(self, x: float, y: float, w: float, h: float) -> None:
+            """Appends a rectangle subpath."""
+
+        def move_to(self, x: float, y: float) -> None:
+            """Begins a new subpath at ``(x, y)``."""
+
+        def line_to(self, x: float, y: float) -> None:
+            """Straight segment to ``(x, y)``."""
+
+        def curve_to(
+            self, x1: float, y1: float, x2: float, y2: float, x3: float, y3: float
+        ) -> None:
+            """Cubic Bezier with two control points."""
+
+        def close(self) -> None:
+            """Closes the current subpath."""
+
+        def stroke(self) -> None:
+            """Strokes the current path."""
+
+        def fill(self) -> None:
+            """Fills the current path, nonzero winding."""
+
+        def set_fill(self, rgb: tuple[float, float, float]) -> None:
+            """Sets the fill color from an ``(r, g, b)`` tuple."""
+
+        def set_stroke(self, rgb: tuple[float, float, float]) -> None:
+            """Sets the stroke color from an ``(r, g, b)`` tuple."""
+
+        def set_line_width(self, width: float) -> None:
+            """Sets the stroke line width."""
+
+    class Page:
+        """One page: its size and the content composed onto it with
+        ``|``."""
+
+        def __init__(self, size: str = "a4", landscape: bool = False) -> None:
+            """``size`` names a page size case-insensitively, resolved at
+            lowering time."""
+
+        def __or__(
+            self,
+            rhs: "write.Text | write.Image | write.Link | write.Paragraph "
+            "| write.Draw",
+        ) -> Self:
+            """Composes one more element onto the page: ``Text``,
+            ``Image``, ``Link``, ``Paragraph``, or any object with a
+            callable ``draw`` attribute (the draw protocol). Returns a new
+            ``Page``; the receiver is unchanged. Raises ``TypeError`` for
+            an unsupported type."""
+
+    class Pdf:
+        """A document under construction: pages in reading order, the
+        singleton ``Metadata``/``Outline``/``Viewer`` slots, and the
+        ``Attachment``/``PageLabel`` sequences. ``|`` accumulates cheap
+        handle copies; nothing is built or read until
+        ``save``/``to_bytes``."""
+
+        def __init__(self) -> None: ...
+
+        def __or__(
+            self,
+            rhs: "write.Page | write.Metadata | write.Outline | write.Viewer "
+            "| write.Attachment | write.PageLabel",
+        ) -> Self:
+            """Composes one more ``Page``, ``Attachment`` or ``PageLabel``
+            (each appended), or ``Metadata``/``Outline``/``Viewer`` (each a
+            singleton slot) onto the document. Returns a new ``Pdf``; the
+            receiver is unchanged. A second ``Metadata``, ``Outline`` or
+            ``Viewer`` raises ``TypeError``."""
+
+        def save(self, path: str | os.PathLike[str]) -> None:
+            """Serializes and writes the document to ``path``."""
+
+        def to_bytes(self) -> bytes:
+            """Serializes the document to file bytes, like ``save``. May
+            be called more than once — each call lowers a fresh document
+            from the accumulated handles, so the composed value is never
+            consumed."""

--- a/python/pdfboss/write.py
+++ b/python/pdfboss/write.py
@@ -1,6 +1,4 @@
-"""PDF document creation: pages composed with `|`, saved once with
-`Pdf.save`/`Pdf.to_bytes`.
-"""
+"""Composing new PDFs: pages, elements and document slots joined with |."""
 
 import pdfboss._pdfboss  # noqa: F401  registers pdfboss._pdfboss.write in sys.modules
 from pdfboss._pdfboss.write import (

--- a/python/pdfboss/write.py
+++ b/python/pdfboss/write.py
@@ -1,0 +1,16 @@
+"""PDF document creation: pages composed with `|`, saved once with
+`Pdf.save`/`Pdf.to_bytes`.
+"""
+
+import pdfboss._pdfboss  # noqa: F401  registers pdfboss._pdfboss.write in sys.modules
+from pdfboss._pdfboss.write import Image, Link, Metadata, Page, Pdf, Standard14, Text
+
+__all__ = [
+    "Image",
+    "Link",
+    "Metadata",
+    "Page",
+    "Pdf",
+    "Standard14",
+    "Text",
+]

--- a/python/pdfboss/write.py
+++ b/python/pdfboss/write.py
@@ -3,14 +3,36 @@
 """
 
 import pdfboss._pdfboss  # noqa: F401  registers pdfboss._pdfboss.write in sys.modules
-from pdfboss._pdfboss.write import Image, Link, Metadata, Page, Pdf, Standard14, Text
+from pdfboss._pdfboss.write import (
+    Attachment,
+    Bookmark,
+    Canvas,
+    Image,
+    Link,
+    Metadata,
+    Outline,
+    Page,
+    PageLabel,
+    Paragraph,
+    Pdf,
+    Standard14,
+    Text,
+    Viewer,
+)
 
 __all__ = [
+    "Attachment",
+    "Bookmark",
+    "Canvas",
     "Image",
     "Link",
     "Metadata",
+    "Outline",
     "Page",
+    "PageLabel",
+    "Paragraph",
     "Pdf",
     "Standard14",
     "Text",
+    "Viewer",
 ]

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -21,7 +21,7 @@ def test_stub_declares_every_write_export() -> None:
     for name in pdfboss.write.__all__:
         if not inspect.isclass(getattr(pdfboss.write, name)):
             continue
-        assert f"class {name}" in stub, f"missing stub for pdfboss.write.{name}"
+        assert f"\n    class {name}:" in stub, f"missing stub for pdfboss.write.{name}"
 
 
 def test_stub_declares_the_element_and_async_surface() -> None:

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -16,6 +16,14 @@ def test_stub_declares_every_exported_class() -> None:
         assert f"class {name}" in stub, f"missing stub for {name}"
 
 
+def test_stub_declares_every_write_export() -> None:
+    stub = STUB.read_text()
+    for name in pdfboss.write.__all__:
+        if not inspect.isclass(getattr(pdfboss.write, name)):
+            continue
+        assert f"class {name}" in stub, f"missing stub for pdfboss.write.{name}"
+
+
 def test_stub_declares_the_element_and_async_surface() -> None:
     stub = STUB.read_text()
     assert "def elements(" in stub

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -325,6 +325,28 @@ def test_viewer_rejects_unknown_mode() -> None:
         Viewer(mode="whatever")
 
 
+def test_write_module_exports_full_vocabulary_sorted() -> None:
+    from pdfboss.write import Pdf, Page, Text, Standard14  # noqa: F401
+
+    assert pdfboss.write.__all__ == sorted(pdfboss.write.__all__)
+    assert pdfboss.write.__all__ == [
+        "Attachment",
+        "Bookmark",
+        "Canvas",
+        "Image",
+        "Link",
+        "Metadata",
+        "Outline",
+        "Page",
+        "PageLabel",
+        "Paragraph",
+        "Pdf",
+        "Standard14",
+        "Text",
+        "Viewer",
+    ]
+
+
 def test_standard14_exposes_all_fourteen_names() -> None:
     names = [
         "HELVETICA",

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,0 +1,154 @@
+"""Tests for `pdfboss.write`: the composition core (Task 9) — frozen
+pyclasses accumulated with `|`, lowered once into a Rust `Pdf` at
+`save`/`to_bytes` time."""
+
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+
+import pdfboss
+from pdfboss.write import Image, Link, Metadata, Page, Pdf, Standard14, Text
+
+
+def make_gray8_png(width: int, height: int, pixel: int) -> bytes:
+    """A minimal 8-bit grayscale PNG, built with the standard library only."""
+
+    def chunk(tag: bytes, payload: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(payload))
+            + tag
+            + payload
+            + struct.pack(">I", zlib.crc32(tag + payload))
+        )
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 0, 0, 0, 0)
+    raw = b"".join(bytes([0]) + bytes([pixel]) * width for _ in range(height))
+    idat = zlib.compress(raw)
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+def test_compose_and_save_bytes() -> None:
+    page = Page(size="a4") | Text("Q3 Report", at=(72, 770), font=Standard14.HELVETICA_BOLD, size=28)
+    data = (Pdf() | page | Metadata(title="Q3 Report")).to_bytes()
+    assert data.startswith(b"%PDF-")
+
+
+def test_slots_are_order_free() -> None:
+    page = Page() | Text("same", at=(72, 700))
+    first = (Pdf() | page | Metadata(title="fine")).to_bytes()
+    second = (Pdf() | Metadata(title="fine") | page).to_bytes()
+    assert first == second
+
+
+def test_duplicate_slot_raises() -> None:
+    with pytest.raises(TypeError, match="already has Metadata"):
+        Pdf() | Metadata(title="a") | Metadata(title="b")
+
+
+def test_or_returns_new_values() -> None:
+    base = Pdf() | (Page() | Text("one", at=(72, 700)))
+    with_meta = base | Metadata(title="t")
+    assert base.to_bytes() != with_meta.to_bytes()
+
+
+def test_pages_keep_order() -> None:
+    first = Page() | Text("first", at=(72, 700))
+    second = Page() | Text("second", at=(72, 700))
+    ab = (Pdf() | first | second).to_bytes()
+    ba = (Pdf() | second | first).to_bytes()
+    assert ab != ba
+
+
+def test_link_requires_exactly_one_target() -> None:
+    with pytest.raises(TypeError):
+        Link(rect=(0, 0, 1, 1))
+    with pytest.raises(TypeError):
+        Link(rect=(0, 0, 1, 1), url="https://x.y", page=0)
+
+
+def test_reopen_and_extract_text(tmp_path: Path) -> None:
+    page = Page(size="a4") | Text("Round trip content", at=(72, 700))
+    data = (Pdf() | page).to_bytes()
+    path = tmp_path / "roundtrip.pdf"
+    path.write_bytes(data)
+    doc = pdfboss.Document(str(path))
+    assert "Round trip content" in doc.extract_text()
+
+
+def test_to_bytes_is_callable_twice() -> None:
+    page = Page() | Text("stable", at=(72, 700))
+    pdf = Pdf() | page
+    assert pdf.to_bytes() == pdf.to_bytes()
+
+
+def test_empty_pdf_raises_pdf_error() -> None:
+    with pytest.raises(pdfboss.PdfError, match="at least one page"):
+        Pdf().to_bytes()
+
+
+def test_save_writes_file(tmp_path: Path) -> None:
+    page = Page() | Text("saved", at=(72, 700))
+    path = tmp_path / "out.pdf"
+    (Pdf() | page).save(str(path))
+    assert path.read_bytes().startswith(b"%PDF-")
+
+
+def test_page_or_rejects_unsupported_type() -> None:
+    with pytest.raises(TypeError, match="int"):
+        Page() | 42
+
+
+def test_pdf_or_rejects_unsupported_type() -> None:
+    with pytest.raises(TypeError, match="str"):
+        Pdf() | "not a page"
+
+
+def test_image_from_bytes_composes() -> None:
+    png = make_gray8_png(2, 2, 128)
+    page = Page() | Image(png, at=(72, 700), width=20.0, height=20.0)
+    data = (Pdf() | page).to_bytes()
+    assert data.startswith(b"%PDF-")
+
+
+def test_image_from_path_reads_file_at_lowering(tmp_path: Path) -> None:
+    png = make_gray8_png(2, 2, 200)
+    path = tmp_path / "dot.png"
+    path.write_bytes(png)
+    page = Page() | Image(str(path), at=(72, 700))
+    data = (Pdf() | page).to_bytes()
+    assert data.startswith(b"%PDF-")
+
+
+def test_image_decode_error_is_pdf_error() -> None:
+    page = Page() | Image(b"not an image", at=(0, 0))
+    with pytest.raises(pdfboss.PdfError):
+        (Pdf() | page).to_bytes()
+
+
+def test_link_composes_into_page() -> None:
+    page = Page() | Link(rect=(0, 0, 100, 20), url="https://example.com")
+    data = (Pdf() | page).to_bytes()
+    assert data.startswith(b"%PDF-")
+
+
+def test_standard14_exposes_all_fourteen_names() -> None:
+    names = [
+        "HELVETICA",
+        "HELVETICA_BOLD",
+        "HELVETICA_OBLIQUE",
+        "HELVETICA_BOLD_OBLIQUE",
+        "TIMES_ROMAN",
+        "TIMES_BOLD",
+        "TIMES_ITALIC",
+        "TIMES_BOLD_ITALIC",
+        "COURIER",
+        "COURIER_BOLD",
+        "COURIER_OBLIQUE",
+        "COURIER_BOLD_OBLIQUE",
+        "SYMBOL",
+        "ZAPF_DINGBATS",
+    ]
+    for name in names:
+        assert hasattr(Standard14, name)

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -57,6 +57,19 @@ def test_slots_are_order_free() -> None:
     assert first == second
 
 
+def test_all_singleton_slots_are_order_free() -> None:
+    page = Page() | Text("same", at=(72, 700))
+    metadata = Metadata(title="fine")
+    outline = Outline(Bookmark("Only", 0))
+    viewer = Viewer(mode="use-none")
+
+    slots_first = (Pdf() | metadata | outline | viewer | page).to_bytes()
+    slots_last = (Pdf() | page | metadata | outline | viewer).to_bytes()
+    shuffled = (Pdf() | viewer | page | metadata | outline).to_bytes()
+
+    assert slots_first == slots_last == shuffled
+
+
 def test_duplicate_slot_raises() -> None:
     with pytest.raises(TypeError, match="already has Metadata"):
         Pdf() | Metadata(title="a") | Metadata(title="b")

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,6 +1,6 @@
-"""Tests for `pdfboss.write`: the composition core (Task 9) — frozen
-pyclasses accumulated with `|`, lowered once into a Rust `Pdf` at
-`save`/`to_bytes` time."""
+"""Tests for `pdfboss.write`: the composition core (Task 9) and the full
+vocabulary plus draw protocol (Task 10) — frozen pyclasses accumulated
+with `|`, lowered once into a Rust `Pdf` at `save`/`to_bytes` time."""
 
 import struct
 import zlib
@@ -9,7 +9,22 @@ from pathlib import Path
 import pytest
 
 import pdfboss
-from pdfboss.write import Image, Link, Metadata, Page, Pdf, Standard14, Text
+from pdfboss.write import (
+    Attachment,
+    Bookmark,
+    Canvas,
+    Image,
+    Link,
+    Metadata,
+    Outline,
+    Page,
+    PageLabel,
+    Paragraph,
+    Pdf,
+    Standard14,
+    Text,
+    Viewer,
+)
 
 
 def make_gray8_png(width: int, height: int, pixel: int) -> bytes:
@@ -131,6 +146,165 @@ def test_link_composes_into_page() -> None:
     page = Page() | Link(rect=(0, 0, 100, 20), url="https://example.com")
     data = (Pdf() | page).to_bytes()
     assert data.startswith(b"%PDF-")
+
+
+def test_letterhead_draw_protocol_composes_and_extracts(tmp_path: Path) -> None:
+    class Letterhead:
+        def draw(self, canvas: Canvas) -> None:
+            canvas.line(72, 806, 523, 806, width=0.5)
+            canvas.text("ACME GmbH", at=(72, 812), font=Standard14.HELVETICA, size=8)
+
+    page = Page(size="a4") | Letterhead() | Text("Body copy", at=(72, 700))
+    data = (Pdf() | page).to_bytes()
+    path = tmp_path / "letterhead.pdf"
+    path.write_bytes(data)
+    doc = pdfboss.Document(str(path))
+    text = doc.extract_text()
+    assert "ACME GmbH" in text
+    assert "Body copy" in text
+
+
+def test_draw_exception_propagates_untouched() -> None:
+    class Bomb:
+        def draw(self, canvas: Canvas) -> None:
+            raise ValueError("boom")
+
+    page = Page(size="a4") | Bomb()
+    with pytest.raises(ValueError, match="boom"):
+        (Pdf() | page).to_bytes()
+
+
+def test_draw_non_none_return_is_ignored() -> None:
+    class Noisy:
+        def draw(self, canvas: Canvas) -> object:
+            canvas.text("noisy", at=(72, 700))
+            return "ignored"
+
+    page = Page(size="a4") | Noisy()
+    data = (Pdf() | page).to_bytes()
+    assert data.startswith(b"%PDF-")
+
+
+def test_canvas_is_unusable_after_draw_returns() -> None:
+    class Escaping:
+        def __init__(self) -> None:
+            self.canvas: Canvas | None = None
+
+        def draw(self, canvas: Canvas) -> None:
+            self.canvas = canvas
+
+    escaping = Escaping()
+    page = Page(size="a4") | escaping
+    (Pdf() | page).to_bytes()
+    assert escaping.canvas is not None
+    with pytest.raises(pdfboss.PdfError, match="canvas is no longer usable outside draw"):
+        escaping.canvas.text("late", at=(0, 0))
+
+
+def test_outline_duplicate_slot_raises() -> None:
+    with pytest.raises(TypeError, match="already has Outline"):
+        Pdf() | Outline(Bookmark("A", 0)) | Outline(Bookmark("B", 0))
+
+
+def test_viewer_duplicate_slot_raises() -> None:
+    with pytest.raises(TypeError, match="already has Viewer"):
+        Pdf() | Viewer(mode="use-none") | Viewer(mode="use-outlines")
+
+
+def test_full_vocabulary_compose_reopens_with_expected_text_and_pages(tmp_path: Path) -> None:
+    first = Page(size="a4") | Text("Cover page", at=(72, 700))
+    second = Page(size="a4") | Text("Appendix page", at=(72, 700))
+    pdf = (
+        Pdf()
+        | first
+        | second
+        | Outline(
+            Bookmark("Summary", 0, children=(Bookmark("Detail", 0),)),
+            Bookmark("Appendix", 1),
+        )
+        | Attachment("raw-numbers.csv", b"a,b,c\n1,2,3\n", mime="text/csv", description="Source data")
+        | PageLabel(0, style="roman-lower", prefix="p. ")
+        | Viewer(layout="single-page", mode="use-outlines", open_to=0)
+    )
+    data = pdf.to_bytes()
+    path = tmp_path / "full.pdf"
+    path.write_bytes(data)
+    doc = pdfboss.Document(str(path))
+    assert doc.page_count == 2
+    text = doc.extract_text()
+    assert "Cover page" in text
+    assert "Appendix page" in text
+
+
+def test_full_vocabulary_compose_is_deterministic() -> None:
+    def build() -> bytes:
+        page = Page(size="a4") | Text("Stable", at=(72, 700))
+        pdf = (
+            Pdf()
+            | page
+            | Outline(Bookmark("Only", 0))
+            | Attachment("data.bin", b"\x00\x01\x02")
+            | PageLabel(0)
+            | Viewer(mode="use-none")
+        )
+        return pdf.to_bytes()
+
+    assert build() == build()
+
+
+def test_multiple_attachments_and_page_labels_compose() -> None:
+    page = Page(size="a4") | Text("x", at=(72, 700))
+    pdf = (
+        Pdf()
+        | page
+        | Attachment("a.txt", b"a")
+        | Attachment("b.txt", b"b")
+        | PageLabel(0, style="decimal")
+    )
+    data = pdf.to_bytes()
+    assert data.startswith(b"%PDF-")
+
+
+def test_paragraph_wraps_and_full_text_survives(tmp_path: Path) -> None:
+    words = [f"word{i}" for i in range(20)]
+    body = " ".join(words)
+    page = Page(size="a4") | Paragraph(body, rect=(72, 400, 222, 700), size=10)
+    data = (Pdf() | page).to_bytes()
+    path = tmp_path / "wrap.pdf"
+    path.write_bytes(data)
+    doc = pdfboss.Document(str(path))
+    text = doc.extract_text()
+    for word in words:
+        assert word in text
+    lines_with_words = [line for line in text.splitlines() if "word" in line]
+    assert len(lines_with_words) >= 2, "the narrow rect must force more than one line"
+
+
+def test_paragraph_overflow_raises_pdf_error() -> None:
+    body = " ".join(f"word{i}" for i in range(20))
+    page = Page(size="a4") | Paragraph(body, rect=(72, 690, 400, 700), size=12)
+    with pytest.raises(pdfboss.PdfError, match="overflows"):
+        (Pdf() | page).to_bytes()
+
+
+def test_paragraph_rejects_unknown_align() -> None:
+    with pytest.raises(TypeError, match="left, center, right"):
+        Paragraph("x", rect=(0, 0, 10, 10), align="diagonal")
+
+
+def test_page_label_rejects_unknown_style() -> None:
+    with pytest.raises(TypeError, match="decimal"):
+        PageLabel(0, style="weird")
+
+
+def test_viewer_rejects_unknown_layout() -> None:
+    with pytest.raises(TypeError, match="single-page"):
+        Viewer(layout="whatever")
+
+
+def test_viewer_rejects_unknown_mode() -> None:
+    with pytest.raises(TypeError, match="use-none"):
+        Viewer(mode="whatever")
 
 
 def test_standard14_exposes_all_fourteen_names() -> None:

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -201,6 +201,24 @@ def test_canvas_is_unusable_after_draw_returns() -> None:
         escaping.canvas.text("late", at=(0, 0))
 
 
+def test_canvas_is_unusable_after_draw_raises() -> None:
+    class EscapingBomb:
+        def __init__(self) -> None:
+            self.canvas: Canvas | None = None
+
+        def draw(self, canvas: Canvas) -> None:
+            self.canvas = canvas
+            raise RuntimeError("boom")
+
+    escaping = EscapingBomb()
+    page = Page(size="a4") | escaping
+    with pytest.raises(RuntimeError, match="boom"):
+        (Pdf() | page).to_bytes()
+    assert escaping.canvas is not None
+    with pytest.raises(pdfboss.PdfError, match="canvas is no longer usable outside draw"):
+        escaping.canvas.text("late", at=(0, 0))
+
+
 def test_outline_duplicate_slot_raises() -> None:
     with pytest.raises(TypeError, match="already has Outline"):
         Pdf() | Outline(Bookmark("A", 0)) | Outline(Bookmark("B", 0))


### PR DESCRIPTION
P3 of the write-suite design: the composition layer, at both language surfaces.

**pdfboss-write (Rust):**
- Element vocabulary: `Content` (`Text`/`Paragraph`/`Image`/`Link`/`Custom`), the `Draw: Send` protocol, and `Page.content` lowering onto the canvas at assemble time. `Paragraph` wraps/aligns/justifies inside a rect (strict overflow errors; justify via word-spacing with leak-proof reset ordering).
- Document slots on `Pdf`: outline bookmark trees (explicit `/XYZ` destinations), an XMP metadata stream synced with the Info dict (ID-free — determinism holds), EmbeddedFiles attachments (byte-sorted name tree), page labels, viewer preferences (`/PageLayout`, `/PageMode`, `/OpenAction`).
- Assemble restructure: all page refs pre-reserved, enabling internal GoTo links — **breaking**: `LinkAnnotation { rect, uri }` → `{ rect, target: LinkTarget::{Uri, Page} }` (both in-repo consumers migrated; 0.x).
- Canvas: form XObject groups (`group`/`draw_group`, recursive resources, doc-wide font sharing) and transparency state (`set_fill_alpha`/`set_stroke_alpha`/`set_blend_mode` → deduped ExtGState entries).

**pdfboss.write (Python):** frozen classes composed with `|` — singleton slots are order-free and duplicate-rejecting (`Pdf already has Metadata — one per document`), sequences keep order, every `|` returns a new value. Anything with a `draw(canvas)` method slots into a page (a `Canvas` shim over the real writer canvas; mid-draw exceptions propagate untouched and the canvas is reclaimed unconditionally). Full stubs + an anchored coverage gate.

**CLI:** `pdfboss create manifest q3.toml -o q3.pdf` — the same vocabulary spelled in strict TOML (`deny_unknown_fields`, path-prefixed errors, PostScript font names).

**Determinism:** byte-identical output across runs AND across singleton-slot composition order, tested at the full vocabulary in both languages.

**Verification:** full workspace sweep green (fmt / clippy / `cargo test --workspace` / doc / maturin+pytest, 176 py tests); every slot verified structurally by re-opening through the toolkit's own reader; the design's q3.toml exit test builds and round-trips; final whole-branch review ran a maximal-document probe (all slots + draw protocol + GoTo + labels in one file) against the reader.

**Deferred by design:** named destinations (P4, with `Update`), manifest outline/attachment tables (P4's `outline --from`), cross-page form dedup, `/Group` transparency dicts.