### PR TITLE
perf(render): extend deflate matches a word at a time, reuse the hash table across the two passes

### DIFF
--- a/crates/pdfboss-render/src/encode.rs
+++ b/crates/pdfboss-render/src/encode.rs
@@ -578,11 +578,14 @@ fn zero_run_end(data: &[u8], mut i: usize) -> usize {
 /// One pass over the filtered image, reporting each token to `emit`. The
 /// tokenization is deterministic, so running it twice — once to count,
 /// once to write — costs two cheap scans instead of one buffered token
-/// stream. After repeated probe misses the scan accelerates LZ4-style,
-/// stepping further between probes so incompressible stretches cost a
-/// fraction of a probe per byte.
-fn tokenize(data: &[u8], mut emit: impl FnMut(Token<'_>)) {
-    let mut table = vec![u32::MAX; 1 << HASH_BITS];
+/// stream; `table` is the hash table's storage, cleared here so both scans
+/// start from the same empty state without paying a second allocation.
+/// After repeated probe misses the scan accelerates LZ4-style, stepping
+/// further between probes so incompressible stretches cost a fraction of a
+/// probe per byte.
+fn tokenize(data: &[u8], table: &mut Vec<u32>, mut emit: impl FnMut(Token<'_>)) {
+    table.clear();
+    table.resize(1 << HASH_BITS, u32::MAX);
     let mut i = 0;
     let mut lit_start = 0;
     let mut misses = 0u32;
@@ -622,8 +625,25 @@ fn tokenize(data: &[u8], mut emit: impl FnMut(Token<'_>)) {
             && i - candidate <= WINDOW
             && data[candidate..candidate + MIN_MATCH] == data[i..i + MIN_MATCH]
         {
+            // Word-wise extension: XOR eight bytes at a time and read the
+            // first mismatch out of the trailing zeros — the same length
+            // the byte loop finds, so the token stream is unchanged.
             let mut len = MIN_MATCH;
             let max = (data.len() - i).min(258);
+            while len + 8 <= max {
+                let held = u64::from_le_bytes(
+                    data[candidate + len..candidate + len + 8]
+                        .try_into()
+                        .unwrap(),
+                );
+                let here = u64::from_le_bytes(data[i + len..i + len + 8].try_into().unwrap());
+                let diff = held ^ here;
+                if diff != 0 {
+                    len += (diff.trailing_zeros() / 8) as usize;
+                    break;
+                }
+                len += 8;
+            }
             while len < max && data[candidate + len] == data[i + len] {
                 len += 1;
             }
@@ -671,7 +691,8 @@ fn deflate_filtered(data: &[u8]) -> Vec<u8> {
     } else {
         data.len()
     };
-    tokenize(&data[..sample_len], |token| match token {
+    let mut table = Vec::new();
+    tokenize(&data[..sample_len], &mut table, |token| match token {
         Token::Literals(bytes) => {
             for &b in bytes {
                 lit_freq[b as usize] += 1;
@@ -693,7 +714,7 @@ fn deflate_filtered(data: &[u8]) -> Vec<u8> {
     bits.write(1, 1); // BFINAL
     bits.write(2, 2); // dynamic Huffman
     write_code_lengths(&mut bits, &lit_lens, &dist_lens[..hdist]);
-    tokenize(data, |token| match token {
+    tokenize(data, &mut table, |token| match token {
         Token::Literals(bytes) => {
             for &b in bytes {
                 let (code, len) = lit_codes[b as usize];


### PR DESCRIPTION
With rendering sped up by the earlier waves, PNG encoding had grown to
41.9% of the mixed-corpus render pass. Two changes inside the encoder's
tokenizer, both provably output-preserving:

- Match extension compared one byte per step; it now XORs eight bytes at
  a time and reads the first mismatch out of the trailing zeros — the
  same length the byte loop found, so the token choice is unchanged.
- The two tokenization passes (count, then write) share one hash-table
  allocation, each pass clearing it back to the empty state a fresh
  table had.

Because the token stream is identical, every PNG byte is identical — the
render oracle stays hard. Verified: per-page sha256 of RGBA pixels AND
PNG bytes unchanged across all 888 certified pages of the 049 corpus;
full workspace suite (2,179 tests), clippy in both `substitute-fonts`
states, fmt, `cargo doc` clean.

Measurement (pre-registered target: 049 mixed render pass — certify,
then render+encode at sample 40, repeat 3 — 16 interleaved paired rounds
main vs this branch, keep iff >=14/16 wins AND median > 3x the A/A-null
median; scan book as 8-round control; gated on AC power and measured
throughput; forecast registered at an honest 1-3%)

- 049 target: keep=YES — 16/16 wins, median +1.87% (5.945s -> 5.831s,
  x1.020), threshold 0.56% (3x null median 0.19%) cleared 3.3x
- scan control: 8/8 wins, median +1.5% — encode is a minor share there,
  small positive expected

A modest wave by design: most encode time sits in one inlined self-blob
that sample(1) cannot attribute, and the deeper rewrite (hash chains,
lazy matching) would change the deflate stream bytes — parked until that
oracle trade is worth discussing.
