### PR TITLE
docs: cover the composition layer in the book

### DIFF
--- a/docs/src/guide/creating.md
+++ b/docs/src/guide/creating.md
@@ -1,10 +1,10 @@
 # Creating PDFs
 
-The write side of pdfboss is the `pdfboss-write` Rust crate plus the `pdfboss create` CLI. This chapter is the canvas level: you place every shape, glyph run and image yourself. To compose a document from CommonMark+GFM source instead — the one creation path Python also exposes, as `pdfboss.md.to_pdf` — see [Markdown to PDF](./md-to-pdf.md); the canvas level itself has no Python API. Everything the writer emits uses the same content-stream IR the reader parses, so a created file round-trips through the rest of the toolkit.
+The write side of pdfboss is the `pdfboss-write` Rust crate, the `pdfboss.write` Python module and the `pdfboss create` CLI. This chapter covers two altitudes: the canvas level, where you place every shape, glyph run and image yourself, and the element level one step above it, where `Text`, `Paragraph`, `Image` and `Link` values compose onto pages and document slots carry outlines, attachments, page labels and viewer preferences. Python reaches both: `pdfboss.write` composes elements and slots with `|`, and its draw protocol paints on the canvas directly. To compose a document from CommonMark+GFM source instead, from the CLI, Rust or Python (`pdfboss.md.to_pdf`), see [Markdown to PDF](./md-to-pdf.md). Everything the writer emits uses the same content-stream IR the reader parses, so a created file round-trips through the rest of the toolkit.
 
 ## The document model
 
-A document is plain data: `Pdf { metadata, pages, options }`. The fields are the composition — pages appear in the output in the order of the `Vec`, singleton slots are `Option`s, and `Default` fills everything optional. Each `Page { size, rotation, canvas, links }` carries its own painted content, plus its clickable areas: a `LinkAnnotation { rect, uri }` marks a rectangle in page user space that opens a URI, emitted as a `/Link` annotation under `/Annots`.
+A document is plain data: `Pdf { metadata, pages, outline, attachments, page_labels, viewer, options }`. The fields are the composition: pages appear in the output in the order of the `Vec`, singleton slots are `Option`s, sequences may stay empty, and `Default` fills everything optional. Each `Page { size, rotation, canvas, content, links }` carries operators painted directly on its `canvas`, composed elements in `content` (lowered onto the canvas at serialization time, after anything painted directly), and its clickable areas: a `LinkAnnotation { rect, target }` marks a rectangle in page user space, emitted as a `/Link` annotation under `/Annots`, whose `LinkTarget` is either `Uri(String)` (a `/URI` action) or `Page(usize)` (a `/GoTo` action with an explicit `/XYZ null null null` destination that keeps the viewer's current position and zoom).
 
 ```rust,no_run
 use pdfboss_write::{Page, PageSize, Pdf, Standard14};
@@ -24,13 +24,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 Coordinates are PDF user space: the origin is the bottom-left corner of the page, y grows upward, and one unit is 1/72 inch (a point). `PageSize` offers `A3` (841.89 × 1190.55), `A4` (595.28 × 841.89, the default), `A5` (419.53 × 595.28), `Letter` (612 × 792), `Legal` (612 × 1008) and `Custom { width, height }`; `dimensions()` returns the pair, and `landscape()` swaps it into a `Custom`. `rotation` is a clockwise view rotation in degrees.
 
-Serialization validates rather than guesses: a document with zero pages is an error, and so is a rotation that is not a multiple of 90.
+Serialization validates rather than guesses. A document with zero pages is an error, and so are a rotation that is not a multiple of 90, a link, bookmark or `open_to` target page out of range, a duplicate attachment name, a page-label set without a range at page 0 or with a duplicate `first_page` or a `start_at` of 0 (numbering starts at 1), and a paragraph whose wrapped lines overflow its rect.
 
 ## Canvas
 
 `Canvas` is an imperative painter. Path construction (`move_to`, `line_to`, `curve_to`, `close`) is separate from painting (`fill`, `fill_even_odd`, `stroke`, `close_stroke`, `fill_stroke`, `end_path`), exactly as in PDF content streams. Convenience shapes append complete subpaths: `rect`, `circle` and `ellipse` (four Bézier arcs), and `polygon` over a slice of `pdfboss_core::Point` (fewer than three points appends nothing).
 
 Graphics state follows the same operators: `save`/`restore` push and pop, `transform` concatenates a `pdfboss_core::Matrix` onto the CTM, and `set_line_width`, `set_line_cap`, `set_line_join`, `set_miter_limit` and `set_dash` control stroking. `clip` and `clip_even_odd` intersect the clip region with the current path and consume it. Colors are device colors — `Color::Gray(g)`, `Color::Rgb(r, g, b)`, `Color::Cmyk(c, m, y, k)`, components in `0.0..=1.0`, with `Color::BLACK` and `Color::WHITE` constants — set independently for fill (`set_fill`) and stroke (`set_stroke`). For anything the methods do not cover, `op` pushes a raw `pdfboss_core::content::Op`.
+
+Canvases nest and carry transparency state. `group(canvas, bbox)` registers a finished sub-canvas as a Form XObject and returns a `GroupHandle`; `draw_group(handle, matrix)` paints it under a matrix, and two calls with the same handle reference one form resource. `set_fill_alpha`, `set_stroke_alpha` and `set_blend_mode` each emit a `gs` operator over a deduplicated single-key `/ExtGState` entry (`/ca`, `/CA` and `/BM` respectively); `BlendMode` covers the twelve separable modes. The resource naming contract, which `op` callers must keep consistent, is fixed: fonts are `F1`, `F2`, …, images `Im1`, …, groups `Gp1`, …, graphics states `Gs1`, …. Fonts are deduplicated document-wide, nested groups included, but a canvas registered as a group on two pages produces two Form XObjects; cross-page group sharing is deferred.
 
 ### Text
 
@@ -134,9 +136,156 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 To embed an existing file instead of a generated raster: `ImageData::png(&std::fs::read("photo.png")?)?`.
 
+## Composing pages
+
+`Page::content` holds `Content` values, an element vocabulary one step above raw canvas operators: `Text`, `Image`, `Link` and `Paragraph`, each convertible with `Content::from`, plus `Content::Custom(Box<dyn Draw>)` via `Content::custom` for anything implementing `Draw` (`fn draw(&self, canvas: &mut Canvas) -> Result<()>`, plus `Send`). Elements lower onto the page's canvas at serialization time, in order, after any operators already painted there directly, so elements paint over manual canvas work, never under it. A `Link` element is the exception: it lowers into the page's `links` vector instead of painting.
+
+`Paragraph { text, rect, font, size, leading, align }` wraps text into its rect. `\n` forces a line break, other whitespace runs between words collapse to one space, and a blank source line keeps its vertical advance. `leading` defaults to `1.2 * size`; `align` is `ParagraphAlign::Left`, `Center`, `Right` or `Justify`, and justification stretches word spacing on every line except the last visible one. A paragraph that does not fit is an error naming how many lines fit and how many were needed, and an unencodable character errors exactly as in `canvas.text`.
+
+`Image { data, at, width, height }` sizes itself from what is given: with both dimensions `None` it paints at the natural pixel size at 72 dpi, one given dimension scales the other by aspect, and both given paint the exact box.
+
+```rust,no_run
+use pdfboss_core::Point;
+use pdfboss_write::{Content, Link, LinkTarget, Page, PageSize, Paragraph, Pdf, Standard14, Text};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut page = Page::new(PageSize::A4);
+    page.content.push(Content::from(Text {
+        value: "Q3 Report".into(),
+        at: Point::new(72.0, 770.0),
+        font: Standard14::HelveticaBold,
+        size: 28.0,
+        ..Text::default()
+    }));
+    page.content.push(Content::from(Paragraph {
+        text: "Prepared for the board. Revenue, costs and outlook for the \
+               quarter, wrapped and aligned without manual line breaks."
+            .into(),
+        rect: [72.0, 600.0, 523.0, 740.0],
+        ..Paragraph::default()
+    }));
+    page.content.push(Content::from(Link {
+        rect: [72.0, 60.0, 200.0, 80.0],
+        target: LinkTarget::Uri("https://example.com/q3".into()),
+    }));
+    let pdf = Pdf {
+        pages: vec![page],
+        ..Pdf::default()
+    };
+    pdf.save("q3.pdf")?;
+    Ok(())
+}
+```
+
+## Document slots
+
+Beside `pages`, four `Pdf` fields carry document-level structure, each plain data and each optional.
+
+`Outline { bookmarks }` is the viewer's bookmark panel: an ordered forest of `Bookmark { title, page, children }` nodes, `Bookmark::new(title, page)` building a leaf. Each bookmark targets a 0-based page index with an explicit `/XYZ null null null` destination, keeping the viewer's current position and zoom.
+
+`Attachment { name, data, mime, modified, description }` embeds a file via the catalog's `/Names /EmbeddedFiles` name tree. `name` becomes the filespec's `/F` and `/UF` and the name-tree key; `data` is stored as the embedded-file stream, compressed per `WriteOptions::compress`; `mime` is the stream's `/Subtype`, defaulting to `application/octet-stream`; `modified` and `description` write `/Params /ModDate` and `/Desc` only when given. Attachments are reordered bytewise by name at emission, since the name tree's keys must be sorted, so the order given is not preserved; a duplicate name is an error.
+
+`page_labels` holds `PageLabel { first_page, style, prefix, start_at }` ranges controlling how viewers display page numbers. A range takes effect from `first_page` (0-based) until the next range or the document's end. `LabelStyle` is `Decimal`, `RomanUpper`, `RomanLower`, `LettersUpper` or `LettersLower`, written as `/S` `D`, `R`, `r`, `A` or `a`; `prefix` prepends text to every number in the range, and `/St` is written only when `start_at` is not 1. Ranges are reordered by `first_page`, and a non-empty set must include a range starting at page 0.
+
+`Viewer { layout, mode, open_to }` writes the catalog's opening preferences: `/PageLayout` from `PageLayout` (`SinglePage`, `OneColumn`, `TwoColumnLeft`, `TwoColumnRight`, `TwoPageLeft`, `TwoPageRight`), `/PageMode` from `PageMode` (`UseNone`, `UseOutlines`, `UseThumbs`, `FullScreen`), and `/OpenAction` opening the document at a page, keeping position and zoom.
+
+```rust,no_run
+use pdfboss_write::{
+    Attachment, Bookmark, LabelStyle, Outline, Page, PageLabel, PageMode, PageSize, Pdf,
+    Standard14, Viewer,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cover = Page::new(PageSize::A4);
+    cover
+        .canvas
+        .text("Cover", 72.0, 770.0, Standard14::HelveticaBold, 24.0)?;
+    let mut body = Page::new(PageSize::A4);
+    body.canvas
+        .text("Body", 72.0, 770.0, Standard14::Helvetica, 12.0)?;
+    let pdf = Pdf {
+        pages: vec![cover, body],
+        outline: Some(Outline {
+            bookmarks: vec![Bookmark::new("Cover", 0), Bookmark::new("Body", 1)],
+        }),
+        attachments: vec![Attachment {
+            name: "raw-numbers.csv".into(),
+            data: b"a,b,c\n1,2,3\n".to_vec(),
+            mime: Some("text/csv".into()),
+            modified: None,
+            description: Some("Source data".into()),
+        }],
+        page_labels: vec![PageLabel {
+            first_page: 0,
+            style: Some(LabelStyle::RomanLower),
+            prefix: None,
+            start_at: 1,
+        }],
+        viewer: Some(Viewer {
+            mode: Some(PageMode::UseOutlines),
+            ..Viewer::default()
+        }),
+        ..Pdf::default()
+    };
+    pdf.save("book.pdf")?;
+    Ok(())
+}
+```
+
+## Python: pdfboss.write
+
+`pdfboss.write` exposes the same vocabulary as frozen values joined with `|`. A `Page(size="a4", landscape=False)` composes `Text`, `Image`, `Link` and `Paragraph` elements; a `Pdf()` composes pages, `Attachment` and `PageLabel` values (each appended, in order) and the singleton `Metadata`, `Outline` and `Viewer` slots, where a second raises `TypeError`. Every `|` returns a new value and leaves the receiver unchanged, and copies are cheap handle clones: nothing is built until `save(path)` or `to_bytes()`, which lower the composition once and release the GIL to serialize. `to_bytes` may be called repeatedly.
+
+```python
+from pdfboss.write import (
+    Bookmark,
+    Link,
+    Metadata,
+    Outline,
+    Page,
+    Paragraph,
+    Pdf,
+    Standard14,
+    Text,
+)
+
+cover = (
+    Page(size="a4")
+    | Text("Q3 Report", at=(72, 770), font=Standard14.HELVETICA_BOLD, size=28)
+    | Paragraph("Prepared for the board.", rect=(72, 700, 500, 740))
+    | Link(rect=(72, 60, 200, 80), url="https://example.com/q3")
+)
+pdf = Pdf() | Metadata(title="Q3 Report") | cover | Outline(Bookmark("Cover", 0))
+pdf.save("q3.pdf")
+```
+
+Constructors mirror the Rust fields with Python spellings: `Standard14` members are SCREAMING_SNAKE (`Standard14.HELVETICA_BOLD`), string enums are kebab-case (`align="justify"`, `style="roman-lower"`, `layout="single-page"`, `mode="use-outlines"`), `Text` takes an optional `(r, g, b)` color tuple, `Image` takes a path string or raw bytes (read and decoded only at `save`/`to_bytes` time), `Link` takes exactly one of `url` or `page`, and `Bookmark(title, page, children=(...))` nests by construction rather than `|`. The Python write surface stays clock-free, so `Metadata` and `Attachment` carry no date parameters. The full inventory is in the [Python API reference](../reference/python.md#the-write-submodule).
+
+### The draw protocol
+
+Any object with a callable `draw` attribute composes onto a `Page` like an element. During `save`/`to_bytes` the page's in-progress canvas is handed to `draw(canvas)` as a `Canvas` value with twelve methods: `text`, `line`, `rect`, `move_to`, `line_to`, `curve_to`, `close`, `stroke`, `fill`, `set_fill`, `set_stroke` and `set_line_width`. Painting lands in content order, exactly where the object sits in the `|` chain.
+
+```python
+from pdfboss.write import Page, Pdf, Text
+
+
+class Letterhead:
+    def draw(self, canvas):
+        canvas.line(72, 806, 523, 806, width=0.5)
+        canvas.text("ACME GmbH", at=(72, 812), size=8)
+
+
+page = Page(size="a4") | Letterhead() | Text("Body copy", at=(72, 700))
+data = (Pdf() | page).to_bytes()
+```
+
+The canvas is only usable inside the call: any method raises `PdfError` once `draw` has returned. An exception raised inside `draw` propagates from `save`/`to_bytes` exactly as the Python code raised it. The protocol is structural: the stub declares a `Draw` protocol type for checkers, but there is no runtime class to import or inherit.
+
 ## Metadata and dates
 
-`Metadata` fills the document information dictionary: `title`, `author`, `subject`, `keywords`, `creator`, `producer`, `creation_date`, `modification_date` — every field an `Option`, and an all-`None` value writes no dictionary at all. Dates are explicit `Date { year, month, day, hour, minute, second, utc_offset_minutes }` values; the writer never reads a clock, so dates appear in output only when supplied. Nothing in the crate reads clocks or randomness — the file identifier derives from a hash of the emitted body — so the same input produces byte-identical output.
+`Metadata` fills the document information dictionary: `title`, `author`, `subject`, `keywords`, `creator`, `producer`, `creation_date`, `modification_date`. Every field is an `Option`, and an all-`None` value writes no `/Info` dictionary at all. Dates are explicit `Date { year, month, day, hour, minute, second, utc_offset_minutes }` values; the writer never reads a clock, so dates appear in output only when supplied.
+
+Any `Some` metadata, all-`None` included, also writes an XMP metadata stream wired into the catalog as `/Metadata`, built from the same value so the two never drift: `title` becomes `dc:title`, `author` `dc:creator`, `subject` `dc:description`, `keywords` `pdf:Keywords`, `producer` `pdf:Producer`, `creator` `xmp:CreatorTool`, and the dates `xmp:CreateDate`/`xmp:ModifyDate` in ISO-8601. The packet carries no `xmpMM:InstanceID`, no `xmpMM:DocumentID` and no generated timestamps. Nothing in the crate reads clocks or randomness, and the file identifier derives from a hash of the emitted body, so the same input produces byte-identical output.
 
 ## Writing the file
 
@@ -238,6 +387,12 @@ One page per input image (PNG or JPEG, detected by content); without `--size`, e
 
 ```bash
 pdfboss create images photo.png --out photos.pdf
+```
+
+A TOML manifest describes metadata and whole pages declaratively, mapping `[meta]`, `[[page]]`, `[[page.text]]`, `[[page.paragraph]]`, `[[page.image]]` and `[[page.link]]` tables onto the element vocabulary above; the schema is in the [CLI reference](../reference/cli.md#create-manifest):
+
+```bash
+pdfboss create manifest q3.toml -o q3.pdf
 ```
 
 Each result can be checked immediately with `pdfboss info`, which reports the version, page count and page sizes. The full flag reference is in the [CLI reference](../reference/cli.md).

--- a/docs/src/guide/md-to-pdf.md
+++ b/docs/src/guide/md-to-pdf.md
@@ -127,8 +127,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 Because the result is a plain `Pdf`, everything from
-[Creating PDFs](./creating.md) applies afterwards: set `metadata`, append
-canvas-painted pages of your own, or stream the bytes asynchronously.
+[Creating PDFs](./creating.md) applies afterwards: set `metadata`, attach an
+outline or embedded files, add page labels or viewer preferences, append
+pages of your own, or stream the bytes asynchronously.
 
 ## Round trip
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -11,7 +11,8 @@ The surfaces expose the same engine at different altitudes. The CLI covers
 extraction, rendering, creation and explorer subcommands over a document's
 structure; the terminal explorer browses a file interactively, local or
 remote. Python gets `Document` and its async twin `AsyncDocument`, with
-pages, styled spans, lazy element iteration, rendering and image extraction.
+pages, styled spans, lazy element iteration, rendering and image extraction,
+plus document creation through `pdfboss.write` and `pdfboss.md.to_pdf`.
 The Rust crates split the core by concern, from parsing (`pdfboss-core`)
 through layout analysis (`pdfboss-output`) and rasterization
 (`pdfboss-render`) to creation (`pdfboss-write`).
@@ -41,9 +42,10 @@ pdfboss extracts plain text and Markdown (headings, lists and tables inferred
 from page layout), yields styled text spans carrying position, font, weight,
 decorations and color, rasterizes pages to PNG through its own JPEG 2000,
 JBIG2, CCITT and ICC codecs, extracts embedded images at their native pixel
-size, creates new PDFs — canvas-level through the `pdfboss-write` crate and
-`pdfboss create`, and CommonMark+GFM composed into CSS-themed documents from
-the CLI, Python (`pdfboss.md.to_pdf`) and Rust — and reads documents
+size, creates new PDFs (canvas painting and element composition through the
+`pdfboss-write` crate, the `pdfboss.write` Python module and `pdfboss create`,
+a TOML manifest form included, plus CommonMark+GFM composed into CSS-themed
+documents from the CLI, Python `pdfboss.md.to_pdf` and Rust), and reads documents
 asynchronously over range-fetching I/O, from local files or HTTP, without
 ever reading the whole file.
 
@@ -67,8 +69,8 @@ guide then takes one task per chapter:
   render reports.
 - [Extracting images](./guide/images.md) — every image a page draws, at
   native size.
-- [Creating PDFs](./guide/creating.md) — blank, text and image pages from
-  the CLI and Rust.
+- [Creating PDFs](./guide/creating.md): canvas painting, composed elements
+  and document slots from the CLI, Python and Rust.
 - [Markdown to PDF](./guide/md-to-pdf.md) — CommonMark+GFM composed into
   themed, paginated documents.
 - [Async and remote documents](./guide/async.md) — range-fetching access to

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -47,9 +47,9 @@ pdf = pdfboss.md.to_pdf(Path("notes.md").read_text())  # markdown -> PDF bytes
 0-based with negative indexes from the end, and `render` returns PNG bytes
 directly. `extract_images` yields each image the page draws at its native
 pixel size, PNG-encoded. `pdfboss.md.to_pdf` composes CommonMark+GFM into a
-themed PDF ([Markdown to PDF](./guide/md-to-pdf.md)); canvas-level creation
-lives in the CLI and the `pdfboss-write` crate
-([Creating PDFs](./guide/creating.md)).
+themed PDF ([Markdown to PDF](./guide/md-to-pdf.md)); `pdfboss.write` composes
+pages, elements and document slots with `|`, the same vocabulary the CLI and
+the `pdfboss-write` crate expose ([Creating PDFs](./guide/creating.md)).
 
 ## Rust
 
@@ -83,7 +83,8 @@ Python; only the CLI counts from 1.
 - [Rendering pages](./guide/rendering.md) for scale, font tiers and PNG
   compression.
 - [Extracting images](./guide/images.md) for what counts as an embedded image.
-- [Creating PDFs](./guide/creating.md) for blank, text and image pages.
+- [Creating PDFs](./guide/creating.md) for canvas painting, composed pages
+  and document slots.
 - [Markdown to PDF](./guide/md-to-pdf.md) for themed CommonMark+GFM
   composition.
 - [Async and remote documents](./guide/async.md) for `AsyncDocument` and HTTP

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -160,13 +160,13 @@ pdfboss q report.pdf -r '.pages[].fonts[].base_font'
 
 ## create
 
-Create a new PDF: blank pages, word-wrapped text, image pages, or a themed Markdown document.
+Create a new PDF: blank pages, word-wrapped text, image pages, a themed Markdown document, or a TOML manifest of composed pages.
 
 ```text
 pdfboss create <COMMAND>
 ```
 
-Four subcommands, each writing to `-o, --out <OUT>`. All four share `--size a3|a4|a5|letter|legal` and `--landscape` (swap page width and height). See [Creating PDFs](../guide/creating.md) and [Markdown to PDF](../guide/md-to-pdf.md).
+Five subcommands, each writing to `-o, --out <OUT>`. The first four share `--size a3|a4|a5|letter|legal` and `--landscape` (swap page width and height); `manifest` takes neither, since page size and orientation live per page inside the TOML. See [Creating PDFs](../guide/creating.md) and [Markdown to PDF](../guide/md-to-pdf.md).
 
 ### create blank
 
@@ -223,4 +223,58 @@ Relative image paths in the markdown resolve against the input file's directory.
 
 ```bash
 pdfboss create md notes.md -o notes.pdf --theme theme.css --size letter
+```
+
+### create manifest
+
+A TOML manifest describing metadata and pages: text, paragraphs, images and links mapped onto the compose vocabulary of `pdfboss-write`. See [Creating PDFs](../guide/creating.md#composing-pages) for that vocabulary.
+
+```text
+pdfboss create manifest --out <OUT> <INPUT>
+```
+
+The manifest's tables:
+
+- `[meta]`: optional document information, mapped onto `/Info`: `title`, `author`, `subject`, `keywords`, `creator`, `producer`, each a string.
+- `[[page]]`: one table per page, in reading order. `size` names a page size case-insensitively (`a3`, `a4`, `a5`, `letter`, `legal`; absent defaults to `a4`) and `landscape` (boolean) swaps width and height, both per page.
+- `[[page.text]]`: one line of text: `value`, `at = [x, y]` (the baseline origin), optional `font` and `size`.
+- `[[page.paragraph]]`: wrapped text: `value`, `rect = [x0, y0, x1, y1]`, optional `font`, `size`, `leading` and `align` (`left`, `center`, `right`, `justify`).
+- `[[page.image]]`: a placed raster: `path` (resolved relative to the manifest's directory, decoded by content as PNG or JPEG), `at = [x, y]`, optional `width` and `height`.
+- `[[page.link]]`: a clickable rectangle: `rect` plus exactly one of `url` or `page` (a 0-based page index in the same document).
+
+Font names are PostScript base names (`Helvetica`, `Helvetica-Bold`, `Times-Roman`, `Courier-Oblique`, …), unlike the kebab-case values of `create text --font`; an unknown name errors listing the valid set, and an absent one defaults to `Helvetica`. Unknown TOML keys are rejected, and every error message is prefixed with the manifest's path. Within a page, content lowers in schema order (text, then paragraphs, then images, then links) regardless of how the tables interleave in the file; TOML's separate arrays of tables carry no cross-type order.
+
+```toml
+[meta]
+title  = "Q3 Report"
+author = "pdfboss"
+
+[[page]]
+size = "a4"
+
+  [[page.text]]
+  value = "Q3 Report"
+  at    = [72, 770]
+  font  = "Helvetica-Bold"
+  size  = 28
+
+  [[page.paragraph]]
+  value   = "Body copy for the quarter."
+  rect    = [72, 380, 523, 720]
+  size    = 11
+  leading = 15
+  align   = "left"
+
+  [[page.image]]
+  path  = "chart.png"
+  at    = [72, 96]
+  width = 200
+
+  [[page.link]]
+  rect = [72, 88, 523, 380]
+  url  = "https://example.com/q3"
+```
+
+```bash
+pdfboss create manifest q3.toml -o q3.pdf
 ```

--- a/docs/src/reference/python.md
+++ b/docs/src/reference/python.md
@@ -1,6 +1,6 @@
 # Python API
 
-The `pdfboss` package re-exports the compiled extension module `pdfboss._pdfboss`. Its public surface is twelve classes, the `md` submodule and the `__version__` string; the typed stubs in [`_pdfboss.pyi`](https://github.com/4thel00z/pdfboss/blob/main/python/pdfboss/_pdfboss.pyi) are the authoritative reference for every signature and docstring. This chapter is the inventory; worked examples live in the guide chapters.
+The `pdfboss` package re-exports the compiled extension module `pdfboss._pdfboss`. Its public surface is twelve top-level classes, the `md` and `write` submodules and the `__version__` string; the typed stubs in [`_pdfboss.pyi`](https://github.com/4thel00z/pdfboss/blob/main/python/pdfboss/_pdfboss.pyi) are the authoritative reference for every signature and docstring. This chapter is the inventory; worked examples live in the guide chapters.
 
 ## The twelve classes
 
@@ -27,13 +27,38 @@ indexes; subscription `doc[i]` accepts them) and `get_object(num, gen=0)`, a
 coroutine fetching one indirect object and returning it through the same
 plain-Python conversion as `Element.value()`.
 
-Guide chapters with runnable examples: [Extracting text](../guide/text.md), [Markdown output](../guide/markdown.md), [Styled spans](../guide/spans.md), [Rendering pages](../guide/rendering.md), [Extracting images](../guide/images.md), [Markdown to PDF](../guide/md-to-pdf.md), [Async and remote documents](../guide/async.md), [Encrypted documents](../guide/encryption.md).
+Guide chapters with runnable examples: [Extracting text](../guide/text.md), [Markdown output](../guide/markdown.md), [Styled spans](../guide/spans.md), [Rendering pages](../guide/rendering.md), [Extracting images](../guide/images.md), [Creating PDFs](../guide/creating.md), [Markdown to PDF](../guide/md-to-pdf.md), [Async and remote documents](../guide/async.md), [Encrypted documents](../guide/encryption.md).
 
 ## The md submodule
 
 `pdfboss.md.to_pdf(markdown, theme=None, size="a4", landscape=False, base_dir=None)` composes CommonMark+GFM source into a themed PDF and returns the file bytes. `theme` is CSS source text, not a path; an unknown `size` raises `PdfError`; replaced characters and skipped raw HTML surface as one `UserWarning`. Details and examples in [Markdown to PDF](../guide/md-to-pdf.md).
 
-That is Python's one creation path. Canvas-level creation — shapes, glyph runs, image placement — is the Rust crate [`pdfboss-write`](./rust.md) and the [`pdfboss create`](./cli.md#create) CLI.
+Canvas-level and element-level creation from Python is the `write` submodule below.
+
+## The write submodule
+
+`pdfboss.write` composes new PDFs from frozen values joined with `|`; the same vocabulary is the Rust crate [`pdfboss-write`](./rust.md) and the [`pdfboss create`](./cli.md#create) CLI, and worked examples live in [Creating PDFs](../guide/creating.md#python-pdfbosswrite). Fourteen classes:
+
+| Name | What it is |
+|---|---|
+| `Pdf` | A document under construction; composes pages, attachments and page labels (appended) and the singleton `Metadata`, `Outline` and `Viewer` slots; `save(path)` and `to_bytes()` serialize |
+| `Page` | One page (`size` names a size case-insensitively, default `"a4"`; `landscape` swaps width and height); composes `Text`, `Image`, `Link`, `Paragraph` or any draw object |
+| `Text` | One line of text: `value`, `at=(x, y)` baseline origin, `font` (default `Standard14.HELVETICA`), `size` (default 12.0), optional `(r, g, b)` `color` |
+| `Paragraph` | Wrapped, aligned text: `text`, `rect`, `font`, `size` (default 11.0), `leading` (default derived from `size`), `align` of `left`, `center`, `right` or `justify` |
+| `Image` | A placed raster: `data` as a path string or bytes, `at`, optional `width`/`height`; either source is read and decoded at `save`/`to_bytes` time |
+| `Link` | A clickable rectangle: `rect` plus exactly one of `url` or `page` (0-based) |
+| `Bookmark` | One outline entry: `title`, `page`, keyword-only `children`; nests by construction |
+| `Outline` | The bookmark panel, `Outline(*bookmarks)`; a singleton `Pdf` slot |
+| `Attachment` | An embedded file: `name`, `data`, optional `mime` and `description`; carries no dates |
+| `PageLabel` | One page-numbering range: `first_page` (0-based), optional `style` (`decimal`, `roman-upper`, `roman-lower`, `letters-upper`, `letters-lower`), `prefix`, `start_at` (default 1) |
+| `Viewer` | Opening preferences: `layout`, `mode`, `open_to`; a singleton `Pdf` slot |
+| `Metadata` | `/Info` text fields: `title`, `author`, `subject`, `keywords`, `creator`, `producer`; a singleton `Pdf` slot |
+| `Standard14` | The fourteen standard faces as SCREAMING_SNAKE members: `HELVETICA`, `TIMES_BOLD_ITALIC`, `ZAPF_DINGBATS`, … |
+| `Canvas` | The painting surface handed to a draw object's `draw` method; it has no public constructor |
+
+Every `|` returns a new value and leaves the receiver unchanged; copies are cheap handle clones, and nothing is built until `save` or `to_bytes`, which lower the composition once under the GIL and release it to serialize. `to_bytes` may be called repeatedly, since the composed value is never consumed.
+
+The draw protocol is structural: any object with a callable `draw` attribute composes onto a `Page`, and its `draw(canvas)` receives a `Canvas` with twelve methods (`text`, `line`, `rect`, `move_to`, `line_to`, `curve_to`, `close`, `stroke`, `fill`, `set_fill`, `set_stroke`, `set_line_width`) that paints in content order. The stub declares a `Draw` protocol type for checkers only; there is no runtime `Draw` class to import or inherit. The canvas is only usable inside the call, and every method raises `PdfError` once `draw` has returned.
 
 ## Error handling
 
@@ -49,6 +74,8 @@ except pdfboss.PdfError as e:
 ```
 
 Two conventional exceptions apply where Python conventions demand them: constructing a `Document` with neither or both of `path` and `data` raises `ValueError` (as does a non-positive `scale`, an unknown `fonts=` or `compression=` string, or an unusable `fonts="full"` setup in `render`), and an out-of-range page index raises `IndexError`. Element iterators have salvage semantics: a per-item failure raises `PdfError` for that item, and iteration may be continued. Span iterators raise `PdfError` when a page cannot be materialized.
+
+The `write` submodule splits its failures by phase. `TypeError` is raised at construction for a `Link` with neither or both of `url` and `page`, an unknown `align`, page-label `style`, viewer `layout` or `mode`, or `Image` data that is neither `str` nor `bytes`; and at composition for an unsupported `|` operand or a second `Metadata`, `Outline` or `Viewer`. Everything that fails while lowering (an unreadable or undecodable image file, a paragraph overflowing its rect, an unencodable character, a target page out of range) raises `PdfError` from `save`/`to_bytes`. A draw object's `Canvas` stops working the moment its `draw` call returns: any later method call on it raises `PdfError` at that call site. An exception raised inside `draw()` itself propagates from `save`/`to_bytes` exactly as the Python code raised it.
 
 ## Threading
 

--- a/docs/src/reference/rust.md
+++ b/docs/src/reference/rust.md
@@ -11,7 +11,7 @@ pdfboss is a workspace of focused crates, all sharing one version. Add the ones 
 | `pdfboss-jpx` | Cleanroom JPEG 2000 (`JPXDecode`) decoder (ITU-T T.800) | [docs.rs](https://docs.rs/pdfboss-jpx) |
 | `pdfboss-icc` | Cleanroom ICC profile parser and colour transform (ICC.1:2010) | [docs.rs](https://docs.rs/pdfboss-icc) |
 | `pdfboss-render` | Page rasterization to RGBA pixmaps and PNG, plus embedded-image extraction | [docs.rs](https://docs.rs/pdfboss-render) |
-| `pdfboss-write` | PDF creation: COS object writer, content canvas, link annotations and document assembly | [docs.rs](https://docs.rs/pdfboss-write) |
+| `pdfboss-write` | PDF creation: COS object writer, content canvas, composed elements (text, paragraph, image, link), outlines, attachments, page labels, viewer preferences, XMP metadata and document assembly | [docs.rs](https://docs.rs/pdfboss-write) |
 | `pdfboss-style` | CSS-subset themes for document composition | [docs.rs](https://docs.rs/pdfboss-style) |
 | `pdfboss-markdown` | CommonMark+GFM composed into themed PDFs | [docs.rs](https://docs.rs/pdfboss-markdown) |
 | `pdfboss-aio` | Async, range-fetching PDF access: huge files, many documents, remote HTTP sources | [docs.rs](https://docs.rs/pdfboss-aio) |
@@ -26,7 +26,7 @@ A further workspace member, `pdfboss-testkit`, is an internal PDF fixture builde
 - Reading a document: `pdfboss_core::Document` — `open`, `load`, and their `_with_password` twins, then `page`, `page_count`, `metadata`, `version`.
 - Text and markdown: `pdfboss_output::{extract_text, extract_markdown}`; positioned styled spans via `pdfboss_text::extract_spans`.
 - Rasterizing: `pdfboss_render::{render_page, render_page_with_options, render_page_reporting}` and `Pixmap::save_png`; embedded images via `extract_page_images`.
-- Creating: `pdfboss_write::{Pdf, Page, Canvas}` — see [Creating PDFs](../guide/creating.md).
+- Creating: `pdfboss_write::{Pdf, Page, Canvas, Content}`, see [Creating PDFs](../guide/creating.md).
 - Composing Markdown: `pdfboss_markdown::to_pdf` with a `pdfboss_style::Theme` — see [Markdown to PDF](../guide/md-to-pdf.md).
 - Async and HTTP sources: `pdfboss_aio::AsyncDocument` — `open`, `open_url`, `from_bytes` — see [Async and remote documents](../guide/async.md).
 - Element iteration: `pdfboss_core::Document::elements(ElementOpts)`, a lazy iterator over physical and logical elements, and the async `AsyncDocument::elements`, which returns an `ElementStream`; see [Exploring PDF internals](../guide/explorer.md).

--- a/python/pdfboss/_pdfboss.pyi
+++ b/python/pdfboss/_pdfboss.pyi
@@ -701,8 +701,8 @@ class write:
             width: float | None = None,
             height: float | None = None,
         ) -> None:
-            """``data`` is a filesystem path, read only at
-            ``save``/``to_bytes`` time, or raw image bytes decoded eagerly.
+            """``data`` is a filesystem path or raw image bytes; either
+            source is read and decoded at ``save``/``to_bytes`` time.
             Raises ``TypeError`` for any other type. ``width``/``height``
             default to the image's native size in points."""
 


### PR DESCRIPTION
Follow-up to #113: PR #112 merged the composition layer (element vocabulary, pdfboss.write, create manifest) with no book changes, which re-opened 27 verified gaps including several now-false statements (Python's one creation path, the Pdf/Page/LinkAnnotation struct shapes, the four-subcommand create count).

This closes all 27: new Composing pages and Document slots sections in the creating chapter, a pdfboss.write reference section (slot semantics, the draw protocol and its stub-only Draw type, error phases), the create manifest TOML schema in the CLI reference, XMP metadata coverage, and scope corrections in the introduction and quickstart. One pyi docstring fixed (Image data decodes at save/to_bytes time, not eagerly).

Verified: mdbook build clean; both Rust examples compiled against the worktree crates; both Python examples executed against a wheel built from the worktree (the q3 manifest round-trips extract_text); the TOML example parses via tomllib.