### PR TITLE
perf(render): AAN fast DCT and a folded quantizer for the jpeg encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">pdfboss</h1>
 
 <p align="center">
-  <strong>A PDF engine written from scratch in Rust: parse, extract text and images, rasterize to PNG, create PDFs. One core, a CLI, and pythonic bindings.</strong>
+  <strong>A PDF engine written from scratch in Rust: parse, extract text and images, rasterize to PNG, PPM, BMP or JPEG, create PDFs. One core, a CLI, and pythonic bindings.</strong>
 </p>
 
 <p align="center">
@@ -29,6 +29,7 @@ Reading a PDF should not require a C library. pdfboss is a clean-room reader bui
 - **Clean-room engine**: implemented from the ISO 32000 specification in safe Rust; no C dependencies, no bindings to another engine.
 - **Fastest text extraction measured**: 7,477 pages/s over a 40-file real-world corpus, about 18× the C-backed PyMuPDF ([benchmarks](#benchmarks)).
 - **Its own codecs**: JPEG 2000, JBIG2, CCITT and ICC are decoded in-tree, implemented from their specifications, not linked in.
+- **Four render formats**: PNG through its own page-tuned encoder, PPM and BMP as the raw pixels behind a header (about 0.3 ms a page, for pipelines that consume the pixels right away), and JPEG from its own baseline encoder with a quality knob; picked by `format=` in Python and by the `-o` extension on the CLI ([guide](https://pdfboss.dev/docs/guide/rendering.html#output-formats)).
 - **Embedded-image extraction**: every image a page draws, at native size, alpha applied, from the CLI, Python and Rust ([example](#extract-embedded-images)).
 - **PDF creation**: document structs, a canvas painter and a COS writer with deterministic output; CommonMark+GFM composes into CSS-themed PDFs from the CLI, Python and Rust ([example](#create-pdfs)).
 - **Async, range-fetching I/O**: documents open over files or `http(s)://` URLs and fetch only the byte ranges they need, never the whole file.

--- a/crates/pdfboss-cli/skill/SKILL.md
+++ b/crates/pdfboss-cli/skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pdfboss
-description: Use when reading, extracting, rendering, creating, or exploring PDF files with pdfboss, the from-scratch Rust PDF engine with a CLI and Python bindings. Triggers include extracting text or Markdown from a PDF, rasterizing pages to PNG, pulling embedded images, composing a new PDF (blank, text, images, Markdown, TOML manifest, or the pdfboss.write API), watermarking an existing PDF, inspecting PDF internals (objects, xref, hexdump, jq-style queries), reading PDFs over HTTP without downloading them whole, and opening encrypted PDFs.
+description: Use when reading, extracting, rendering, creating, or exploring PDF files with pdfboss, the from-scratch Rust PDF engine with a CLI and Python bindings. Triggers include extracting text or Markdown from a PDF, rasterizing pages to PNG, PPM, BMP or JPEG, pulling embedded images, composing a new PDF (blank, text, images, Markdown, TOML manifest, or the pdfboss.write API), watermarking an existing PDF, inspecting PDF internals (objects, xref, hexdump, jq-style queries), reading PDFs over HTTP without downloading them whole, and opening encrypted PDFs.
 ---
 
 # pdfboss
 
-A PDF engine written from scratch in safe Rust: parse, extract text and Markdown, rasterize to PNG, extract embedded images, and create PDFs. One core behind the `pdfboss` CLI and the `pdfboss` Python package. Clean-room from ISO 32000, no C dependencies. The reader is lenient: broken cross-reference tables are reconstructed, wrong stream lengths tolerated, garbage operators skipped, and every dropped or approximated item is reported instead of silently lost.
+A PDF engine written from scratch in safe Rust: parse, extract text and Markdown, rasterize to PNG, PPM, BMP or JPEG, extract embedded images, and create PDFs. One core behind the `pdfboss` CLI and the `pdfboss` Python package. Clean-room from ISO 32000, no C dependencies. The reader is lenient: broken cross-reference tables are reconstructed, wrong stream lengths tolerated, garbage operators skipped, and every dropped or approximated item is reported instead of silently lost.
 
 ## Install
 
@@ -21,7 +21,7 @@ cargo install pdfboss-cli      # the `pdfboss` binary
 pdfboss info    doc.pdf                     # version, page count, sizes, metadata
 pdfboss text    doc.pdf --page 2            # omit --page for all pages
 pdfboss md      doc.pdf                     # Markdown: headings, lists, tables from layout
-pdfboss render  doc.pdf --page 1 -o p.png --scale 2.0
+pdfboss render  doc.pdf --page 1 -o p.png --scale 2.0   # -o extension picks .png/.ppm/.bmp/.jpg; --jpeg-quality 1-100
 pdfboss images  doc.pdf -o out/             # embedded images as native-size PNGs
 pdfboss tui     doc.pdf                     # interactive terminal explorer
 ```
@@ -57,7 +57,7 @@ import pdfboss
 doc  = pdfboss.Document("doc.pdf")            # or Document(data=raw_bytes), password=""
 text = doc.extract_text()                     # pages fan out across cores
 md   = doc.extract_markdown()
-png  = doc[0].render(scale=2.0)               # PNG bytes
+png  = doc[0].render(scale=2.0)               # PNG bytes; format="ppm"/"bmp" for raw RGB pixels, "jpeg" (quality=90) for lossy
 png, warnings = doc[0].render_reporting()     # warnings list every drop or approximation
 images = doc[0].extract_images()              # each: .data (PNG bytes), .width, .height
 spans  = list(doc.spans())                    # styled spans: font, weight, color, position
@@ -82,7 +82,7 @@ stamped = pdfboss.write.watermark(original_bytes, overlay_bytes)
 data = pdfboss.md.to_pdf("# Hello\n\nWorld", theme=None, size="a4")
 ```
 
-`fonts=` on the render methods defaults to `None`, resolving to `"full"` when `font_dir=` is given or the `pdfboss-fonts` package is importable, else `"all-embedded"`; an explicit `fonts="full"` with no face source raises `ValueError`. The type stubs in `pdfboss/_pdfboss.pyi` are the authoritative signatures.
+`fonts=` on the render methods defaults to `None`, resolving to `"full"` when `font_dir=` is given or the `pdfboss-fonts` package is importable, else `"all-embedded"`; an explicit `fonts="full"` with no face source raises `ValueError`. `format=` is `"png"` (default), `"ppm"`, `"bmp"` or `"jpeg"`: PPM and BMP are the pixels behind a header (no encode cost, alpha dropped), JPEG is the lossy one with `quality=` 1 to 100. The type stubs in `pdfboss/_pdfboss.pyi` are the authoritative signatures.
 
 ## Rust
 

--- a/crates/pdfboss-render/src/jpeg.rs
+++ b/crates/pdfboss-render/src/jpeg.rs
@@ -4,7 +4,7 @@
 //! tables written verbatim. Chroma is not subsampled because a page is
 //! mostly sharp edges, where 4:2:0 smears colored text.
 
-use std::f32::consts::PI;
+use std::f32::consts::FRAC_1_SQRT_2;
 
 use crate::{Error, Result};
 
@@ -111,7 +111,8 @@ pub(crate) fn encode_jpeg(width: u32, height: u32, rgba: &[u8], quality: u8) -> 
     let mut out = Vec::with_capacity((width as usize * height as usize) / 4 + 1024);
     write_headers(&mut out, width, height, &luma_quant, &chroma_quant);
 
-    let cos = cos_table();
+    let luma_quantizer = Quantizer::new(&luma_quant);
+    let chroma_quantizer = Quantizer::new(&chroma_quant);
     let mut writer = BitWriter::new(out);
     let mut previous_dc = [0i32; 3];
     let mut blocks = [[0f32; 64]; 3];
@@ -119,11 +120,11 @@ pub(crate) fn encode_jpeg(width: u32, height: u32, rgba: &[u8], quality: u8) -> 
         for block_x in 0..width.div_ceil(8) {
             gather_block(rgba, width, height, block_x, block_y, &mut blocks);
             for (component, samples) in blocks.iter().enumerate() {
-                let (quant, dc, ac) = match component {
-                    0 => (&luma_quant, &dc_luma, &ac_luma),
-                    _ => (&chroma_quant, &dc_chroma, &ac_chroma),
+                let (quantizer, dc, ac) = match component {
+                    0 => (&luma_quantizer, &dc_luma, &ac_luma),
+                    _ => (&chroma_quantizer, &dc_chroma, &ac_chroma),
                 };
-                let coefficients = fdct_quantize(samples, quant, &cos);
+                let coefficients = fdct_quantize(samples, quantizer);
                 encode_block(
                     &mut writer,
                     &coefficients,
@@ -237,39 +238,83 @@ fn gather_block(
     }
 }
 
-/// `COS[k][n] = c(k) / 2 * cos((2n + 1) k pi / 16)`, the separable DCT-II
-/// basis with the normalization of A.3.3 folded in.
-fn cos_table() -> [[f32; 8]; 8] {
-    let mut table = [[0f32; 8]; 8];
-    for (k, row) in table.iter_mut().enumerate() {
-        let c = if k == 0 {
-            std::f32::consts::FRAC_1_SQRT_2
-        } else {
-            1.0
-        };
-        for (n, entry) in row.iter_mut().enumerate() {
-            *entry = c / 2.0 * (((2 * n + 1) * k) as f32 * PI / 16.0).cos();
-        }
-    }
-    table
+/// What each 1-D output of [`aan`] is scaled by relative to the DCT-II of
+/// A.3.3: `1` at k = 0, `sqrt(2) cos(k pi / 16)` above, times `2 sqrt 2`
+/// per pass.
+const AAN_SCALE: [f32; 8] = [
+    1.0, 1.3870399, 1.306563, 1.1758755, 1.0, 0.78569496, 0.5411961, 0.27589938,
+];
+
+/// One multiplier per coefficient, row-major, folding the AAN scale of
+/// both passes and the quantizer, so quantizing is a multiply and a round.
+struct Quantizer {
+    scale: [f32; 64],
 }
 
-/// The forward DCT of one level-shifted block, quantized by `quant` and
-/// returned in zig-zag order.
-fn fdct_quantize(samples: &[f32; 64], quant: &[u8; 64], cos: &[[f32; 8]; 8]) -> [i32; 64] {
-    let mut rows = [[0f32; 8]; 8];
-    for v in 0..8 {
-        for x in 0..8 {
-            rows[v][x] = (0..8).map(|y| cos[v][y] * samples[y * 8 + x]).sum();
+impl Quantizer {
+    fn new(quant: &[u8; 64]) -> Quantizer {
+        let mut scale = [0f32; 64];
+        for (n, entry) in scale.iter_mut().enumerate() {
+            let (v, u) = (n / 8, n % 8);
+            *entry = 1.0 / (AAN_SCALE[v] * AAN_SCALE[u] * 8.0 * f32::from(quant[n]));
+        }
+        Quantizer { scale }
+    }
+}
+
+/// The forward DCT of one level-shifted block, rows then columns through
+/// [`aan`], quantized through `quantizer` and returned in zig-zag order.
+fn fdct_quantize(samples: &[f32; 64], quantizer: &Quantizer) -> [i32; 64] {
+    let mut block = *samples;
+    for row in block.as_chunks_mut::<8>().0 {
+        aan(row);
+    }
+    for x in 0..8 {
+        let mut column = [0f32; 8];
+        for (y, value) in column.iter_mut().enumerate() {
+            *value = block[y * 8 + x];
+        }
+        aan(&mut column);
+        for (y, value) in column.iter().enumerate() {
+            block[y * 8 + x] = *value;
         }
     }
     let mut zigzag = [0i32; 64];
     for (k, &natural) in ZIGZAG.iter().enumerate() {
-        let (v, u) = (natural / 8, natural % 8);
-        let coefficient: f32 = (0..8).map(|x| rows[v][x] * cos[u][x]).sum();
-        zigzag[k] = (coefficient / f32::from(quant[natural])).round() as i32;
+        zigzag[k] = (block[natural] * quantizer.scale[natural]).round() as i32;
     }
     zigzag
+}
+
+/// One 8-point pass of the Arai, Agui and Nakajima factorization of the
+/// DCT-II: 5 multiplies and 29 additions, leaving each output scaled by
+/// its [`AAN_SCALE`] entry.
+fn aan(d: &mut [f32; 8]) {
+    let (sum07, diff07) = (d[0] + d[7], d[0] - d[7]);
+    let (sum16, diff16) = (d[1] + d[6], d[1] - d[6]);
+    let (sum25, diff25) = (d[2] + d[5], d[2] - d[5]);
+    let (sum34, diff34) = (d[3] + d[4], d[3] - d[4]);
+
+    let (even0, even3) = (sum07 + sum34, sum07 - sum34);
+    let (even1, even2) = (sum16 + sum25, sum16 - sum25);
+    d[0] = even0 + even1;
+    d[4] = even0 - even1;
+    let rotated = (even2 + even3) * FRAC_1_SQRT_2;
+    d[2] = even3 + rotated;
+    d[6] = even3 - rotated;
+
+    let odd0 = diff34 + diff25;
+    let odd1 = diff25 + diff16;
+    let odd2 = diff16 + diff07;
+    let shared = (odd0 - odd2) * 0.38268343;
+    let low = 0.5411961 * odd0 + shared;
+    let high = 1.306563 * odd2 + shared;
+    let middle = odd1 * FRAC_1_SQRT_2;
+    let (plus, minus) = (diff07 + middle, diff07 - middle);
+    d[5] = minus + low;
+    d[3] = minus - low;
+    d[1] = plus + high;
+    d[7] = plus - high;
 }
 
 /// Writes one block's DC difference and run-length coded AC coefficients.
@@ -414,6 +459,74 @@ mod tests {
         (0..256).filter(|&s| table.len[s] > 0).collect()
     }
 
+    /// The separable DCT-II written out directly from A.3.3 and quantized
+    /// with a division per coefficient: the reference the fast transform
+    /// is held to.
+    fn reference_fdct_quantize(samples: &[f32; 64], quant: &[u8; 64]) -> [i32; 64] {
+        let mut cos = [[0f32; 8]; 8];
+        for (k, row) in cos.iter_mut().enumerate() {
+            let c = if k == 0 {
+                std::f32::consts::FRAC_1_SQRT_2
+            } else {
+                1.0
+            };
+            for (n, entry) in row.iter_mut().enumerate() {
+                *entry = c / 2.0 * (((2 * n + 1) * k) as f32 * std::f32::consts::PI / 16.0).cos();
+            }
+        }
+        let mut rows = [[0f32; 8]; 8];
+        for v in 0..8 {
+            for x in 0..8 {
+                rows[v][x] = (0..8).map(|y| cos[v][y] * samples[y * 8 + x]).sum();
+            }
+        }
+        let mut zigzag = [0i32; 64];
+        for (k, &natural) in ZIGZAG.iter().enumerate() {
+            let (v, u) = (natural / 8, natural % 8);
+            let coefficient: f32 = (0..8).map(|x| rows[v][x] * cos[u][x]).sum();
+            zigzag[k] = (coefficient / f32::from(quant[natural])).round() as i32;
+        }
+        zigzag
+    }
+
+    /// Level-shifted noise blocks from a fixed-seed linear congruential
+    /// generator, so the comparison is deterministic and dependency-free.
+    fn noise_blocks(count: usize) -> Vec<[f32; 64]> {
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        (0..count)
+            .map(|_| {
+                let mut block = [0f32; 64];
+                for sample in &mut block {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1_442_695_040_888_963_407);
+                    *sample = ((state >> 40) & 0xFF) as f32 - 128.0;
+                }
+                block
+            })
+            .collect()
+    }
+
+    #[test]
+    fn fast_dct_matches_the_reference_within_one_quantized_step() {
+        let flat = [1u8; 64];
+        for quant in [flat, LUMA_QUANT, CHROMA_QUANT] {
+            let quantizer = Quantizer::new(&quant);
+            for block in noise_blocks(200) {
+                let fast = fdct_quantize(&block, &quantizer);
+                let reference = reference_fdct_quantize(&block, &quant);
+                for k in 0..64 {
+                    assert!(
+                        (fast[k] - reference[k]).abs() <= 1,
+                        "coefficient {k}: fast {} vs reference {}",
+                        fast[k],
+                        reference[k]
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn ac_tables_cover_every_run_size_pair_plus_eob_and_zrl() {
         let mut expected: Vec<usize> = (0..16)
@@ -488,7 +601,7 @@ mod tests {
     #[test]
     fn a_flat_block_quantizes_to_a_lone_dc_coefficient() {
         let samples = [64.0f32; 64];
-        let coefficients = fdct_quantize(&samples, &LUMA_QUANT, &cos_table());
+        let coefficients = fdct_quantize(&samples, &Quantizer::new(&LUMA_QUANT));
         assert_eq!(coefficients[0], (8.0f32 * 64.0 / 16.0).round() as i32);
         assert!(coefficients[1..].iter().all(|&c| c == 0));
     }

--- a/docs/src/guide/rendering.md
+++ b/docs/src/guide/rendering.md
@@ -170,7 +170,7 @@ quantization tables (50 uses them as printed, 100 keeps every
 coefficient). On a mostly white text page PNG stays both smaller and
 exact, so prefer JPEG only where the content is continuous-tone. Chroma
 is not subsampled, so colored text keeps sharp edges. The encoder is
-pdfboss's own, written from the JPEG specification, and costs about four
+pdfboss's own, written from the JPEG specification, and costs two to three
 times the default PNG encode per page.
 
 ```python


### PR DESCRIPTION
The forward DCT now runs the Arai, Agui and Nakajima factorization (5 multiplies and 29 additions per 8-point pass, rows then columns) instead of the separable matrix form, and quantization is one multiply per coefficient through a table that folds the AAN post-scale, the DCT normalization and the quantizer. The naive transform stays in the tests as the reference: 600 noise blocks across three quantization tables land within one quantized step of it, and every round-trip, marker, CLI and Python test holds.

Per 1224×1584 page, min of 3 (Rust rig): DCT plus quantize 12.1 ms to 4.7 ms; the whole JPEG encode 17 to 25 ms to 12.5 to 17 ms, now two to three times the default PNG encode instead of four. Stage split after the change: gather 2.6 ms, DCT 4.7 ms, Huffman 2.8 to 5.6 ms.

Also in this PR: the README highlight for the four render formats, the in-repo skill (`crates/pdfboss-cli/skill/SKILL.md`) describing `-o` extensions, `--jpeg-quality`, `format=` and `quality=`, and the rendering guide's cost sentence.

Verification: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, `cargo doc`, pytest 195 passed.
