### PR TITLE
docs: serve the book at pdfboss.dev/docs, keyword crate metadata

### DIFF
--- a/.github/workflows/book.yaml
+++ b/.github/workflows/book.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           mdbook-version: "0.4.52"
       - run: mdbook build docs
+      - run: docs/finalize-book.sh docs/book
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/book

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ version = "1.0.0" # x-release-please-version
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/4thel00z/pdfboss"
+homepage = "https://pdfboss.dev"
+documentation = "https://pdfboss.dev/docs/"
 readme = "README.md"
 keywords = ["pdf", "iso-32000"]
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 <p align="center">
   <a href="https://github.com/4thel00z/pdfboss/actions/workflows/ci.yaml"><img src="https://github.com/4thel00z/pdfboss/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
   <a href="https://github.com/4thel00z/pdfboss/actions/workflows/python-ci.yml"><img src="https://github.com/4thel00z/pdfboss/actions/workflows/python-ci.yml/badge.svg" alt="python-ci"></a>
-  <a href="https://4thel00z.github.io/pdfboss/"><img src="https://img.shields.io/badge/docs-book-blue?logo=mdbook&logoColor=white" alt="Documentation"></a>
+  <a href="https://pdfboss.dev/docs/"><img src="https://img.shields.io/badge/docs-book-blue?logo=mdbook&logoColor=white" alt="Documentation"></a>
   <a href="https://pypi.org/project/pdfboss/"><img src="https://img.shields.io/pypi/v/pdfboss?logo=pypi&logoColor=white" alt="PyPI"></a>
   <img src="https://img.shields.io/badge/rust-2021-000000?logo=rust&logoColor=white" alt="Rust 2021">
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="MIT OR Apache-2.0"></a>
 </p>
 
 <p align="center">
-  <a href="https://4thel00z.github.io/pdfboss/">Docs</a> ·
+  <a href="https://pdfboss.dev/docs/">Docs</a> ·
   <a href="https://pypi.org/project/pdfboss/">PyPI</a> ·
   <a href="https://crates.io/crates/pdfboss-cli">crates.io</a> ·
   <a href="#benchmarks">Benchmarks</a>
@@ -394,7 +394,7 @@ Optional content groups (PDF layers, ISO 32000 §8.11) are honored per the docum
 
 ## Documentation
 
-The [pdfboss book](https://4thel00z.github.io/pdfboss/) covers installation, guides for every surface (text, Markdown, styled spans, rendering, image extraction, creation, Markdown-to-PDF composition, async and remote documents, the explorer, encryption) and CLI/Python/Rust reference chapters. It is built with mdBook from [`docs/`](docs/) and deployed through GitHub Pages. Per-crate Rust API documentation is on [docs.rs](https://docs.rs/pdfboss-core).
+The [pdfboss book](https://pdfboss.dev/docs/) covers installation, guides for every surface (text, Markdown, styled spans, rendering, image extraction, creation, Markdown-to-PDF composition, async and remote documents, the explorer, encryption) and CLI/Python/Rust reference chapters. It is built with mdBook from [`docs/`](docs/) by the `book` workflow and served at pdfboss.dev/docs. Per-crate Rust API documentation is on [docs.rs](https://docs.rs/pdfboss-core).
 
 ## Development
 

--- a/crates/pdfboss-aio/Cargo.toml
+++ b/crates/pdfboss-aio/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pdfboss-aio"
-description = "Async, range-fetching PDF access for pdfboss: huge files, many documents, remote HTTP sources (ISO 32000)"
+description = "Async, range-fetching PDF reader: huge files, many documents, remote PDFs over HTTP (ISO 32000)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["pdf", "async", "http", "range-requests", "tokio"]
+categories = ["asynchronous", "network-programming"]
 
 [dependencies]
 pdfboss-core = { workspace = true }

--- a/crates/pdfboss-cli/Cargo.toml
+++ b/crates/pdfboss-cli/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pdfboss-cli"
-description = "Command-line interface for pdfboss: info, text, render, obj, and the json/hex/q/tui explorer subcommands"
+description = "PDF command line: PDF to text, Markdown and PNG, image extraction, PDF creation, and the json/hex/q/tui explorer"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["pdf", "cli", "pdf-to-text", "pdf-to-png", "markdown"]
+categories = ["command-line-utilities", "text-processing"]
 
 [dependencies]
 pdfboss-core = { workspace = true }

--- a/crates/pdfboss-cli/skill/SKILL.md
+++ b/crates/pdfboss-cli/skill/SKILL.md
@@ -94,7 +94,7 @@ Library crates on crates.io: `pdfboss-core` (the reader), `pdfboss-text`, `pdfbo
 
 ## Links
 
-- User guide: https://4thel00z.github.io/pdfboss/
+- User guide: https://pdfboss.dev/docs/
 - Site and benchmarks: https://pdfboss.dev
 - Race it in a browser: https://pdfarena.tahrioui.de
 - Repository: https://github.com/4thel00z/pdfboss

--- a/crates/pdfboss-core/Cargo.toml
+++ b/crates/pdfboss-core/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pdfboss-core"
-description = "PDF syntax, objects, filters, cross-references and document model (ISO 32000)"
+description = "PDF parser in pure Rust: syntax, objects, filters, cross-references and the document model (ISO 32000)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["pdf", "parser", "pdf-parser", "iso-32000", "document"]
+categories = ["parser-implementations", "text-processing"]
 
 [dependencies]
 thiserror = "2"

--- a/crates/pdfboss-encoding/Cargo.toml
+++ b/crates/pdfboss-encoding/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["pdf", "encoding", "glyph", "fonts", "iso-32000"]
+categories = ["encoding", "text-processing"]
 
 [dependencies]

--- a/crates/pdfboss-icc/Cargo.toml
+++ b/crates/pdfboss-icc/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "pdfboss-icc"
-description = "Cleanroom ICC profile parser and colour transform for pdfboss (ICC.1:2010)"
+description = "Cleanroom ICC profile parser and colour transform in pure Rust for pdfboss (ICC.1:2010)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["icc", "color", "color-profile", "pdf", "srgb"]
+categories = ["multimedia::images", "graphics"]
 
 [dependencies]

--- a/crates/pdfboss-jpx/Cargo.toml
+++ b/crates/pdfboss-jpx/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "pdfboss-jpx"
-description = "Cleanroom JPEG 2000 (JPXDecode) decoder for pdfboss (ITU-T T.800)"
+description = "Cleanroom JPEG 2000 (JPXDecode) decoder in pure Rust for pdfboss (ITU-T T.800)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["jpeg2000", "jpx", "decoder", "image", "pdf"]
+categories = ["multimedia::images", "multimedia::encoding"]
 
 [dependencies]

--- a/crates/pdfboss-markdown/Cargo.toml
+++ b/crates/pdfboss-markdown/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pdfboss-markdown"
-description = "Markdown to PDF composition for pdfboss"
+description = "Markdown to PDF in pure Rust: CommonMark+GFM composed into CSS-themed documents"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["markdown", "pdf", "markdown-to-pdf", "commonmark", "gfm"]
+categories = ["text-processing"]
 
 [dependencies]
 pdfboss-write = { workspace = true }

--- a/crates/pdfboss-output/Cargo.toml
+++ b/crates/pdfboss-output/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pdfboss-output"
-description = "Layout analysis and output rendering (plain text, markdown) for pdfboss"
+description = "PDF to plain text and Markdown: layout analysis and output rendering for pdfboss"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["pdf", "markdown", "pdf-to-markdown", "pdf-to-text", "layout"]
+categories = ["text-processing"]
 
 [dependencies]
 pdfboss-core = { workspace = true }

--- a/crates/pdfboss-render/Cargo.toml
+++ b/crates/pdfboss-render/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pdfboss-render"
-description = "Page rasterization to RGBA pixmaps and PNG for pdfboss"
+description = "PDF rendering in pure Rust: rasterize pages to RGBA pixmaps and PNG, extract embedded images"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["pdf", "rendering", "rasterizer", "pdf-to-png", "png"]
+categories = ["rendering", "multimedia::images", "graphics"]
 
 [dependencies]
 pdfboss-core = { workspace = true }

--- a/crates/pdfboss-style/Cargo.toml
+++ b/crates/pdfboss-style/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pdfboss-style"
-description = "CSS-subset theme parsing for pdfboss document composition"
+description = "CSS-subset theme parsing for pdfboss Markdown-to-PDF composition"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["css", "theme", "pdf", "stylesheet", "typesetting"]
+categories = ["text-processing", "parser-implementations"]
 
 [dependencies]
 pdfboss-write = { workspace = true }

--- a/crates/pdfboss-text/Cargo.toml
+++ b/crates/pdfboss-text/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pdfboss-text"
-description = "Font loading, encodings, ToUnicode CMaps and text extraction for pdfboss"
+description = "PDF text extraction in pure Rust: font loading, encodings, ToUnicode CMaps and positioned text spans"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["pdf", "text-extraction", "pdf-to-text", "fonts", "cmap"]
+categories = ["text-processing", "parser-implementations"]
 
 [dependencies]
 pdfboss-core = { workspace = true }

--- a/crates/pdfboss-tui/Cargo.toml
+++ b/crates/pdfboss-tui/Cargo.toml
@@ -6,7 +6,8 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["pdf", "tui", "terminal", "explorer", "ratatui"]
+categories = ["command-line-interface", "visualization"]
 
 [dependencies]
 pdfboss-aio = { workspace = true }

--- a/crates/pdfboss-write/Cargo.toml
+++ b/crates/pdfboss-write/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pdfboss-write"
-description = "PDF creation for pdfboss: COS object writer, content canvas and document assembly"
+description = "PDF creation in pure Rust: COS object writer, content canvas, composed elements and document assembly"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-keywords.workspace = true
+keywords = ["pdf", "pdf-generation", "pdf-writer", "create-pdf", "document"]
+categories = ["text-processing", "encoding"]
 
 [dependencies]
 pdfboss-core = { workspace = true }

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,12 +1,12 @@
 [book]
 title = "pdfboss"
-description = "A PDF engine written from scratch in Rust: parse, extract text and Markdown, rasterize to PNG, extract images, create PDFs."
+description = "pdfboss documentation: extract text and Markdown from PDFs, render pages to PNG, extract images and create PDFs from the CLI, Python and Rust."
 authors = ["4thel00z"]
 language = "en"
 src = "src"
 
 [output.html]
-site-url = "/pdfboss/"
+site-url = "/docs/"
 git-repository-url = "https://github.com/4thel00z/pdfboss"
 edit-url-template = "https://github.com/4thel00z/pdfboss/edit/main/docs/{path}"
 

--- a/docs/finalize-book.sh
+++ b/docs/finalize-book.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Post-processes a built mdBook for pdfboss.dev/docs: a canonical link on
+# every page, noindex on the print view, and a sitemap of the chapters.
+set -euo pipefail
+
+book="${1:-docs/book}"
+base="https://pdfboss.dev/docs"
+sitemap="$book/sitemap.xml"
+
+index_copies=""
+for file in "$book"/*.html; do
+  name="$(basename "$file")"
+  [ "$name" = "index.html" ] && continue
+  cmp -s "$file" "$book/index.html" && index_copies="$index_copies $name"
+done
+
+{
+  echo '<?xml version="1.0" encoding="UTF-8"?>'
+  echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+} > "$sitemap"
+
+find "$book" -name '*.html' | sort | while read -r file; do
+  rel="${file#"$book"/}"
+  case " $rel " in
+    " 404.html "|" toc.html ") continue ;;
+    " print.html ")
+      sed -i.bak 's|<head>|<head><meta name="robots" content="noindex">|' "$file"
+      rm "$file.bak"
+      continue ;;
+  esac
+  url="$base/$rel"
+  listed=1
+  if [ "$rel" = "index.html" ]; then
+    url="$base/"
+  fi
+  case " $index_copies " in
+    *" $rel "*) url="$base/"; listed=0 ;;
+  esac
+  sed -i.bak "s|<head>|<head><link rel=\"canonical\" href=\"$url\">|" "$file"
+  rm "$file.bak"
+  [ "$listed" = 1 ] && echo "  <url><loc>$url</loc></url>" >> "$sitemap"
+done
+
+echo '</urlset>' >> "$sitemap"
+echo "canonicals added, sitemap at $sitemap ($(grep -c '<loc>' "$sitemap") urls)"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,20 +9,20 @@
 
 # Guide
 
-- [Extracting text](guide/text.md)
-- [Markdown output](guide/markdown.md)
+- [Extracting text from PDFs](guide/text.md)
+- [PDF to Markdown](guide/markdown.md)
 - [Styled spans](guide/spans.md)
-- [Rendering pages](guide/rendering.md)
-- [Extracting images](guide/images.md)
+- [Rendering PDF pages to PNG](guide/rendering.md)
+- [Extracting images from PDFs](guide/images.md)
 - [Creating PDFs](guide/creating.md)
 - [Markdown to PDF](guide/md-to-pdf.md)
-- [Async and remote documents](guide/async.md)
+- [Async and remote PDFs over HTTP](guide/async.md)
 - [Exploring PDF internals](guide/explorer.md)
-- [Encrypted documents](guide/encryption.md)
+- [Encrypted PDFs](guide/encryption.md)
 
 # Reference
 
-- [CLI reference](reference/cli.md)
-- [Python API](reference/python.md)
-- [Rust crates](reference/rust.md)
+- [pdfboss CLI reference](reference/cli.md)
+- [Python API reference](reference/python.md)
+- [Rust crate reference](reference/rust.md)
 - [Limitations](reference/limitations.md)

--- a/docs/src/guide/async.md
+++ b/docs/src/guide/async.md
@@ -1,4 +1,4 @@
-# Async and remote documents
+# Async and remote PDFs over HTTP
 
 `AsyncDocument` opens a PDF without reading the whole file. The open flow fetches only what it needs (the header, the cross-reference chain and the page tree) and every later operation fetches only the byte ranges it touches. The file backend reads windows of the file on demand; the HTTP backend turns each read into a `Range` request, so a document on a server can be paged through without downloading it. A server that ignores `Range` and answers `200` with the full body (`python3 -m http.server`, for one) still works: the first such answer is kept as the whole resource and every read is served from it, at the cost of one full download held in memory for the life of the document.
 

--- a/docs/src/guide/encryption.md
+++ b/docs/src/guide/encryption.md
@@ -1,4 +1,4 @@
-# Encrypted documents
+# Encrypted PDFs
 
 pdfboss opens files encrypted with the PDF Standard security handler: RC4
 (40–128-bit, `/V` 1–2, and `/V` 4 with crypt filter `V2`), AES-128 (`/V` 4,

--- a/docs/src/guide/images.md
+++ b/docs/src/guide/images.md
@@ -1,4 +1,4 @@
-# Extracting images
+# Extracting images from PDFs
 
 pdfboss extracts the images a page draws (photographs, scans, logos, figures),
 each decoded at its own pixel dimensions and delivered as RGBA with alpha.

--- a/docs/src/guide/markdown.md
+++ b/docs/src/guide/markdown.md
@@ -1,4 +1,4 @@
-# Markdown output
+# PDF to Markdown
 
 Markdown output runs layout analysis over the same positioned spans that
 [plain text extraction](./text.md) flattens, and renders the result as CommonMark.

--- a/docs/src/guide/rendering.md
+++ b/docs/src/guide/rendering.md
@@ -1,4 +1,4 @@
-# Rendering pages
+# Rendering PDF pages to PNG
 
 pdfboss rasterizes pages to RGBA pixels with anti-aliasing and encodes them as
 PNG. The scale factor is the points-to-pixels ratio: at `1.0` one PDF point

--- a/docs/src/guide/text.md
+++ b/docs/src/guide/text.md
@@ -1,4 +1,4 @@
-# Extracting text
+# Extracting text from PDFs
 
 Text extraction turns a page's positioned glyphs back into readable text: spans are
 grouped into lines, lines are ordered top to bottom and joined with `\n`, and spaces

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -1,4 +1,4 @@
-# CLI reference
+# pdfboss CLI reference
 
 One binary, `pdfboss`, with a subcommand per job. This chapter is the flag inventory; worked examples live in the guide chapters linked from each entry.
 

--- a/docs/src/reference/python.md
+++ b/docs/src/reference/python.md
@@ -1,4 +1,4 @@
-# Python API
+# Python API reference
 
 The `pdfboss` package re-exports the compiled extension module `pdfboss._pdfboss`. Its public surface is twelve top-level classes, the `md` and `write` submodules and the `__version__` string; the typed stubs in [`_pdfboss.pyi`](https://github.com/4thel00z/pdfboss/blob/main/python/pdfboss/_pdfboss.pyi) are the authoritative reference for every signature and docstring. This chapter is the inventory; worked examples live in the guide chapters.
 

--- a/docs/src/reference/rust.md
+++ b/docs/src/reference/rust.md
@@ -1,4 +1,4 @@
-# Rust crates
+# Rust crate reference
 
 pdfboss is a workspace of focused crates, all sharing one version. Add the ones you need with `cargo add`; each crate's API reference lives on docs.rs.
 

--- a/docs/theme/head.hbs
+++ b/docs/theme/head.hbs
@@ -1,0 +1,10 @@
+<meta name="theme-color" content="#0c0c09">
+<script>
+  (function () {
+    if (location.hostname !== "4thel00z.github.io") {
+      return;
+    }
+    var path = location.pathname.replace(/^\/pdfboss\/?/, "");
+    location.replace("https://pdfboss.dev/docs/" + path + location.search + location.hash);
+  })();
+</script>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "maturin"
 [project]
 name = "pdfboss"
 version = "1.0.0"
-description = "PDF parsing, text extraction and rendering in pure Rust with pythonic bindings"
+description = "Fast PDF text extraction, Markdown conversion and page rendering in pure Rust, with pythonic bindings"
 readme = "README.md"
 requires-python = ">=3.12"
 license = "MIT OR Apache-2.0"
 license-files = ["LICENSE-MIT", "LICENSE-APACHE"]
 authors = [{ name = "4thel00z" }]
-keywords = ["pdf", "parser", "text-extraction", "rendering", "rasterizer", "rust"]
+keywords = ["pdf", "parser", "text-extraction", "pdf-to-text", "pdf-to-markdown", "markdown", "rendering", "pdf-to-png", "rasterizer", "images", "rust"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -23,8 +23,11 @@ classifiers = [
 ]
 
 [project.urls]
+Homepage = "https://pdfboss.dev"
+Documentation = "https://pdfboss.dev/docs/"
 Repository = "https://github.com/4thel00z/pdfboss"
 Issues = "https://github.com/4thel00z/pdfboss/issues"
+Changelog = "https://github.com/4thel00z/pdfboss/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 # Pulls in the bundled OFL substitute fonts (packages/pdfboss-fonts) so


### PR DESCRIPTION
The book keeps building on GitHub Pages and pdfboss.dev proxies it under `/docs`, so the documentation pages accrue to the project domain. This PR makes the book correct at that URL and gives the crates search-friendly metadata.

- `docs/book.toml`: `site-url` is `/docs/`; description carries the words people search for.
- `docs/theme/head.hbs`: visitors landing on 4thel00z.github.io are sent to the same page on pdfboss.dev/docs.
- `docs/finalize-book.sh`, run by the book workflow after `mdbook build`: a `pdfboss.dev/docs` canonical on every page, `noindex` on `print.html`, and a `sitemap.xml` of the chapters. `index.html` and its `introduction.html` twin both canonicalize to `/docs/`.
- Chapter titles name the task: "Extracting text from PDFs", "Rendering PDF pages to PNG", "PDF to Markdown", "Async and remote PDFs over HTTP". File names and URLs are unchanged.
- README and the CLI skill link to pdfboss.dev/docs.
- Per-crate descriptions, keywords and categories, workspace `homepage` and `documentation`, PyPI project URLs and keywords. These surface at the next publish.

Deploy order: the Caddy `/docs` proxy on pdfboss.dev goes live before this merges, otherwise the head redirect would send github.io visitors to a 404.

Verified locally with mdbook 0.4.52: 17 sitemap URLs, canonicals on index, introduction and every chapter, noindex on print, none on 404 or toc; `cargo metadata` parses every manifest; keywords validated against the crates.io rules.

https://claude.ai/code/session_01RxtaEd2iuCMMYNJdnZqBtF
