### PR TITLE
test: pass ReadingOrder to extract_text in the assemble and importer tests

### DIFF
--- a/crates/pdfboss-cli/tests/assemble_cmd.rs
+++ b/crates/pdfboss-cli/tests/assemble_cmd.rs
@@ -44,7 +44,8 @@ fn merge_combines_a_whole_file_and_a_selected_page() {
     let texts: Vec<String> = (0..3)
         .map(|i| {
             let page = doc.page(i).unwrap();
-            pdfboss_output::extract_text(&doc, &page).unwrap()
+            pdfboss_output::extract_text(&doc, &page, pdfboss_output::ReadingOrder::Content)
+                .unwrap()
         })
         .collect();
     assert!(texts[0].contains("a1"), "page 0: {:?}", texts[0]);
@@ -262,7 +263,8 @@ fn rewrite_writes_a_fresh_file_preserving_pages() {
     let texts: Vec<String> = (0..3)
         .map(|i| {
             let page = doc.page(i).unwrap();
-            pdfboss_output::extract_text(&doc, &page).unwrap()
+            pdfboss_output::extract_text(&doc, &page, pdfboss_output::ReadingOrder::Content)
+                .unwrap()
         })
         .collect();
     assert!(texts[0].contains("one"), "page 0: {:?}", texts[0]);

--- a/crates/pdfboss-write/src/assemble.rs
+++ b/crates/pdfboss-write/src/assemble.rs
@@ -208,7 +208,7 @@ pub fn split_document(doc: &Document, every: usize, options: WriteOptions) -> Re
 #[cfg(test)]
 mod tests {
     use pdfboss_core::xref::{parse_section_at, startxref, XrefEntry};
-    use pdfboss_output::extract_text;
+    use pdfboss_output::{extract_text, ReadingOrder};
     use pdfboss_testkit::{encrypted_rc4_doc, multi_page_doc, PdfBuilder};
 
     use crate::pdf::{Metadata, Page, PageSize, Pdf};
@@ -228,7 +228,7 @@ mod tests {
         let texts: Vec<String> = (0..4)
             .map(|i| {
                 let page = merged.page(i).expect("page exists");
-                extract_text(&merged, &page).expect("text extracts")
+                extract_text(&merged, &page, ReadingOrder::Content).expect("text extracts")
             })
             .collect();
         assert!(texts[0].contains("a1"), "page 0: {:?}", texts[0]);
@@ -246,8 +246,12 @@ mod tests {
         assert_eq!(merged.page_count(), 2);
         let first = merged.page(0).expect("first page exists");
         let second = merged.page(1).expect("second page exists");
-        assert!(extract_text(&merged, &first).unwrap().contains("three"));
-        assert!(extract_text(&merged, &second).unwrap().contains("one"));
+        assert!(extract_text(&merged, &first, ReadingOrder::Content)
+            .unwrap()
+            .contains("three"));
+        assert!(extract_text(&merged, &second, ReadingOrder::Content)
+            .unwrap()
+            .contains("one"));
     }
 
     #[test]
@@ -268,7 +272,7 @@ mod tests {
         let texts: Vec<String> = (0..2)
             .map(|i| {
                 let page = first.page(i).expect("page exists");
-                extract_text(&first, &page).expect("text extracts")
+                extract_text(&first, &page, ReadingOrder::Content).expect("text extracts")
             })
             .collect();
         assert!(texts[0].contains("one"), "page 0: {:?}", texts[0]);
@@ -277,7 +281,7 @@ mod tests {
         let second = Document::load(parts[1].clone()).expect("second part loads");
         assert_eq!(second.page_count(), 1);
         let page = second.page(0).expect("page exists");
-        let text = extract_text(&second, &page).expect("text extracts");
+        let text = extract_text(&second, &page, ReadingOrder::Content).expect("text extracts");
         assert!(text.contains("three"), "page 0: {:?}", text);
     }
 
@@ -486,7 +490,7 @@ mod tests {
         );
 
         let page = rewritten.page(0).expect("page exists");
-        let text = extract_text(&rewritten, &page).expect("text extracts");
+        let text = extract_text(&rewritten, &page, ReadingOrder::Content).expect("text extracts");
         assert!(text.contains("hello"), "text: {text:?}");
     }
 

--- a/crates/pdfboss-write/tests/importer.rs
+++ b/crates/pdfboss-write/tests/importer.rs
@@ -2,7 +2,7 @@
 //! [`Writer`], exercised directly rather than through `watermark_with`.
 
 use pdfboss_core::{Dict, Document, Name, ObjRef, Object, Rect, Stream};
-use pdfboss_output::extract_text;
+use pdfboss_output::{extract_text, ReadingOrder};
 use pdfboss_testkit::{encrypted_rc4_doc, multi_page_doc, simple_doc, PdfBuilder};
 use pdfboss_write::{watermark, watermark_with, Error, Importer, WriteOptions, Writer, XrefStyle};
 
@@ -65,7 +65,7 @@ fn imported_page_is_self_contained() {
     let reloaded = Document::load(bytes).expect("assembled document loads");
     assert_eq!(reloaded.page_count(), 1);
     let page = reloaded.page(0).expect("the one page exists");
-    let text = extract_text(&reloaded, &page).expect("text extracts");
+    let text = extract_text(&reloaded, &page, ReadingOrder::Content).expect("text extracts");
     assert!(text.contains("two"), "unexpected text: {text:?}");
     assert!(page.dict().get("Resources").is_some());
     assert!(page.dict().get("MediaBox").is_some());
@@ -99,7 +99,7 @@ fn page_import_pulls_in_no_sibling_content_without_links() {
     );
     let reloaded = Document::load(bytes).expect("assembled document loads");
     let page = reloaded.page(0).expect("the one page exists");
-    let text = extract_text(&reloaded, &page).expect("text extracts");
+    let text = extract_text(&reloaded, &page, ReadingOrder::Content).expect("text extracts");
     assert!(text.contains("two"), "unexpected text: {text:?}");
 }
 
@@ -313,7 +313,7 @@ fn substitute_swaps_a_body_verbatim() {
     let texts: Vec<String> = (0..3)
         .map(|i| {
             let page = reloaded.page(i).expect("page exists");
-            extract_text(&reloaded, &page).expect("text extracts")
+            extract_text(&reloaded, &page, ReadingOrder::Content).expect("text extracts")
         })
         .collect();
     assert!(texts[0].contains("one"), "page 0: {:?}", texts[0]);
@@ -374,7 +374,7 @@ fn document_import_reaches_the_whole_graph() {
     assert_eq!(reloaded.page_count(), 3);
     for (index, expected) in ["one", "two", "three"].iter().enumerate() {
         let page = reloaded.page(index).expect("page exists");
-        let text = extract_text(&reloaded, &page).expect("text extracts");
+        let text = extract_text(&reloaded, &page, ReadingOrder::Content).expect("text extracts");
         assert!(text.contains(expected), "page {index}: {text:?}");
     }
 }
@@ -428,7 +428,7 @@ fn inline_page_gets_its_own_object() {
         Some(page_ref),
         "the imported page must now be an indirect object"
     );
-    let text = extract_text(&reloaded, &page).expect("text extracts");
+    let text = extract_text(&reloaded, &page, ReadingOrder::Content).expect("text extracts");
     assert!(text.contains("inline"), "unexpected text: {text:?}");
 }
 


### PR DESCRIPTION
Fixes the CI failure on main after #154 and #155 merged back to back (run 33615589019).

#155 added the `assemble_cmd`, `importer` and `assemble.rs` unit tests calling the two-argument `extract_text`. #154 merged on top of it and made a `ReadingOrder` the required third argument. Each PR was green on its own; main broke on the combination. CI only reported the two `assemble_cmd` sites because cargo stops at the first failing target; the other 11 sites in pdfboss-write were never reached.

All 13 call sites now pass `ReadingOrder::Content`, matching what #154 did in `create_cmd.rs`. Test-only change, no library code touched.

Verified locally with the five commands from ci.yaml:

| step | result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p pdfboss-aio --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo test --workspace` | 2603 passed, 0 failed, 67 targets |
| `cargo test -p pdfboss-aio --all-features` | exit 0 |

Not in this PR: README.md:167, docs/src/quickstart.md:66, docs/src/guide/creating.md:419 and docs/src/guide/markdown.md:95 still show the pre-#154 two-argument `extract_text` and one-argument `extract_markdown` snippets. They are not compiled, so CI does not catch them.
