### PR TITLE
perf(text): pull-parse content operators, lex numeric runs in one pass

### DIFF
--- a/crates/pdfboss-core/src/content.rs
+++ b/crates/pdfboss-core/src/content.rs
@@ -229,83 +229,130 @@ fn ops_estimate(len: usize) -> usize {
     (len / 16).min(1 << 17)
 }
 
-/// The parse loop behind both public entry points: one pass over the
-/// tokens, each finished operator handed to `emit` — so the span-less
-/// caller never materializes spans it will throw away.
+/// The parse loop behind both public entry points, as a wrapper over the
+/// pull parser: each finished operator is handed to `emit` — so the
+/// span-less caller never materializes spans it will throw away.
 fn parse_content_ops(data: &[u8], mut emit: impl FnMut(Op, Span)) -> Result<()> {
-    let mut lexer = Lexer::new(data);
-    let mut stack: Vec<Object> = Vec::new();
-    // Start of the current operand run; cleared whenever the run dies
-    // (an operator was emitted, an unknown operator dropped it, or a
-    // stray closer flushed it).
-    let mut run_start: Option<usize> = None;
-    loop {
-        let (token_start, raw) = lexer.next_raw_token_spanned()?;
-        let kw = match raw {
-            RawToken::Keyword(kw) => {
-                if run_start.is_none() {
-                    run_start = Some(token_start);
-                }
-                kw
-            }
-            RawToken::Hex(span) => {
-                if run_start.is_none() {
-                    run_start = Some(token_start);
-                }
-                stack.push(Object::String(decode_hex(span)));
-                continue;
-            }
-            RawToken::Owned(token) => {
-                if !matches!(token, Token::Eof) && run_start.is_none() {
-                    run_start = Some(token_start);
-                }
-                match token {
-                    Token::Eof => break,
-                    Token::Int(i) => stack.push(Object::Int(i)),
-                    Token::Real(r) => stack.push(Object::Real(r)),
-                    Token::Name(n) => stack.push(Object::Name(n)),
-                    Token::LitString(s) | Token::HexString(s) => stack.push(Object::String(s)),
-                    Token::ArrayOpen => {
-                        let a = parse_array(&mut lexer, 0)?;
-                        stack.push(a);
+    let mut ops = ContentOps::new(data);
+    while let Some((op, span)) = ops.next_op()? {
+        emit(op, span);
+    }
+    Ok(())
+}
+
+/// A pull parser over one content stream: each [`ContentOps::next_op`]
+/// yields the next operator with its byte range, in stream order — an
+/// executor consumes operators one at a time without materializing the
+/// whole vector.
+pub struct ContentOps<'a> {
+    lexer: Lexer<'a>,
+    stack: Vec<Object>,
+    /// Start of the current operand run; cleared whenever the run dies
+    /// (an operator was emitted, an unknown operator dropped it, or a
+    /// stray closer flushed it).
+    run_start: Option<usize>,
+}
+
+impl<'a> ContentOps<'a> {
+    /// Starts a pull parse at the beginning of `data`.
+    pub fn new(data: &'a [u8]) -> ContentOps<'a> {
+        ContentOps::at(data, 0)
+    }
+
+    /// Resumes a pull parse at byte offset `pos`. The operand stack is
+    /// empty at every operator boundary, so the offset [`ContentOps::pos`]
+    /// reported between two `next_op` calls is the parser's whole state —
+    /// an executor that suspends a stream mid-walk (a form invocation)
+    /// rebuilds from it exactly.
+    pub fn at(data: &'a [u8], pos: usize) -> ContentOps<'a> {
+        ContentOps {
+            lexer: Lexer::at(data, pos),
+            stack: Vec::new(),
+            run_start: None,
+        }
+    }
+
+    /// The cursor's byte offset — a resume point between `next_op` calls.
+    pub fn pos(&self) -> usize {
+        self.lexer.pos()
+    }
+
+    /// Parses forward to the next complete operator and returns it with
+    /// its span, or `None` at the end of the stream.
+    pub fn next_op(&mut self) -> Result<Option<(Op, Span)>> {
+        loop {
+            let (token_start, raw) = self.lexer.next_raw_token_spanned()?;
+            let kw = match raw {
+                RawToken::Keyword(kw) => {
+                    if self.run_start.is_none() {
+                        self.run_start = Some(token_start);
                     }
-                    Token::DictOpen => {
-                        let d = parse_dict(&mut lexer, 0)?;
-                        stack.push(Object::Dict(d));
+                    kw
+                }
+                RawToken::Hex(span) => {
+                    if self.run_start.is_none() {
+                        self.run_start = Some(token_start);
                     }
-                    // Stray closers: malformed input, drop pending operands.
-                    Token::ArrayClose | Token::DictClose => {
-                        stack.clear();
-                        run_start = None;
+                    self.stack.push(Object::String(decode_hex(span)));
+                    continue;
+                }
+                RawToken::Owned(token) => {
+                    if !matches!(token, Token::Eof) && self.run_start.is_none() {
+                        self.run_start = Some(token_start);
                     }
-                    Token::Keyword(_) => {
-                        unreachable!("next_raw_token yields keywords borrowed")
+                    match token {
+                        Token::Eof => return Ok(None),
+                        Token::Int(i) => self.stack.push(Object::Int(i)),
+                        Token::Real(r) => self.stack.push(Object::Real(r)),
+                        Token::Name(n) => self.stack.push(Object::Name(n)),
+                        Token::LitString(s) | Token::HexString(s) => {
+                            self.stack.push(Object::String(s))
+                        }
+                        Token::ArrayOpen => {
+                            let a = parse_array(&mut self.lexer, 0)?;
+                            self.stack.push(a);
+                        }
+                        Token::DictOpen => {
+                            let d = parse_dict(&mut self.lexer, 0)?;
+                            self.stack.push(Object::Dict(d));
+                        }
+                        // Stray closers: malformed input, drop pending operands.
+                        Token::ArrayClose | Token::DictClose => {
+                            self.stack.clear();
+                            self.run_start = None;
+                        }
+                        Token::Keyword(_) => {
+                            unreachable!("next_raw_token yields keywords borrowed")
+                        }
+                    }
+                    continue;
+                }
+            };
+            match kw {
+                b"true" => self.stack.push(Object::Bool(true)),
+                b"false" => self.stack.push(Object::Bool(false)),
+                b"null" => self.stack.push(Object::Null),
+                b"BI" => {
+                    let start = self.run_start.take().unwrap_or(token_start);
+                    let image = parse_inline_image(&mut self.lexer);
+                    self.stack.clear();
+                    if let Some(op) = image {
+                        let span = Span::new(start as u64, self.lexer.pos() as u64);
+                        return Ok(Some((op, span)));
                     }
                 }
-                continue;
-            }
-        };
-        match kw {
-            b"true" => stack.push(Object::Bool(true)),
-            b"false" => stack.push(Object::Bool(false)),
-            b"null" => stack.push(Object::Null),
-            b"BI" => {
-                let start = run_start.take().unwrap_or(token_start);
-                if let Some(op) = parse_inline_image(&mut lexer) {
-                    emit(op, Span::new(start as u64, lexer.pos() as u64));
+                _ => {
+                    let start = self.run_start.take().unwrap_or(token_start);
+                    let op = dispatch(kw, &mut self.stack);
+                    self.stack.clear();
+                    if let Some(op) = op {
+                        let span = Span::new(start as u64, self.lexer.pos() as u64);
+                        return Ok(Some((op, span)));
+                    }
                 }
-                stack.clear();
-            }
-            _ => {
-                let start = run_start.take().unwrap_or(token_start);
-                if let Some(op) = dispatch(kw, &mut stack) {
-                    emit(op, Span::new(start as u64, lexer.pos() as u64));
-                }
-                stack.clear();
             }
         }
     }
-    Ok(())
 }
 
 /// Composes an array value; the opening `[` has already been consumed.

--- a/crates/pdfboss-core/src/lexer.rs
+++ b/crates/pdfboss-core/src/lexer.rs
@@ -119,6 +119,19 @@ fn parse_number_fast(run: &[u8]) -> Option<Token> {
             _ => return None,
         }
     }
+    number_from_parts(negative, mantissa, digit_count, frac_len)
+}
+
+/// The fast path's finish: the accumulated parts become a token, or `None`
+/// when the parts fall outside the exact ranges and the caller must take
+/// the standard parse. Shared by [`parse_number_fast`] and the fused scan
+/// in [`Lexer::lex_number_or_keyword`], so the two cannot drift.
+fn number_from_parts(
+    negative: bool,
+    mantissa: u64,
+    digit_count: usize,
+    frac_len: Option<usize>,
+) -> Option<Token> {
     if digit_count == 0 {
         return None;
     }
@@ -304,13 +317,73 @@ impl<'a> Lexer<'a> {
 
     /// Lexes a run starting with a digit, sign, or period: a number when the
     /// run contains only numeric characters, otherwise a keyword (lenient).
+    /// One pass over the run finds its end, classifies it, and accumulates
+    /// the fast-path number as it goes — content streams are mostly numeric
+    /// operands, and three separate scans of each run showed up in profiles.
+    /// A run the fast path cannot represent exactly (a stray sign or second
+    /// period, an overflowing mantissa) falls back to [`number_token`]'s
+    /// full parse, unchanged.
     fn lex_number_or_keyword(&mut self) -> RawToken<'a> {
-        let run = self.take_regular_run();
-        if !run
-            .iter()
-            .all(|&b| matches!(b, b'0'..=b'9' | b'+' | b'-' | b'.'))
-        {
+        let start = self.pos;
+        let mut numeric = true;
+        let mut exact = true;
+        let mut negative = false;
+        let mut mantissa = 0u64;
+        let mut digit_count = 0usize;
+        let mut frac_len: Option<usize> = None;
+        let mut i = start;
+        while let Some(&b) = self.data.get(i) {
+            if !is_regular(b) {
+                break;
+            }
+            match b {
+                b'0'..=b'9' => {
+                    match mantissa
+                        .checked_mul(10)
+                        .and_then(|m| m.checked_add(u64::from(b - b'0')))
+                    {
+                        Some(next) => {
+                            mantissa = next;
+                            digit_count += 1;
+                            if let Some(count) = frac_len.as_mut() {
+                                *count += 1;
+                            }
+                        }
+                        None => exact = false,
+                    }
+                }
+                b'.' => {
+                    if frac_len.is_none() {
+                        frac_len = Some(0);
+                    } else {
+                        exact = false;
+                    }
+                }
+                b'-' => {
+                    if i == start {
+                        negative = true;
+                    } else {
+                        exact = false;
+                    }
+                }
+                b'+' => {
+                    if i != start {
+                        exact = false;
+                    }
+                }
+                _ => numeric = false,
+            }
+            i += 1;
+        }
+        self.pos = i;
+        let run = &self.data[start..i];
+        if !numeric {
             return RawToken::Keyword(run);
+        }
+        if exact {
+            if let Some(token) = number_from_parts(negative, mantissa, digit_count, frac_len) {
+                return RawToken::Owned(token);
+            }
         }
         RawToken::Owned(number_token(run))
     }

--- a/crates/pdfboss-text/src/extract.rs
+++ b/crates/pdfboss-text/src/extract.rs
@@ -3,7 +3,7 @@
 
 use crate::font::Font;
 use crate::{Ruling, TextSpan};
-use pdfboss_core::content::{parse_content, Op, TextItem};
+use pdfboss_core::content::{ContentOps, Op, TextItem};
 use pdfboss_core::{
     content_stream_data_with, page_content_with, AsyncObjectSource, Dict, FastMap, Matrix, Name,
     ObjRef, Object, OcState, Page, Point, Rect,
@@ -196,13 +196,6 @@ pub async fn page_spans_and_rulings_with<S: AsyncObjectSource>(
             Vec::new()
         }
     };
-    let ops = match parse_content(&content) {
-        Ok(ops) => ops,
-        Err(_) => {
-            report.record(SkippedTextKind::PageContents, SkipCause::Parse);
-            Vec::new()
-        }
-    };
     let mut exec = Executor {
         src: &src,
         spans: Vec::new(),
@@ -216,10 +209,11 @@ pub async fn page_spans_and_rulings_with<S: AsyncObjectSource>(
         categories: FastMap::default(),
     };
     let root = Frame::new(
-        ops.into(),
+        Arc::new(content),
         vec![Arc::new(page.resources.clone())],
         GState::new(),
         0,
+        (0, 0),
     );
     exec.run(root).await;
     let mut spans = exec.spans;
@@ -480,15 +474,24 @@ struct Subpath {
 /// `Send` over an asynchronous source and merely non-`Send` over a synchronous
 /// one, which is correct for both.
 struct Frame {
-    /// Shared rather than owned so a handle can be held while the frame stack is
-    /// pushed onto. Cloned once per visit to the frame, never per operator.
-    ops: Arc<[Op]>,
+    /// The stream's decoded bytes; operators are pull-parsed from it one at
+    /// a time, never materialized as a vector. Shared rather than owned so
+    /// a handle can be held while the frame stack is pushed onto — cloned
+    /// once per visit to the frame, never per operator.
+    content: Arc<Vec<u8>>,
     /// Resource dictionaries, innermost first. Owned, because a form's own
     /// `/Resources` is read out of its stream dictionary and so outlives nothing
     /// already on the stack.
     chain: Vec<Arc<Dict>>,
-    /// Index of the next operator to execute.
-    pc: usize,
+    /// Byte offset of the next operator: the pull parser's whole state at
+    /// an operator boundary, so a suspended frame resumes from it exactly.
+    pos: usize,
+    /// Lengths of the executor's spans and rulings when this frame was
+    /// created. A stream that stops parsing mid-way contributes nothing —
+    /// exactly as it contributed nothing when the whole stream was parsed
+    /// up front — so its error truncates both back to these marks.
+    spans_mark: usize,
+    rulings_mark: usize,
     /// Form-XObject nesting depth, checked against `MAX_FORM_DEPTH`.
     depth: usize,
     gs: GState,
@@ -511,11 +514,19 @@ struct Frame {
 }
 
 impl Frame {
-    fn new(ops: Arc<[Op]>, chain: Vec<Arc<Dict>>, gs: GState, depth: usize) -> Frame {
+    fn new(
+        content: Arc<Vec<u8>>,
+        chain: Vec<Arc<Dict>>,
+        gs: GState,
+        depth: usize,
+        (spans_mark, rulings_mark): (usize, usize),
+    ) -> Frame {
         Frame {
-            ops,
+            content,
             chain,
-            pc: 0,
+            pos: 0,
+            spans_mark,
+            rulings_mark,
             depth,
             gs,
             saved: Vec::new(),
@@ -800,11 +811,28 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         'frames: while let Some(mut frame) = frames.pop() {
             // Cloned once per visit rather than once per operator: the handle has
             // to outlive the `&mut frame` borrows below.
-            let ops = Arc::clone(&frame.ops);
-            while frame.pc < ops.len() {
-                let op = &ops[frame.pc];
-                frame.pc += 1;
-                match op {
+            let content = Arc::clone(&frame.content);
+            let mut ops = ContentOps::at(&content, frame.pos);
+            loop {
+                let op = match ops.next_op() {
+                    Ok(Some((op, _))) => op,
+                    Ok(None) => break,
+                    Err(_) => {
+                        // The stream stops parsing mid-way: it contributes
+                        // nothing, exactly as it contributed nothing when
+                        // the whole stream was parsed up front.
+                        self.spans.truncate(frame.spans_mark);
+                        self.rulings.truncate(frame.rulings_mark);
+                        let kind = if frame.depth == 0 {
+                            SkippedTextKind::PageContents
+                        } else {
+                            SkippedTextKind::Form
+                        };
+                        self.report.record(kind, SkipCause::Parse);
+                        continue 'frames;
+                    }
+                };
+                match &op {
                     Op::SetFont(name, size) => {
                         let loaded = self.font(&frame.chain, &name.0, &mut frame.fonts).await;
                         frame.gs.font = Some(loaded);
@@ -830,6 +858,7 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                             // runs to completion, then the caller resumes at the
                             // operator after its `Do`. That is the depth-first
                             // order the recursive version emitted.
+                            frame.pos = ops.pos();
                             frames.push(frame);
                             frames.push(child);
                             continue 'frames;
@@ -1209,13 +1238,6 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
                 return None;
             }
         };
-        let ops = match parse_content(&data) {
-            Ok(ops) => ops,
-            Err(_) => {
-                self.report.record(SkippedTextKind::Form, SkipCause::Parse);
-                return None;
-            }
-        };
         // The form's own /Resources shadows the caller's for the names it
         // defines and falls through for the ones it does not, so it is
         // prepended rather than substituted. A form that declares
@@ -1231,7 +1253,13 @@ impl<S: AsyncObjectSource> Executor<'_, S> {
         if let Some(m) = self.form_matrix(&stream.dict).await {
             inner.ctm = m.concat(inner.ctm);
         }
-        Some(Frame::new(ops.into(), inner_chain, inner, depth + 1))
+        Some(Frame::new(
+            Arc::new(data),
+            inner_chain,
+            inner,
+            depth + 1,
+            (self.spans.len(), self.rulings.len()),
+        ))
     }
 
     /// A stream dictionary's own `/Resources`, when it has a usable one.


### PR DESCRIPTION
A fresh xctrace profile at 0.25.0+ re-ranked the extraction levers: the
zero-copy/mmap work previously queued measured at only ~2-4% (the
stream-decode path owns under 1% of allocator traffic, and mmap would
touch only the 5% `read` slice of a 14% syscall floor on the pdf_oxide
corpus), so it stays parked. What the profile did point at, two levers,
both output-identical:

- The extraction executor materialized a `Vec<Op>` per content stream
  (the page and every form invocation): allocated, written, and dropped
  once per stream. `content::ContentOps` is a new pull parser whose
  `next_op` yields one operator at a time; the operand stack is empty at
  every operator boundary, so a byte offset is the parser's whole resume
  state, and a frame suspended by a form invocation resumes from it
  exactly. `parse_content` and friends become wrappers over the same
  loop. A stream that stops parsing mid-way contributes nothing, as
  before: the frame records the same skip and truncates spans and
  rulings back to its entry marks.
- The lexer scanned every numeric run three times (find the end,
  classify it, parse the digits). One fused pass does all three; the
  finish is shared with `parse_number_fast` through `number_from_parts`
  so the two cannot drift, and the differential fuzz enters through the
  fused path.

Verified: text+md sha256 per document byte-identical on 049 (259 docs)
and pdf_oxide (3,910 docs); render pixels AND png bytes byte-identical
on all 888 certified pages (lexer and content parser are shared with
rendering); full workspace suite, clippy in both `substitute-fonts`
states, fmt, `cargo doc` clean.

Measurement (pre-registered target: 049 extraction pass, 16 interleaved
paired rounds main 9bfa5cf vs this branch, keep iff >=14/16 wins AND
median > 3x the A/A-null median; pdf_oxide as 8-round control; gated on
AC power and measured throughput; forecast registered at an honest
3-7%)

- 049 target: keep=YES — 16/16 wins, median +5.66% (1.824s -> 1.695s,
  x1.077), threshold 3.64% (3x null median 1.21%) cleared 1.55x
- oxide control: keep=YES — 8/8 wins, median +4.21% (x1.057); document
  parsing shares the lexer, so the spillover was expected
- per-file best-of-3 sweep: 217/259 wins, median +3.1%, sum x1.059;
  the 5 files flagged beyond the A/A p90 (6.3% — a noisy sweep) are all
  in the 0.2-5ms range, and re-timing the worst four interleaved puts
  every round within +-2% with B equal or faster in 6 of 8 — phantom,
  the wave-5/7 pattern
