### PR TITLE
feat(cli): bundled Claude Code skill and pdfboss skill install

### DIFF
--- a/crates/pdfboss-cli/skill/SKILL.md
+++ b/crates/pdfboss-cli/skill/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: pdfboss
+description: Use when reading, extracting, rendering, creating, or exploring PDF files with pdfboss, the from-scratch Rust PDF engine with a CLI and Python bindings. Triggers include extracting text or Markdown from a PDF, rasterizing pages to PNG, pulling embedded images, composing a new PDF (blank, text, images, Markdown, TOML manifest, or the pdfboss.write API), inspecting PDF internals (objects, xref, hexdump, jq-style queries), reading PDFs over HTTP without downloading them whole, and opening encrypted PDFs.
+---
+
+# pdfboss
+
+A PDF engine written from scratch in safe Rust: parse, extract text and Markdown, rasterize to PNG, extract embedded images, and create PDFs. One core behind the `pdfboss` CLI and the `pdfboss` Python package. Clean-room from ISO 32000, no C dependencies. The reader is lenient: broken cross-reference tables are reconstructed, wrong stream lengths tolerated, garbage operators skipped, and every dropped or approximated item is reported instead of silently lost.
+
+## Install
+
+```bash
+pip install pdfboss            # abi3 wheels, CPython 3.12+, no toolchain needed
+pip install 'pdfboss[full]'    # adds the OFL substitute faces (pdfboss-fonts)
+cargo install pdfboss-cli      # the `pdfboss` binary
+```
+
+## CLI
+
+```bash
+pdfboss info    doc.pdf                     # version, page count, sizes, metadata
+pdfboss text    doc.pdf --page 2            # omit --page for all pages
+pdfboss md      doc.pdf                     # Markdown: headings, lists, tables from layout
+pdfboss render  doc.pdf --page 1 -o p.png --scale 2.0
+pdfboss images  doc.pdf -o out/             # embedded images as native-size PNGs
+pdfboss tui     doc.pdf                     # interactive terminal explorer
+```
+
+Every command takes a local path or an `http(s)://` URL; remote files are fetched in byte ranges rather than downloaded whole. Encrypted files take `--password` (an empty user password opens transparently).
+
+Creation:
+
+```bash
+pdfboss create blank  -o out.pdf --pages 3
+pdfboss create text   notes.txt -o out.pdf
+pdfboss create images a.png b.jpg -o out.pdf
+pdfboss create md     notes.md -o out.pdf        # CommonMark+GFM, CSS-themable
+pdfboss create manifest doc.toml -o out.pdf      # [meta] plus [[page]] text/paragraph/image/link
+```
+
+Explorer:
+
+```bash
+pdfboss json doc.pdf                 # the document as a JSON value tree (--layout adds page blocks)
+pdfboss q    doc.pdf '.header.version'
+pdfboss obj  doc.pdf 5               # pretty-print object 5
+pdfboss hex  doc.pdf obj:5           # hexdump the file or one element
+```
+
+Fonts: `--fonts embedded-only|all-embedded|full`. The default resolves to `full` when substitute faces are available (the compiled-in OFL set or `--font-dir`), otherwise `all-embedded`. Text a tier leaves unpainted still advances, so the rest of the page keeps its layout.
+
+## Python
+
+```python
+import pdfboss
+
+doc  = pdfboss.Document("doc.pdf")            # or Document(data=raw_bytes), password=""
+text = doc.extract_text()                     # pages fan out across cores
+md   = doc.extract_markdown()
+png  = doc[0].render(scale=2.0)               # PNG bytes
+png, warnings = doc[0].render_reporting()     # warnings list every drop or approximation
+images = doc[0].extract_images()              # each: .data (PNG bytes), .width, .height
+spans  = list(doc.spans())                    # styled spans: font, weight, color, position
+
+# async, over files or HTTP, range-fetched
+doc = await pdfboss.AsyncDocument.open_url("https://example.com/doc.pdf")
+
+# composition: pages and elements join with |, singleton slots raise on duplicates
+from pdfboss.write import Pdf, Page, Text, Paragraph, Metadata, Standard14
+page = (
+    Page(size="a4")
+    | Text("Title", at=(72, 770), font=Standard14.HELVETICA_BOLD, size=28)
+    | Paragraph("Body text.", rect=(72, 100, 451, 640))
+)
+data = (Pdf() | Metadata(title="Title") | page).to_bytes()
+
+# markdown to PDF: returns the file bytes
+data = pdfboss.md.to_pdf("# Hello\n\nWorld", theme=None, size="a4")
+```
+
+`fonts=` on the render methods defaults to `None`, resolving to `"full"` when `font_dir=` is given or the `pdfboss-fonts` package is importable, else `"all-embedded"`; an explicit `fonts="full"` with no face source raises `ValueError`. The type stubs in `pdfboss/_pdfboss.pyi` are the authoritative signatures.
+
+## Rust
+
+Library crates on crates.io: `pdfboss-core` (the reader), `pdfboss-text`, `pdfboss-output` (plain text and Markdown), `pdfboss-render` (rasterizer; `RenderOptions` fields `glyph_painting`, `substitutes`, `oc`, `cache`), `pdfboss-write` (creation), `pdfboss-markdown` (Markdown to PDF), `pdfboss-aio` (async range-fetching I/O), `pdfboss-jpx` and `pdfboss-icc` (its own codecs), `pdfboss-tui`.
+
+## Gotchas
+
+- Rendering never fails on unreadable content; when fidelity matters, use `render_reporting` and check the warnings instead of assuming a clean render.
+- `/Symbol` and `/ZapfDingbats` have no license-clean substitute and stay blank at every tier.
+- Scanned PDFs (JBIG2, CCITT) carry no text layer: `text` and `md` return little or nothing there; render the pages instead.
+- `extract_markdown` drops repeated page headers and footers by design.
+- A whole-document Rust render walk should share one `RenderCache` through `RenderOptions::cache` so fonts and ICC profiles load once.
+
+## Links
+
+- User guide: https://4thel00z.github.io/pdfboss/
+- Site and benchmarks: https://pdfboss.dev
+- Race it in a browser: https://pdfarena.tahrioui.de
+- Repository: https://github.com/4thel00z/pdfboss

--- a/crates/pdfboss-cli/src/main.rs
+++ b/crates/pdfboss-cli/src/main.rs
@@ -7,6 +7,7 @@ mod input;
 mod json;
 mod manifest;
 mod q;
+mod skill;
 
 use pdfboss_core::pretty;
 
@@ -248,6 +249,11 @@ enum Command {
         #[arg(long)]
         content_ops: bool,
     },
+    /// Install or print the bundled Claude Code skill for coding agents.
+    Skill {
+        #[command(subcommand)]
+        command: skill::SkillCommand,
+    },
 }
 
 /// `--fonts` choices for `render`, mapping to `pdfboss_render::GlyphPainting`.
@@ -315,6 +321,7 @@ fn main() {
     let cli = Cli::parse();
     let result: Result<(), Failure> = match cli.command {
         Command::Create { command } => create::cmd_create(command).map_err(Failure::from),
+        Command::Skill { command } => skill::cmd_skill(command).map_err(Failure::from),
         Command::Info { file, password } => cmd_info(&file, &password).map_err(Failure::from),
         Command::Text {
             file,

--- a/crates/pdfboss-cli/src/skill.rs
+++ b/crates/pdfboss-cli/src/skill.rs
@@ -1,0 +1,110 @@
+//! `pdfboss skill`: installing the bundled Claude Code skill, which teaches
+//! coding agents the CLI, Python and Rust surfaces of pdfboss.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::Subcommand;
+
+/// The skill document compiled into the binary, so the installed skill
+/// always matches the installed pdfboss version.
+const SKILL_MD: &str = include_str!("../skill/SKILL.md");
+
+/// The nested subcommands of `pdfboss skill`.
+#[derive(Subcommand)]
+pub enum SkillCommand {
+    /// Install the skill for coding agents: into ./.claude/skills/pdfboss
+    /// (this project), or with --global into ~/.claude/skills/pdfboss.
+    Install {
+        /// Install into ~/.claude/skills instead of ./.claude/skills.
+        #[arg(long, short = 'g')]
+        global: bool,
+    },
+    /// Print the skill document to stdout.
+    Show,
+}
+
+pub fn cmd_skill(command: SkillCommand) -> Result<(), String> {
+    match command {
+        SkillCommand::Install { global } => {
+            let root = skills_root(global)?;
+            let path = install_into(&root)?;
+            println!("installed {}", path.display());
+            Ok(())
+        }
+        SkillCommand::Show => {
+            print!("{SKILL_MD}");
+            Ok(())
+        }
+    }
+}
+
+/// The `.claude/skills` directory the flag selects: the home directory's
+/// for `--global`, the current directory's otherwise.
+fn skills_root(global: bool) -> Result<PathBuf, String> {
+    if !global {
+        return Ok(PathBuf::from(".claude").join("skills"));
+    }
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .ok_or_else(|| "cannot locate the home directory: neither HOME nor USERPROFILE is set".to_string())?;
+    Ok(PathBuf::from(home).join(".claude").join("skills"))
+}
+
+/// Writes the skill under `root/pdfboss/SKILL.md`, creating directories as
+/// needed and overwriting any previous install, and returns the file path.
+fn install_into(root: &Path) -> Result<PathBuf, String> {
+    let dir = root.join("pdfboss");
+    fs::create_dir_all(&dir)
+        .map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+    let path = dir.join("SKILL.md");
+    fs::write(&path, SKILL_MD).map_err(|e| format!("cannot write {}: {e}", path.display()))?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "pdfboss-skill-{tag}-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn installs_and_overwrites() {
+        let root = scratch_dir("install");
+        let path = install_into(&root).unwrap();
+        assert_eq!(path, root.join("pdfboss").join("SKILL.md"));
+        let written = fs::read_to_string(&path).unwrap();
+        assert_eq!(written, SKILL_MD);
+
+        // A second install overwrites rather than failing.
+        fs::write(&path, "stale").unwrap();
+        install_into(&root).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), SKILL_MD);
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn skill_document_has_frontmatter_and_no_em_dashes() {
+        assert!(SKILL_MD.starts_with("---\nname: pdfboss\n"));
+        assert!(SKILL_MD.contains("description:"));
+        assert!(!SKILL_MD.contains('\u{2014}'));
+    }
+
+    #[test]
+    fn local_root_is_relative_and_global_root_is_under_home() {
+        assert_eq!(
+            skills_root(false).unwrap(),
+            PathBuf::from(".claude").join("skills")
+        );
+        let global = skills_root(true).unwrap();
+        assert!(global.ends_with(Path::new(".claude").join("skills")));
+        assert!(global.is_absolute());
+    }
+}

--- a/crates/pdfboss-cli/src/skill.rs
+++ b/crates/pdfboss-cli/src/skill.rs
@@ -47,7 +47,9 @@ fn skills_root(global: bool) -> Result<PathBuf, String> {
     }
     let home = std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
-        .ok_or_else(|| "cannot locate the home directory: neither HOME nor USERPROFILE is set".to_string())?;
+        .ok_or_else(|| {
+            "cannot locate the home directory: neither HOME nor USERPROFILE is set".to_string()
+        })?;
     Ok(PathBuf::from(home).join(".claude").join("skills"))
 }
 
@@ -55,8 +57,7 @@ fn skills_root(global: bool) -> Result<PathBuf, String> {
 /// needed and overwriting any previous install, and returns the file path.
 fn install_into(root: &Path) -> Result<PathBuf, String> {
     let dir = root.join("pdfboss");
-    fs::create_dir_all(&dir)
-        .map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+    fs::create_dir_all(&dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
     let path = dir.join("SKILL.md");
     fs::write(&path, SKILL_MD).map_err(|e| format!("cannot write {}: {e}", path.display()))?;
     Ok(path)
@@ -67,10 +68,7 @@ mod tests {
     use super::*;
 
     fn scratch_dir(tag: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "pdfboss-skill-{tag}-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("pdfboss-skill-{tag}-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         dir
     }


### PR DESCRIPTION
Adds a Claude Code skill for pdfboss, compiled into the binary, and a subcommand to install it:

- `pdfboss skill install` writes ./.claude/skills/pdfboss/SKILL.md (project-local)
- `pdfboss skill install --global` writes ~/.claude/skills/pdfboss/SKILL.md
- `pdfboss skill show` prints the document

The skill covers the CLI (including create manifest and the explorer), the Python surface (Document, render_reporting, spans, AsyncDocument, pdfboss.write slot composition, md.to_pdf returning bytes), the Rust crate map, the fonts-default resolution rule, and the practical gotchas (reporting, scanned PDFs, Symbol/ZapfDingbats, RenderCache). Every code example was checked against the type stubs and crate sources; the document deliberately carries no benchmark numbers so it stays true across releases. Embedding via include_str! keeps the installed skill in lockstep with the installed binary.

Verified: cargo test -p pdfboss-cli green (184), clippy -D warnings clean, both install modes exercised end to end with the built binary.