### PR TITLE
feat(aio)!: fall back to one full download when the server ignores Range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pdfboss-aio"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bytes",
  "flate2",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-cli"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "base64",
  "clap",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "criterion",
  "flate2",
@@ -1279,19 +1279,19 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-encoding"
-version = "0.24.0"
+version = "0.25.0"
 
 [[package]]
 name = "pdfboss-icc"
-version = "0.24.0"
+version = "0.25.0"
 
 [[package]]
 name = "pdfboss-jpx"
-version = "0.24.0"
+version = "0.25.0"
 
 [[package]]
 name = "pdfboss-markdown"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "pdfboss-core",
  "pdfboss-output",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-output"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "criterion",
  "pdfboss-core",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-py"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "futures-util",
  "pdfboss-aio",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-render"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "criterion",
  "jpeg-decoder",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-style"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "cssparser",
  "pdfboss-write",
@@ -1355,11 +1355,11 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-testkit"
-version = "0.24.0"
+version = "0.25.0"
 
 [[package]]
 name = "pdfboss-text"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "pdfboss-core",
  "pdfboss-encoding",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-tui"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "crossterm",
  "futures-util",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-write"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "flate2",
  "pdfboss-core",

--- a/crates/pdfboss-aio/src/backend.rs
+++ b/crates/pdfboss-aio/src/backend.rs
@@ -1,7 +1,8 @@
 //! Random-access byte sources: in-memory bytes, positioned file reads on a
 //! blocking thread, and (behind the `http` feature) remote HTTP range
-//! requests. The trait is object-safe — futures are boxed — so documents
-//! can hold `Arc<dyn Backend>`.
+//! requests with a one-time full-download fallback for range-less servers.
+//! The trait is object-safe — futures are boxed — so documents can hold
+//! `Arc<dyn Backend>`.
 
 use std::io;
 use std::path::Path;
@@ -38,6 +39,18 @@ impl From<Bytes> for MemBackend {
     }
 }
 
+/// One bounded read from an in-memory byte source: offsets at or past the
+/// end read zero bytes, everything else fills as much of `buf` as the data
+/// allows.
+fn read_from_bytes(data: &[u8], offset: u64, buf: &mut [u8]) -> usize {
+    let start = usize::try_from(offset)
+        .unwrap_or(usize::MAX)
+        .min(data.len());
+    let count = buf.len().min(data.len() - start);
+    buf[..count].copy_from_slice(&data[start..start + count]);
+    count
+}
+
 impl Backend for MemBackend {
     fn len(&self) -> BoxFuture<'_, io::Result<u64>> {
         let total = self.0.len() as u64;
@@ -45,15 +58,7 @@ impl Backend for MemBackend {
     }
 
     fn read_at<'a>(&'a self, offset: u64, buf: &'a mut [u8]) -> BoxFuture<'a, io::Result<usize>> {
-        Box::pin(async move {
-            let data = &self.0;
-            let start = usize::try_from(offset)
-                .unwrap_or(usize::MAX)
-                .min(data.len());
-            let count = buf.len().min(data.len() - start);
-            buf[..count].copy_from_slice(&data[start..start + count]);
-            Ok(count)
-        })
+        Box::pin(async move { Ok(read_from_bytes(&self.0, offset, buf)) })
     }
 }
 
@@ -136,14 +141,18 @@ impl Backend for FileBackend {
 }
 
 /// A byte source over HTTP: length via `HEAD`/`Content-Length`, reads via
-/// `Range: bytes=` requests. A server that ignores Range (answers 200
-/// with the full body instead of 206) yields
-/// [`crate::Error::RangeUnsupported`].
+/// `Range: bytes=` requests. A server that ignores Range (answers 200 with
+/// the full body instead of 206, like `python3 -m http.server`) triggers a
+/// one-time fallback: that very response body is the whole resource, so it
+/// is collected into memory (capped at the declared length) and every read
+/// is served from it. Range-less servers cost one full download held
+/// resident instead of failing.
 #[cfg(feature = "http")]
 pub struct HttpBackend {
     client: reqwest::Client,
     url: reqwest::Url,
     len: u64,
+    full: std::sync::OnceLock<Bytes>,
 }
 
 #[cfg(feature = "http")]
@@ -178,7 +187,39 @@ impl HttpBackend {
                 status: Some(response.status().as_u16()),
                 msg: format!("HEAD {url}: missing or malformed Content-Length"),
             })?;
-        Ok(HttpBackend { client, url, len })
+        Ok(HttpBackend {
+            client,
+            url,
+            len,
+            full: std::sync::OnceLock::new(),
+        })
+    }
+
+    /// Collects a 200 response body (the whole resource) capped at the
+    /// declared length, so a hostile (or merely buggy) server whose body
+    /// is larger, or never finishes, cannot grow memory past `len` or
+    /// stall the read; a body that ends short of `len` is kept as-is and
+    /// later reads past it come back short.
+    async fn collect_full_body(&self, response: reqwest::Response) -> io::Result<Bytes> {
+        use futures_util::StreamExt;
+        let cap = usize::try_from(self.len).unwrap_or(usize::MAX);
+        let mut collected = Vec::new();
+        let mut chunks = response.bytes_stream();
+        while collected.len() < cap {
+            let chunk = match chunks.next().await {
+                Some(Ok(chunk)) => chunk,
+                Some(Err(err)) => {
+                    return Err(http_io_error(crate::error::TransportMarker {
+                        status: None,
+                        msg: format!("GET {}: {err}", self.url),
+                    }))
+                }
+                None => break, // body ended short of the declared length
+            };
+            let take = (cap - collected.len()).min(chunk.len());
+            collected.extend_from_slice(&chunk[..take]);
+        }
+        Ok(Bytes::from(collected))
     }
 }
 
@@ -202,6 +243,9 @@ impl Backend for HttpBackend {
             if offset >= self.len || buf.is_empty() {
                 return Ok(0);
             }
+            if let Some(body) = self.full.get() {
+                return Ok(read_from_bytes(body, offset, buf));
+            }
             let last = (offset + buf.len() as u64 - 1).min(self.len - 1);
             let response = self
                 .client
@@ -210,7 +254,7 @@ impl Backend for HttpBackend {
                 .send()
                 .await
                 .map_err(|err| {
-                    http_io_error(crate::error::TransportMarker::Http {
+                    http_io_error(crate::error::TransportMarker {
                         status: err.status().map(|status| status.as_u16()),
                         msg: format!("GET {} range {offset}-{last}: {err}", self.url),
                     })
@@ -218,14 +262,18 @@ impl Backend for HttpBackend {
             match response.status().as_u16() {
                 206 => {}
                 200 => {
-                    // The server ignored the Range header and answered
-                    // with the whole body: range fetching cannot work.
-                    return Err(http_io_error(
-                        crate::error::TransportMarker::RangeUnsupported,
-                    ));
+                    // The server ignored the Range header and answered with
+                    // the whole resource: keep it and serve every read,
+                    // this one included, from memory. Losing the OnceLock
+                    // race to a concurrent read just drops a redundant
+                    // body, the same stance CachedBackend documents for
+                    // concurrent chunk misses.
+                    let collected = self.collect_full_body(response).await?;
+                    let body = self.full.get_or_init(|| collected);
+                    return Ok(read_from_bytes(body, offset, buf));
                 }
                 status => {
-                    return Err(http_io_error(crate::error::TransportMarker::Http {
+                    return Err(http_io_error(crate::error::TransportMarker {
                         status: Some(status),
                         msg: format!("GET {} range {offset}-{last} failed", self.url),
                     }));
@@ -247,7 +295,7 @@ impl Backend for HttpBackend {
                 let chunk = match chunks.next().await {
                     Some(Ok(chunk)) => chunk,
                     Some(Err(err)) => {
-                        return Err(http_io_error(crate::error::TransportMarker::Http {
+                        return Err(http_io_error(crate::error::TransportMarker {
                             status: None,
                             msg: format!("GET {} range {offset}-{last}: {err}", self.url),
                         }))
@@ -324,13 +372,8 @@ mod tests {
 
     #[cfg(feature = "http")]
     #[test]
-    fn range_refusal_marker_round_trips_through_io_error() {
-        let refused = http_io_error(crate::error::TransportMarker::RangeUnsupported);
-        assert!(matches!(
-            crate::Error::from(refused),
-            crate::Error::RangeUnsupported
-        ));
-        let failed = http_io_error(crate::error::TransportMarker::Http {
+    fn transport_marker_round_trips_through_io_error() {
+        let failed = http_io_error(crate::error::TransportMarker {
             status: Some(503),
             msg: "unavailable".to_string(),
         });

--- a/crates/pdfboss-aio/src/error.rs
+++ b/crates/pdfboss-aio/src/error.rs
@@ -1,7 +1,7 @@
 //! Error type for pdfboss-aio: wraps core parse errors and transport
-//! failures, with dedicated variants for range-refusing HTTP servers and
-//! short reads. Messages are prefixed by layer ("parse:", "io:", "http:")
-//! so downstream consumers can present them uniformly.
+//! failures, with a dedicated variant for short reads. Messages are
+//! prefixed by layer ("parse:", "io:", "http:") so downstream consumers
+//! can present them uniformly.
 
 /// Convenience alias used throughout pdfboss-aio.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -26,12 +26,6 @@ pub enum Error {
     #[cfg(feature = "http")]
     #[error("http{}: {msg}", status.map(|code| format!(" {code}")).unwrap_or_default())]
     Http { status: Option<u16>, msg: String },
-    /// The server ignored `Range` requests (answered 200 with the full
-    /// body instead of 206), so range-fetching cannot work. Wording matches
-    /// what the Python binding independently produces for this variant
-    /// (`crates/pdfboss-py/src/lib.rs`'s `aio_err`), so both surfaces agree.
-    #[error("http: server does not support Range requests")]
-    RangeUnsupported,
     /// A read stopped short of the requested range while more bytes were
     /// expected (the source is shorter than its declared length).
     #[error("truncated read at offset {offset}: wanted {wanted} bytes, got {got}")]
@@ -49,12 +43,9 @@ impl From<std::io::Error> for Error {
             .get_ref()
             .and_then(|source| source.downcast_ref::<TransportMarker>())
         {
-            return match marker {
-                TransportMarker::RangeUnsupported => Error::RangeUnsupported,
-                TransportMarker::Http { status, msg } => Error::Http {
-                    status: *status,
-                    msg: msg.clone(),
-                },
+            return Error::Http {
+                status: marker.status,
+                msg: marker.msg.clone(),
             };
         }
         Error::Io(inner)
@@ -81,18 +72,15 @@ impl From<Error> for pdfboss_core::Error {
 /// [`From<std::io::Error>`] above. Only the HTTP backend produces these.
 #[cfg(feature = "http")]
 #[derive(Debug)]
-pub(crate) enum TransportMarker {
-    RangeUnsupported,
-    Http { status: Option<u16>, msg: String },
+pub(crate) struct TransportMarker {
+    pub(crate) status: Option<u16>,
+    pub(crate) msg: String,
 }
 
 #[cfg(feature = "http")]
 impl std::fmt::Display for TransportMarker {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TransportMarker::RangeUnsupported => write!(f, "server ignored Range requests"),
-            TransportMarker::Http { status, msg } => write!(f, "http {status:?}: {msg}"),
-        }
+        write!(f, "http {:?}: {}", self.status, self.msg)
     }
 }
 
@@ -129,10 +117,6 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "truncated read at offset 512: wanted 100 bytes, got 3"
-        );
-        assert_eq!(
-            Error::RangeUnsupported.to_string(),
-            "http: server does not support Range requests"
         );
     }
 

--- a/crates/pdfboss-aio/tests/http.rs
+++ b/crates/pdfboss-aio/tests/http.rs
@@ -2,42 +2,49 @@
 
 //! The HTTP backend against a local mock server: a Range-honoring server
 //! yields a working document; a Range-refusing server (200 with the full
-//! body) yields `Error::RangeUnsupported`.
+//! body) yields a working document too, from a single full download.
 
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
-use pdfboss_aio::{AsyncDocument, Backend, Error, HttpBackend};
+use pdfboss_aio::{AsyncDocument, Backend, HttpBackend};
 use pdfboss_testkit::simple_doc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 /// Serves `data` from a minimal hand-rolled HTTP/1.1 responder.
 /// `honor_range` selects whether GETs with a Range header receive 206
-/// slices or the full 200 body.
-async fn spawn_server(data: Vec<u8>, honor_range: bool) -> SocketAddr {
+/// slices or the full 200 body. The returned counter tracks GET requests
+/// (HEADs excluded).
+async fn spawn_server(data: Vec<u8>, honor_range: bool) -> (SocketAddr, Arc<AtomicUsize>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
+    let gets = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&gets);
     tokio::spawn(async move {
         loop {
             let Ok((socket, peer)) = listener.accept().await else {
                 break;
             };
             let payload = data.clone();
+            let counter = Arc::clone(&counter);
             tokio::spawn(async move {
-                if let Err(err) = handle_connection(socket, payload, honor_range).await {
+                if let Err(err) = handle_connection(socket, payload, honor_range, counter).await {
                     eprintln!("mock server, peer {peer}: {err}");
                 }
             });
         }
     });
-    addr
+    (addr, gets)
 }
 
 async fn handle_connection(
     mut socket: TcpStream,
     data: Vec<u8>,
     honor_range: bool,
+    gets: Arc<AtomicUsize>,
 ) -> std::io::Result<()> {
     loop {
         let Some(head) = read_request_head(&mut socket).await? else {
@@ -51,6 +58,7 @@ async fn handle_connection(
             socket.write_all(response.as_bytes()).await?;
             continue;
         }
+        gets.fetch_add(1, Ordering::SeqCst);
         match parse_range_header(&head).filter(|_| honor_range) {
             Some((start, end)) => {
                 let end = end.min(total - 1);
@@ -109,7 +117,7 @@ fn parse_range_header(head: &str) -> Option<(usize, usize)> {
 async fn open_url_works_against_a_range_honoring_server() {
     let data = simple_doc("remote");
     let sync_doc = pdfboss_core::Document::load(data.clone()).unwrap();
-    let addr = spawn_server(data, true).await;
+    let (addr, _) = spawn_server(data, true).await;
     let doc = AsyncDocument::open_url(format!("http://{addr}/remote.pdf"))
         .await
         .unwrap();
@@ -119,17 +127,21 @@ async fn open_url_works_against_a_range_honoring_server() {
 }
 
 #[tokio::test]
-async fn range_refusing_server_yields_range_unsupported() {
+async fn range_refusing_server_falls_back_to_one_full_download() {
     let data = simple_doc("no ranges");
-    let addr = spawn_server(data, false).await;
-    match AsyncDocument::open_url(format!("http://{addr}/no-ranges.pdf")).await {
-        Err(Error::RangeUnsupported) => {}
-        Err(other) => panic!("expected RangeUnsupported, got {other:?}"),
-        Ok(doc) => panic!(
-            "expected failure, opened a document with {} pages",
-            doc.page_count()
-        ),
-    }
+    let sync_doc = pdfboss_core::Document::load(data.clone()).unwrap();
+    let (addr, gets) = spawn_server(data, false).await;
+    let doc = AsyncDocument::open_url(format!("http://{addr}/no-ranges.pdf"))
+        .await
+        .unwrap();
+    assert_eq!(doc.version(), sync_doc.version());
+    assert_eq!(doc.page_count(), sync_doc.page_count());
+    assert_eq!(doc.metadata().await.unwrap(), sync_doc.metadata());
+    assert_eq!(
+        gets.load(Ordering::SeqCst),
+        1,
+        "every read after the 200 fallback must come from memory, not new GETs"
+    );
 }
 
 /// Serves a HEAD with a small declared length, but answers every GET with a
@@ -181,6 +193,96 @@ async fn handle_oversized_connection(
         tokio::time::sleep(Duration::from_secs(3600)).await;
         return Ok(());
     }
+}
+
+/// Serves a HEAD declaring `declared_len`, and answers every GET with a
+/// plain 200 (no Range support at all, like `python3 -m http.server`)
+/// promising `promised_len` bytes, delivering only `body`, then either
+/// hanging forever or closing cleanly.
+async fn spawn_200_server(
+    declared_len: usize,
+    promised_len: usize,
+    body: Vec<u8>,
+    hang: bool,
+) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((socket, _)) = listener.accept().await else {
+                break;
+            };
+            let body = body.clone();
+            tokio::spawn(async move {
+                let _ = handle_200_connection(socket, declared_len, promised_len, body, hang).await;
+            });
+        }
+    });
+    addr
+}
+
+async fn handle_200_connection(
+    mut socket: TcpStream,
+    declared_len: usize,
+    promised_len: usize,
+    body: Vec<u8>,
+    hang: bool,
+) -> std::io::Result<()> {
+    loop {
+        let Some(head) = read_request_head(&mut socket).await? else {
+            return Ok(()); // client closed the connection
+        };
+        if head.starts_with("HEAD ") {
+            let response = format!("HTTP/1.1 200 OK\r\nContent-Length: {declared_len}\r\n\r\n");
+            socket.write_all(response.as_bytes()).await?;
+            continue;
+        }
+        let response = format!("HTTP/1.1 200 OK\r\nContent-Length: {promised_len}\r\n\r\n");
+        socket.write_all(response.as_bytes()).await?;
+        socket.write_all(&body).await?;
+        socket.flush().await?;
+        if hang {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        }
+        return Ok(());
+    }
+}
+
+#[tokio::test]
+async fn fallback_caps_collection_of_an_oversized_200_body() {
+    let full = b"ABCDEFGH".to_vec();
+    // The 200 promises ~100 MB and never finishes; collection must stop at
+    // the HEAD-declared length and serve reads from what arrived.
+    let addr = spawn_200_server(full.len(), 100_000_000, full.clone(), true).await;
+    let backend = HttpBackend::new(format!("http://{addr}/big.bin"))
+        .await
+        .unwrap();
+    let mut buf = [0u8; 8];
+    let outcome = tokio::time::timeout(Duration::from_secs(5), backend.read_at(0, &mut buf)).await;
+    let count = outcome
+        .expect(
+            "read_at must return once the declared length has arrived, not \
+             block waiting for the rest of a never-finishing 200 body",
+        )
+        .unwrap();
+    assert_eq!(count, buf.len(), "reads exactly the declared length");
+    assert_eq!(&buf, full.as_slice(), "correct content, no error");
+}
+
+#[tokio::test]
+async fn fallback_body_shorter_than_declared_length_yields_short_reads() {
+    let body = b"ABCDEFGH".to_vec();
+    // HEAD declared 16 bytes but the 200 delivers only 8 and closes: reads
+    // past the delivered body are short, never a panic.
+    let addr = spawn_200_server(16, body.len(), body.clone(), false).await;
+    let backend = HttpBackend::new(format!("http://{addr}/short.bin"))
+        .await
+        .unwrap();
+    let mut tail = [0u8; 4];
+    assert_eq!(backend.read_at(12, &mut tail).await.unwrap(), 0);
+    let mut head = [0u8; 8];
+    assert_eq!(backend.read_at(0, &mut head).await.unwrap(), 8);
+    assert_eq!(&head, body.as_slice());
 }
 
 #[tokio::test]

--- a/crates/pdfboss-cli/skill/SKILL.md
+++ b/crates/pdfboss-cli/skill/SKILL.md
@@ -26,7 +26,7 @@ pdfboss images  doc.pdf -o out/             # embedded images as native-size PNG
 pdfboss tui     doc.pdf                     # interactive terminal explorer
 ```
 
-Every command takes a local path or an `http(s)://` URL; remote files are fetched in byte ranges rather than downloaded whole. Encrypted files take `--password` (an empty user password opens transparently).
+Every command takes a local path or an `http(s)://` URL; remote files are fetched in byte ranges rather than downloaded whole (a server that ignores `Range` costs one full download). Encrypted files take `--password` (an empty user password opens transparently).
 
 Creation:
 

--- a/crates/pdfboss-py/src/lib.rs
+++ b/crates/pdfboss-py/src/lib.rs
@@ -59,7 +59,6 @@ fn aio_err(e: pdfboss_aio::Error) -> PyErr {
             Some(code) => format!("http: {code}: {msg}"),
             None => format!("http: {msg}"),
         },
-        AioError::RangeUnsupported => "http: server does not support Range requests".to_string(),
         AioError::TruncatedRead {
             offset,
             wanted,

--- a/docs/src/guide/async.md
+++ b/docs/src/guide/async.md
@@ -1,6 +1,6 @@
 # Async and remote documents
 
-`AsyncDocument` opens a PDF without reading the whole file. The open flow fetches only what it needs (the header, the cross-reference chain and the page tree) and every later operation fetches only the byte ranges it touches. The file backend reads windows of the file on demand; the HTTP backend turns each read into a `Range` request, so a document on a server can be paged through without downloading it. A server that ignores `Range` and answers `200` with the full body cannot be range-read: the open fails (in Python, a `PdfError` reading `http: server does not support Range requests`) instead of falling back to a full download.
+`AsyncDocument` opens a PDF without reading the whole file. The open flow fetches only what it needs (the header, the cross-reference chain and the page tree) and every later operation fetches only the byte ranges it touches. The file backend reads windows of the file on demand; the HTTP backend turns each read into a `Range` request, so a document on a server can be paged through without downloading it. A server that ignores `Range` and answers `200` with the full body (`python3 -m http.server`, for one) still works: the first such answer is kept as the whole resource and every read is served from it, at the cost of one full download held in memory for the life of the document.
 
 ## Python
 
@@ -80,7 +80,7 @@ A document reads through the `Backend` trait: `len()` and `read_at(offset, buf)`
 
 - `MemBackend`: bytes fully resident in memory; `from_bytes` uses it directly, with no cache.
 - `FileBackend`: positioned reads (`pread`-style, no shared cursor) run on tokio's blocking thread pool, so disk I/O never stalls the async runtime. The length is captured once at open; the file is treated as immutable while the backend lives.
-- `HttpBackend` (feature `http`): the length comes from a `HEAD` request's `Content-Length`; each read is a `GET` with a `Range: bytes=` header. A `200` answer where `206` was asked for yields `Error::RangeUnsupported`, and a response body is collected only up to the requested size, so a buggy or hostile server cannot balloon memory.
+- `HttpBackend` (feature `http`): the length comes from a `HEAD` request's `Content-Length`; each read is a `GET` with a `Range: bytes=` header. A `200` answer where `206` was asked for means the server ignores `Range`; its body is the whole resource, so it is collected once (capped at the declared length, so a buggy or hostile server cannot balloon memory) and all reads are served from it. A `206` body is likewise collected only up to the requested size.
 - `CachedBackend`: a chunked LRU read cache over any backend: many small reads become few chunk-sized fetches, and hot chunks stay resident up to a byte budget. Defaults: 64 KiB chunks, 32 MiB total.
 
 `open` and `open_url` wrap their backend in a `CachedBackend` automatically. `from_bytes` stays uncached, and `with_backend` adds nothing, so a composition of your own is used exactly as given:

--- a/docs/src/guide/explorer.md
+++ b/docs/src/guide/explorer.md
@@ -128,7 +128,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## CLI
 
-Four subcommands plus the terminal explorer. `json`, `q`, `hex` and `tui` accept a local path or an http(s) URL (a URL is fetched in ranges and never downloaded whole); `obj` takes a local path. Full flag listings are in the [CLI reference](../reference/cli.md).
+Four subcommands plus the terminal explorer. `json`, `q`, `hex` and `tui` accept a local path or an http(s) URL (a URL is fetched in ranges when the server honors `Range`; one that doesn't costs a single full download); `obj` takes a local path. Full flag listings are in the [CLI reference](../reference/cli.md).
 
 ### json: the document as a JSON value tree
 
@@ -208,3 +208,5 @@ pdfboss tui report.pdf
 The screen splits into a tree pane on the left, an inspector above a hex pane on the right, and a status bar. The tree is the element model as a lazy hierarchy, populated by background tasks as sections expand: Document → Pages (each with its Fonts, Images, Annotations and Contents) → Objects → Xref sections → Trailer. The inspector pretty-prints the selection; `d` cycles it through raw bytes, decoded bytes and disassembled content operators for streams, and `Enter` jumps through any `N G R` reference under the cursor (`Backspace` goes back). `p` swaps the inspector for a rasterized page preview and `m` for the page's Markdown. The hex pane tracks the selection's bytes.
 
 `Tab` cycles focus, arrows or `j`/`k`/`h`/`l` move, `g`/`G` jump to top/bottom, `/` searches (with `n`/`N` for next/previous hit), `q` quits. `Ctrl+Shift+arrows` resize the panes: left/right move the tree divider, up/down the inspector/hex divider (terminals that do not transmit the Shift bit can use plain `Ctrl+arrows`). Long operations (element streaming, hex fetches, search, preview rasterization) run off the event loop, so input never blocks, including over an HTTP-backed document.
+
+`y` opens a yank menu that copies the selection to the clipboard: `q` the `pdfboss q` expression addressing it (`.objects["12 0"]`, `.pages[0].fonts`, `.trailer`), `c` the full shell command, `x` a hexdump of its bytes, `b` the raw bytes, `v` the pretty-printed value, `o` the object reference (`12 0 R`), `Esc` cancels. Copies go to the native clipboard, falling back to the OSC 52 escape sequence (which works over SSH in terminals that support it). A selection past 1 MiB yields the equivalent `pdfboss hex` command instead of the bytes.

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -5,7 +5,7 @@ One binary, `pdfboss`, with a subcommand per job. This chapter is the flag inven
 Shared behavior:
 
 - Every subcommand that reads a PDF takes `--password <PASSWORD>` for encrypted files: user or owner password; the empty user password opens transparently. See [Encrypted documents](../guide/encryption.md).
-- The explorer subcommands (`tui`, `json`, `hex`, `q`) accept either a local path or an `http(s)://` URL as input; URLs are range-fetched, never downloaded whole. The other subcommands take a local path.
+- The explorer subcommands (`tui`, `json`, `hex`, `q`) accept either a local path or an `http(s)://` URL as input; URLs are range-fetched, and a server that ignores `Range` costs one full download instead. The other subcommands take a local path.
 - Exit codes: 0 on success, 1 for PDF and I/O problems, 2 for an invalid jq program (mirroring clap's own usage-error code). `render` and `images` are lenient: content that cannot be read is skipped with a warning on stderr, and the exit code stays 0.
 
 ## info

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -359,12 +359,12 @@ class TestOpenUrl:
         assert catalog["Type"] == "Catalog"
 
     @pytest.mark.asyncio
-    async def test_server_without_range_support_raises_http_error(
-        self, no_range_server: str
+    async def test_server_without_range_support_falls_back_to_full_download(
+        self, no_range_server: str, hello_pdf: Path
     ) -> None:
-        with pytest.raises(PdfError) as exc:
-            await AsyncDocument.open_url(no_range_server)
-        assert str(exc.value).startswith("http:")
+        doc = await AsyncDocument.open_url(no_range_server)
+        assert doc.page_count == 1
+        assert doc.version == Document(str(hello_pdf)).version
 
     @pytest.mark.asyncio
     async def test_unreachable_url_raises_http_error(self) -> None:


### PR DESCRIPTION
## What

`pdfboss tui` (and `json`/`q`/`hex`, plus Python's `AsyncDocument.open_url`) failed against any server that ignores `Range`, such as `python3 -m http.server`:

```
pdfboss: http://127.0.0.1:8123/test.pdf: http: server does not support Range requests
```

A ranged GET answered `200` means the body is the whole resource. `HttpBackend` now collects that body once into a `OnceLock<Bytes>`, capped at the HEAD-declared length (keeping the hostile-server memory bound), and serves this and every later read from memory. Range-honoring servers are untouched; range-less servers cost one full download held resident instead of failing.

`Error::RangeUnsupported` no longer has a producer and is removed, and `TransportMarker` collapses to a struct.

**BREAKING CHANGE**: `pdfboss_aio::Error::RangeUnsupported` is removed; range-less servers now open successfully via a single full download.

## Verification

- New tests (watched fail first): the range-refusing mock now opens a working document with **exactly one** GET (request counter proves later reads come from memory); a never-finishing oversized `200` body returns once the declared length arrived; a `200` body shorter than declared yields short reads, no panic.
- `pdfboss-aio` 76 tests pass (`--all-features`), clippy clean; `pdfboss-cli` 184 pass; `tests/test_async.py` 36 pass with the extension rebuilt, including the flipped no-range-server test.
- Live: `tui`, `q`, `json`, `hex` verified against a running `python3 -m http.server` (before: exit 1 at open; after: the TUI opens and runs).
- Book prose (`async.md`, `explorer.md`, `cli.md`) and the CLI skill updated to describe the fallback and its memory cost.