### PR TITLE
perf(core): skip whitespace once per token, compose operands from raw tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pdfboss-aio"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bytes",
  "flate2",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-cli"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "base64",
  "clap",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "criterion",
  "flate2",
@@ -1279,19 +1279,19 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-encoding"
-version = "0.24.0"
+version = "0.25.0"
 
 [[package]]
 name = "pdfboss-icc"
-version = "0.24.0"
+version = "0.25.0"
 
 [[package]]
 name = "pdfboss-jpx"
-version = "0.24.0"
+version = "0.25.0"
 
 [[package]]
 name = "pdfboss-markdown"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "pdfboss-core",
  "pdfboss-output",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-output"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "criterion",
  "pdfboss-core",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-py"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "futures-util",
  "pdfboss-aio",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-render"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "criterion",
  "jpeg-decoder",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-style"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "cssparser",
  "pdfboss-write",
@@ -1355,11 +1355,11 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-testkit"
-version = "0.24.0"
+version = "0.25.0"
 
 [[package]]
 name = "pdfboss-text"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "pdfboss-core",
  "pdfboss-encoding",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-tui"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "crossterm",
  "futures-util",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "pdfboss-write"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "flate2",
  "pdfboss-core",

--- a/crates/pdfboss-core/src/content.rs
+++ b/crates/pdfboss-core/src/content.rs
@@ -240,9 +240,8 @@ fn parse_content_ops(data: &[u8], mut emit: impl FnMut(Op, Span)) -> Result<()> 
     // stray closer flushed it).
     let mut run_start: Option<usize> = None;
     loop {
-        lexer.skip_whitespace_and_comments();
-        let token_start = lexer.pos();
-        let kw = match lexer.next_raw_token()? {
+        let (token_start, raw) = lexer.next_raw_token_spanned()?;
+        let kw = match raw {
             RawToken::Keyword(kw) => {
                 if run_start.is_none() {
                     run_start = Some(token_start);
@@ -318,10 +317,10 @@ fn parse_array(lexer: &mut Lexer, depth: usize) -> Result<Object> {
     }
     let mut items = Vec::new();
     loop {
-        match lexer.next_token()? {
-            Token::ArrayClose | Token::Eof => break,
-            tok => {
-                if let Some(v) = compose_value(lexer, tok, depth)? {
+        match lexer.next_raw_token()? {
+            RawToken::Owned(Token::ArrayClose | Token::Eof) => break,
+            raw => {
+                if let Some(v) = compose_raw_value(lexer, raw, depth)? {
                     items.push(v);
                 }
             }
@@ -397,15 +396,15 @@ fn parse_dict(lexer: &mut Lexer, depth: usize) -> Result<Dict> {
     }
     let mut dict = Dict::new();
     loop {
-        match lexer.next_token()? {
-            Token::DictClose | Token::Eof => break,
-            Token::Name(key) => {
-                let tok = lexer.next_token()?;
-                if matches!(tok, Token::DictClose | Token::Eof) {
+        match lexer.next_raw_token()? {
+            RawToken::Owned(Token::DictClose | Token::Eof) => break,
+            RawToken::Owned(Token::Name(key)) => {
+                let raw = lexer.next_raw_token()?;
+                if matches!(raw, RawToken::Owned(Token::DictClose | Token::Eof)) {
                     // Key with no value: drop it.
                     break;
                 }
-                if let Some(v) = compose_value(lexer, tok, depth)? {
+                if let Some(v) = compose_raw_value(lexer, raw, depth)? {
                     dict.insert(key, v);
                 }
             }
@@ -571,13 +570,11 @@ fn dispatch_color_text(kw: &[u8], stack: &mut [Object]) -> Option<Op> {
             let Object::Array(items) = stack.last_mut()? else {
                 return None;
             };
-            let adjusted = items
-                .iter_mut()
-                .filter_map(|o| match o {
-                    Object::String(s) => Some(TextItem::Str(std::mem::take(s))),
-                    other => num(other).map(TextItem::Offset),
-                })
-                .collect();
+            let mut adjusted = Vec::with_capacity(items.len());
+            adjusted.extend(items.iter_mut().filter_map(|o| match o {
+                Object::String(s) => Some(TextItem::Str(std::mem::take(s))),
+                other => num(other).map(TextItem::Offset),
+            }));
             Op::ShowTextAdjusted(adjusted)
         }
         b"'" => Op::NextLineShowText(str1(stack)?),
@@ -786,6 +783,22 @@ fn expand_colorspace(value: Object) -> Object {
         })),
         Object::Array(items) => Object::Array(items.into_iter().map(expand_colorspace).collect()),
         other => other,
+    }
+}
+
+/// [`compose_value`] over a raw token: a borrowed keyword matches the
+/// three value keywords without the copy [`Lexer::next_token`] would
+/// make, and a hex span decodes straight to its string bytes.
+fn compose_raw_value(lexer: &mut Lexer, raw: RawToken, depth: usize) -> Result<Option<Object>> {
+    match raw {
+        RawToken::Owned(tok) => compose_value(lexer, tok, depth),
+        RawToken::Keyword(kw) => Ok(match kw {
+            b"true" => Some(Object::Bool(true)),
+            b"false" => Some(Object::Bool(false)),
+            b"null" => Some(Object::Null),
+            _ => None,
+        }),
+        RawToken::Hex(span) => Ok(Some(Object::String(decode_hex(span)))),
     }
 }
 

--- a/crates/pdfboss-core/src/lexer.rs
+++ b/crates/pdfboss-core/src/lexer.rs
@@ -201,54 +201,64 @@ impl<'a> Lexer<'a> {
     /// instead of copied. This is the one lexing implementation;
     /// `next_token` merely copies the borrows out.
     pub fn next_raw_token(&mut self) -> Result<RawToken<'a>> {
+        Ok(self.next_raw_token_spanned()?.1)
+    }
+
+    /// [`Lexer::next_raw_token`] plus the byte offset where the token
+    /// begins (after any whitespace and comments). The content parser
+    /// needs that offset for operator spans, and reading it from here
+    /// skips the whitespace once per token instead of twice.
+    pub fn next_raw_token_spanned(&mut self) -> Result<(usize, RawToken<'a>)> {
         self.skip_whitespace_and_comments();
+        let start = self.pos;
         let Some(&b) = self.data.get(self.pos) else {
-            return Ok(RawToken::Owned(Token::Eof));
+            return Ok((start, RawToken::Owned(Token::Eof)));
         };
-        match b {
+        let token = match b {
             b'[' => {
                 self.pos += 1;
-                Ok(RawToken::Owned(Token::ArrayOpen))
+                RawToken::Owned(Token::ArrayOpen)
             }
             b']' => {
                 self.pos += 1;
-                Ok(RawToken::Owned(Token::ArrayClose))
+                RawToken::Owned(Token::ArrayClose)
             }
             b'<' => {
                 if self.data.get(self.pos + 1) == Some(&b'<') {
                     self.pos += 2;
-                    Ok(RawToken::Owned(Token::DictOpen))
+                    RawToken::Owned(Token::DictOpen)
                 } else {
                     self.pos += 1;
-                    Ok(RawToken::Hex(self.hex_span()))
+                    RawToken::Hex(self.hex_span())
                 }
             }
             b'>' => {
                 if self.data.get(self.pos + 1) == Some(&b'>') {
                     self.pos += 2;
-                    Ok(RawToken::Owned(Token::DictClose))
+                    RawToken::Owned(Token::DictClose)
                 } else {
                     // Stray `>`: surfaced leniently as a one-byte keyword.
                     self.pos += 1;
-                    Ok(RawToken::Keyword(&self.data[self.pos - 1..self.pos]))
+                    RawToken::Keyword(&self.data[self.pos - 1..self.pos])
                 }
             }
             b'(' => {
                 self.pos += 1;
-                Ok(RawToken::Owned(self.lex_literal_string()))
+                RawToken::Owned(self.lex_literal_string())
             }
             b'/' => {
                 self.pos += 1;
-                Ok(RawToken::Owned(self.lex_name()))
+                RawToken::Owned(self.lex_name())
             }
             // Stray delimiters with no token of their own: kept lenient.
             b')' | b'{' | b'}' => {
                 self.pos += 1;
-                Ok(RawToken::Keyword(&self.data[self.pos - 1..self.pos]))
+                RawToken::Keyword(&self.data[self.pos - 1..self.pos])
             }
-            b'0'..=b'9' | b'+' | b'-' | b'.' => Ok(self.lex_number_or_keyword()),
-            _ => Ok(RawToken::Keyword(self.take_regular_run())),
-        }
+            b'0'..=b'9' | b'+' | b'-' | b'.' => self.lex_number_or_keyword(),
+            _ => RawToken::Keyword(self.take_regular_run()),
+        };
+        Ok((start, token))
     }
 
     /// Returns the next token without consuming it.
@@ -259,12 +269,18 @@ impl<'a> Lexer<'a> {
         token
     }
 
-    /// Advances past whitespace and `%` comments.
+    /// Advances past whitespace and `%` comments. The cursor sits on a
+    /// token byte far more often than on whitespace (tokens are separated
+    /// by a single space or newline, and the content parser skips before
+    /// every token), so this checks one byte at a time and returns on the
+    /// first non-whitespace instead of setting up a run scan.
     pub fn skip_whitespace_and_comments(&mut self) {
-        loop {
-            let rest = &self.data[self.pos.min(self.data.len())..];
-            self.pos += rest.iter().take_while(|&&b| is_whitespace(b)).count();
-            if self.data.get(self.pos) != Some(&b'%') {
+        while let Some(&b) = self.data.get(self.pos) {
+            if is_whitespace(b) {
+                self.pos += 1;
+                continue;
+            }
+            if b != b'%' {
                 return;
             }
             let rest = &self.data[self.pos..];


### PR DESCRIPTION
After wave 5 the content parser stood as the largest share of the 049
extraction pass (~29.5%), and inside it the whitespace skipper alone was
~6.4% of the whole pass — run twice per token. Four changes, all
token-identical by construction:

- `next_raw_token_spanned` returns the token's start offset, so the
  content parser's operator spans come from the one whitespace skip
  instead of a second explicit one per token.
- `skip_whitespace_and_comments` returns on the first non-whitespace
  byte instead of setting up a run scan; the cursor sits on a token byte
  far more often than on whitespace.
- `parse_array`/`parse_dict` match raw tokens: value keywords compose
  without the `Token::Keyword` copy `next_token` would make, and hex
  strings decode once, straight to their bytes. Inline images stay on
  the owned path — they are cold.
- A `TJ` array converts to text items at exact capacity instead of
  growing through `collect`.

Verified: text+md sha256 per document byte-identical on 049 (259 docs)
and pdf_oxide (3,910 docs) against a fresh main-side binary; render
pixel+PNG sha256 byte-identical on all 888 certified 049 pages (the
lexer is shared with rendering and document parsing); full workspace
suite (2,270 tests), clippy in both `substitute-fonts` states, fmt,
`cargo doc` clean.

Also syncs Cargo.lock to the 0.25.0 release, which shipped without it.

Measurement (pre-registered target: 049 extraction pass, 16 interleaved
paired rounds main 7699895 vs this branch, keep iff >=14/16 wins AND
median > 3x the A/A-null median; pdf_oxide as 8-round control; gated on
AC power and measured throughput; forecast registered at an honest 2-5%)

- 049 target: keep=YES — 16/16 wins, median +5.48% (1.9217s -> 1.8225s,
  x1.054), threshold 2.39% (3x null median 0.80%) cleared 2.3x
- oxide control: 8/8 wins, median +2.72% (x1.042) — document parsing
  shares the lexer, so a positive was expected
- per-file best-of-3 sweep: 189/259 wins, median +2.0%, sum x1.030;
  the 18 files flagged beyond the A/A p90 (5.0% — a noisy sweep) are
  all in the 0.4-8ms range, and re-timing the worst four interleaved
  shows B faster in 5 of 6 rounds with the sixth inside 1% — phantom,
  as in wave 5
