### PR TITLE
chore: extend the Makefile to cover CI lanes, Python, docs and benches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,89 @@
 .DEFAULT_GOAL := help
 
-##@ Development
+# `make help` renders this file's own comments: `##@ Name` opens a section,
+# `target: ## text` documents a target. Undocumented targets stay hidden.
+ifdef NO_COLOR
+BOLD :=
+CYAN :=
+DIM :=
+RESET :=
+else
+BOLD := \033[1m
+CYAN := \033[36m
+DIM := \033[2m
+RESET := \033[0m
+endif
+
+##@ Build
 
 .PHONY: build
 build: ## Build the whole workspace
 	cargo build --workspace
 
-.PHONY: test
-test: ## Run the full workspace test suite
-	cargo test --workspace
+.PHONY: release
+release: ## Build the whole workspace with optimizations
+	cargo build --workspace --release
+
+.PHONY: clean
+clean: ## Remove all build artifacts
+	cargo clean
+
+##@ Checks
 
 .PHONY: fmt
 fmt: ## Format all crates
 	cargo fmt --all
 
+.PHONY: fmt-check
+fmt-check: ## Fail on unformatted code, changing nothing
+	cargo fmt --all -- --check
+
 .PHONY: lint
-lint: ## Clippy over all targets with warnings denied
+lint: ## Clippy with warnings denied, both CI lanes
 	cargo clippy --workspace --all-targets -- -D warnings
+	cargo clippy -p pdfboss-aio --all-targets --all-features -- -D warnings
+
+.PHONY: test
+test: ## Run the workspace tests plus the aio all-features lane
+	cargo test --workspace
+	cargo test -p pdfboss-aio --all-features
+
+.PHONY: ci
+ci: fmt-check lint test doc ## Everything the Rust CI runs, in order
 
 ##@ Python
+
+.PHONY: develop
+develop: ## Build and install the extension into the active venv
+	maturin develop
+
+.PHONY: test-py
+test-py: develop ## Run the Python integration tests
+	pytest -q
 
 .PHONY: wheel
 wheel: ## Build the release wheel with maturin
 	maturin build --release
 
-.PHONY: develop
-develop: ## Install the Python package into the active venv
-	maturin develop
+##@ Docs
+
+.PHONY: doc
+doc: ## Rustdoc for the workspace, warnings denied
+	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+
+.PHONY: book
+book: ## Build the mdBook into docs/book
+	mdbook build docs
+
+.PHONY: book-serve
+book-serve: ## Serve the mdBook locally and open it
+	mdbook serve docs --open
+
+##@ Benchmarks
+
+.PHONY: bench
+bench: ## Run the criterion benches (core, render, output)
+	cargo bench --workspace
 
 ##@ Install
 
@@ -38,4 +95,8 @@ install: ## Install the pdfboss CLI to ~/.cargo/bin
 
 .PHONY: help
 help: ## Show this help
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make $(CYAN)<target>$(RESET)\n"} \
+		/^##@/ { printf "\n$(BOLD)%s$(RESET)\n", substr($$0, 5); next } \
+		/^[a-zA-Z0-9_-]+:.*?##/ { printf "  $(CYAN)%-12s$(RESET) %s\n", $$1, $$2 }' \
+		$(MAKEFILE_LIST)
+	@printf "\n$(DIM)Docs above are generated from this Makefile's ## comments.$(RESET)\n\n"


### PR DESCRIPTION
The Makefile from #27 had 8 targets and missed the lanes CI actually runs. It now covers fmt-check, both clippy lanes, the aio all-features test lane, rustdoc with denied warnings, mdBook build/serve, maturin develop plus pytest, criterion benches, and a `ci` aggregate that chains fmt-check, lint, test and doc.

`make help` stays the default goal; the docs it prints are generated from the `##` comments next to each target (`##@` lines open bold sections, targets render cyan-aligned), and `NO_COLOR` strips all escapes.

Verified: `make help` with and without `NO_COLOR`, dry runs of all 16 targets, `make fmt-check` for real.